### PR TITLE
feat(docker): network alias support for cross-project DNS

### DIFF
--- a/internal/server/deploy/services.go
+++ b/internal/server/deploy/services.go
@@ -117,6 +117,17 @@ func runsAsService(s cobaltfile.Service) bool {
 // serviceCreateOpts translates a BuiltService into the docker package's
 // ServiceCreateOpts, attaching the per-deployment network plus cobalt-main
 // so cross-service hooks and exposedInternally references resolve.
+//
+// Network aliases mirror disco's behavior:
+//   - per-deployment network → alias = service name (e.g. `web`), so other
+//     services within the same project can reach this one by its short
+//     name regardless of deployment number.
+//   - cobalt-main → if exposedInternally, alias = `{project}-{service}`
+//     (e.g. `redis-redis`) — the stable cross-project hostname that
+//     callers like api's `REDIS_HOST` rely on. Otherwise the alias is the
+//     service's full deployment-numbered name, which keeps the
+//     "every service has an alias on every network" invariant for any
+//     future reconciler / inspection tooling.
 func serviceCreateOpts(
 	project store.Project,
 	dep store.Deployment,
@@ -132,9 +143,12 @@ func serviceCreateOpts(
 		Image:            b.ImageTag,
 		Command:          b.Service.Command,
 		EnvVars:          envVars,
-		Networks:         []string{deploymentNetwork, MainNetworkName},
-		Replicas:         1,
-		ExtraParams:      docker.SplitParams(b.Service.ExtraSwarmParams),
+		Networks: []docker.NetworkAttachment{
+			{Name: deploymentNetwork, Alias: b.Name},
+			{Name: MainNetworkName, Alias: mainNetAlias(project, b, dep)},
+		},
+		Replicas:    1,
+		ExtraParams: docker.SplitParams(b.Service.ExtraSwarmParams),
 	}
 	if b.Service.Health != nil && b.Service.Health.Command != "" {
 		opts.HealthCommand = b.Service.Health.Command
@@ -153,4 +167,19 @@ func serviceCreateOpts(
 		})
 	}
 	return opts
+}
+
+// mainNetAlias returns the DNS alias a service should answer to on the
+// shared cobalt-main overlay. When the service opts into cross-project
+// reachability via `exposedInternally`, the alias is the stable short form
+// `{project}-{service}` — what env vars like `REDIS_HOST=redis-redis`
+// resolve against. Otherwise the alias is the service's full
+// deployment-numbered name, keeping the alias field non-empty so any
+// future tooling that reads `docker service inspect ... .Aliases` sees a
+// uniform shape across all cobalt-managed services.
+func mainNetAlias(project store.Project, b BuiltService, dep store.Deployment) string {
+	if b.Service.ExposedInternally {
+		return project.Name + "-" + b.Name
+	}
+	return docker.ServiceName(project.Name, dep.Number, b.Name)
 }

--- a/internal/server/deploy/services_test.go
+++ b/internal/server/deploy/services_test.go
@@ -1,0 +1,186 @@
+package deploy
+
+import (
+	"testing"
+
+	"github.com/heyblueteam/cobalt/internal/server/cobaltfile"
+	"github.com/heyblueteam/cobalt/internal/server/docker"
+	"github.com/heyblueteam/cobalt/internal/server/store"
+)
+
+// findAttachment returns the NetworkAttachment matching name, or fails the
+// test if absent. Centralizes the "ordering is implementation detail, but
+// each network must be present exactly once" assertion the alias tests all
+// share.
+func findAttachment(t *testing.T, atts []docker.NetworkAttachment, name string) docker.NetworkAttachment {
+	t.Helper()
+	var hits []docker.NetworkAttachment
+	for _, a := range atts {
+		if a.Name == name {
+			hits = append(hits, a)
+		}
+	}
+	if len(hits) == 0 {
+		t.Fatalf("no NetworkAttachment for %q in %+v", name, atts)
+	}
+	if len(hits) > 1 {
+		t.Fatalf("multiple NetworkAttachments for %q in %+v — every service must attach to each network exactly once", name, atts)
+	}
+	return hits[0]
+}
+
+// TestServiceCreateOpts_AliasesExposedInternally is the core happy-path
+// case: a service with `exposedInternally: true` must answer to its short
+// stable cross-project name on cobalt-main (e.g. `redis-redis`). This is
+// what api's `REDIS_HOST=redis-redis` env var depends on at runtime.
+// Without this alias, api's redis connection fails with NXDOMAIN.
+func TestServiceCreateOpts_AliasesExposedInternally(t *testing.T) {
+	t.Parallel()
+	project := store.Project{ID: 7, Name: "redis"}
+	dep := store.Deployment{Number: 1}
+	b := BuiltService{
+		Name: "redis",
+		Service: cobaltfile.Service{
+			ExposedInternally: true,
+		},
+		ImageTag: "redis/redis-stack:7.4.0-v8",
+	}
+
+	opts := serviceCreateOpts(project, dep, b, nil, "cobalt-project-redis-1")
+
+	main := findAttachment(t, opts.Networks, MainNetworkName)
+	if main.Alias != "redis-redis" {
+		t.Errorf("cobalt-main alias = %q, want %q (stable cross-project name)", main.Alias, "redis-redis")
+	}
+	perDeploy := findAttachment(t, opts.Networks, "cobalt-project-redis-1")
+	if perDeploy.Alias != "redis" {
+		t.Errorf("per-deploy alias = %q, want %q (within-project short name)", perDeploy.Alias, "redis")
+	}
+}
+
+// TestServiceCreateOpts_AliasesNotExposedInternally verifies the
+// "fallback" branch: when exposedInternally is false, the cobalt-main
+// alias is the full deployment-numbered service name. This preserves the
+// invariant that every service has a non-empty alias on every attached
+// network — useful for future inspection tooling and reconcilers — while
+// avoiding accidental cross-project exposure of services the operator
+// didn't opt-in.
+func TestServiceCreateOpts_AliasesNotExposedInternally(t *testing.T) {
+	t.Parallel()
+	project := store.Project{ID: 7, Name: "api"}
+	dep := store.Deployment{Number: 200}
+	b := BuiltService{
+		Name: "web",
+		Service: cobaltfile.Service{
+			ExposedInternally: false,
+		},
+		ImageTag: "cobalt/project-api-web:200",
+	}
+
+	opts := serviceCreateOpts(project, dep, b, nil, "cobalt-project-api-200")
+
+	main := findAttachment(t, opts.Networks, MainNetworkName)
+	if main.Alias != "api-200-web" {
+		t.Errorf("cobalt-main alias = %q, want %q (fallback = full service name)", main.Alias, "api-200-web")
+	}
+	perDeploy := findAttachment(t, opts.Networks, "cobalt-project-api-200")
+	if perDeploy.Alias != "web" {
+		t.Errorf("per-deploy alias = %q, want %q", perDeploy.Alias, "web")
+	}
+}
+
+// TestServiceCreateOpts_HyphenatedProjectName checks that hyphens in
+// project / service names pass through untouched. The white-label* family
+// of projects exercises this — if we ever do alias-name sanitization
+// (uppercasing, hyphen->underscore, etc.), env vars like
+// `FILES_HOST=white-label-files-web` would silently break.
+func TestServiceCreateOpts_HyphenatedProjectName(t *testing.T) {
+	t.Parallel()
+	project := store.Project{ID: 12, Name: "white-label-files"}
+	dep := store.Deployment{Number: 7}
+
+	// exposedInternally branch — the alias should be project + "-" + service.
+	bExposed := BuiltService{
+		Name:    "web",
+		Service: cobaltfile.Service{ExposedInternally: true},
+	}
+	opts := serviceCreateOpts(project, dep, bExposed, nil, "cobalt-project-white-label-files-7")
+	if got := findAttachment(t, opts.Networks, MainNetworkName).Alias; got != "white-label-files-web" {
+		t.Errorf("exposed alias = %q, want %q", got, "white-label-files-web")
+	}
+
+	// non-exposed branch — falls back to full service name.
+	bUnexposed := BuiltService{Name: "web"}
+	opts2 := serviceCreateOpts(project, dep, bUnexposed, nil, "cobalt-project-white-label-files-7")
+	if got := findAttachment(t, opts2.Networks, MainNetworkName).Alias; got != "white-label-files-7-web" {
+		t.Errorf("unexposed alias = %q, want %q", got, "white-label-files-7-web")
+	}
+}
+
+// TestServiceCreateOpts_AttachesBothNetworks documents the
+// always-two-networks contract: every cobalt-managed service joins both
+// the per-deployment overlay AND cobalt-main. The deploy orchestrator,
+// caddy reconciler, hooks, and one-shot containers all assume this; a
+// regression that drops cobalt-main would silently break cross-project
+// communication.
+func TestServiceCreateOpts_AttachesBothNetworks(t *testing.T) {
+	t.Parallel()
+	project := store.Project{ID: 1, Name: "api"}
+	dep := store.Deployment{Number: 1}
+	b := BuiltService{Name: "web"}
+
+	opts := serviceCreateOpts(project, dep, b, nil, "cobalt-project-api-1")
+
+	if len(opts.Networks) != 2 {
+		t.Fatalf("got %d networks, want 2: %+v", len(opts.Networks), opts.Networks)
+	}
+	// The per-deployment network must be first; some downstream tooling
+	// treats the first network as primary.
+	if opts.Networks[0].Name != "cobalt-project-api-1" {
+		t.Errorf("Networks[0] = %q, want per-deployment network first", opts.Networks[0].Name)
+	}
+	if opts.Networks[1].Name != MainNetworkName {
+		t.Errorf("Networks[1] = %q, want cobalt-main second", opts.Networks[1].Name)
+	}
+}
+
+// TestMainNetAlias_PureFunction exercises the alias-picker directly to
+// pin down the contract: exposedInternally selects the short stable form,
+// otherwise the full deployment-numbered name. Useful so a regression in
+// either branch shows up at the unit level even if higher-level tests
+// happen to mask it.
+func TestMainNetAlias_PureFunction(t *testing.T) {
+	t.Parallel()
+	cases := []struct {
+		name              string
+		project           string
+		service           string
+		deployment        int
+		exposedInternally bool
+		want              string
+	}{
+		{"exposed_simple", "redis", "redis", 1, true, "redis-redis"},
+		{"exposed_different_service_name", "plunk", "web", 6, true, "plunk-web"},
+		{"unexposed_full_name", "api", "web", 200, false, "api-200-web"},
+		{"unexposed_at_deployment_1", "api", "web", 1, false, "api-1-web"},
+		{"hyphenated_project_exposed", "white-label-files", "web", 7, true, "white-label-files-web"},
+		{"hyphenated_project_unexposed", "white-label-files", "web", 7, false, "white-label-files-7-web"},
+		{"multi_service_project", "openpanel", "clickhouse", 2, true, "openpanel-clickhouse"},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			project := store.Project{Name: tc.project}
+			dep := store.Deployment{Number: tc.deployment}
+			b := BuiltService{
+				Name: tc.service,
+				Service: cobaltfile.Service{
+					ExposedInternally: tc.exposedInternally,
+				},
+			}
+			if got := mainNetAlias(project, b, dep); got != tc.want {
+				t.Errorf("mainNetAlias(%s, %s, deploy=%d, exposed=%v) = %q, want %q",
+					tc.project, tc.service, tc.deployment, tc.exposedInternally, got, tc.want)
+			}
+		})
+	}
+}

--- a/internal/server/docker/service.go
+++ b/internal/server/docker/service.go
@@ -22,6 +22,23 @@ type ServiceVolume struct {
 	DestinationPath string
 }
 
+// NetworkAttachment binds a swarm service to an overlay network with an
+// optional DNS alias. An empty Alias renders as `--network <Name>`; a
+// non-empty Alias renders as `--network name=<Name>,alias=<Alias>`, which
+// gives the service a stable hostname on that network independent of its
+// swarm service name. Other services on the same network can resolve the
+// alias via Docker's embedded DNS.
+//
+// Aliases matter for cross-project references (e.g. api connecting to
+// `redis-redis:6379`) and within-project short names (e.g. api's web
+// service reaching `worker` instead of `api-3-worker`). The alias survives
+// across deployments — the swarm service name (which includes the
+// deployment number) does not.
+type NetworkAttachment struct {
+	Name  string
+	Alias string // optional
+}
+
 // ServiceCreateOpts describes a `docker service create` invocation.
 type ServiceCreateOpts struct {
 	ProjectID        int64
@@ -32,11 +49,11 @@ type ServiceCreateOpts struct {
 	Command          string
 	EnvVars          map[string]string
 	PublishedPorts   []PublishedPort
-	Networks         []string // network names; first one is primary
-	Replicas         int      // 0 means use docker default (1)
-	HealthCommand    string   // optional; sets --health-cmd
-	HealthStartPeriod time.Duration // defaults to 5 minutes
-	HealthInterval    time.Duration // defaults to 3 seconds
+	Networks         []NetworkAttachment // first one is primary
+	Replicas         int                 // 0 means use docker default (1)
+	HealthCommand    string              // optional; sets --health-cmd
+	HealthStartPeriod time.Duration      // defaults to 5 minutes
+	HealthInterval    time.Duration      // defaults to 3 seconds
 	Volumes          []ServiceVolume
 	ExtraParams      []string // pre-split, e.g. via SplitParams(extraSwarmParams)
 }
@@ -70,7 +87,7 @@ func (c *Client) CreateService(ctx context.Context, opts ServiceCreateOpts) erro
 	}
 
 	for _, n := range opts.Networks {
-		args = append(args, "--network", n)
+		args = append(args, "--network", networkFlagValue(n))
 	}
 	for _, p := range opts.PublishedPorts {
 		proto := p.Protocol
@@ -270,6 +287,17 @@ func (c *Client) taskStates(ctx context.Context, serviceName string) ([]string, 
 		states = append(states, state)
 	}
 	return states, nil
+}
+
+// networkFlagValue renders a NetworkAttachment as the string passed to
+// `--network`. When the alias is empty we emit the bare network name; with
+// an alias we use docker's name=,alias= form so the service registers a
+// per-network DNS alias.
+func networkFlagValue(n NetworkAttachment) string {
+	if n.Alias == "" {
+		return n.Name
+	}
+	return "name=" + n.Name + ",alias=" + n.Alias
 }
 
 func sortedKeys(m map[string]string) []string {

--- a/internal/server/docker/service_test.go
+++ b/internal/server/docker/service_test.go
@@ -23,7 +23,7 @@ func TestCreateService_FullArgs(t *testing.T) {
 		PublishedPorts: []PublishedPort{
 			{PublishedAs: 80, FromContainerPort: 3000, Protocol: "tcp"},
 		},
-		Networks:          []string{"cobalt-project-api-3"},
+		Networks:          []NetworkAttachment{{Name: "cobalt-project-api-3"}},
 		Replicas:          2,
 		HealthCommand:     "curl -f http://localhost:3000/healthz",
 		HealthStartPeriod: 10 * time.Minute,
@@ -122,6 +122,160 @@ func TestCreateService_NoHealthFlag(t *testing.T) {
 	for _, w := range []string{"--health-cmd", "--health-start-period", "--health-start-interval"} {
 		if argHas(args, w) {
 			t.Errorf("unexpected %q in %v", w, args)
+		}
+	}
+}
+
+// TestCreateService_NetworkWithAlias verifies that a NetworkAttachment
+// with a non-empty Alias renders as `--network name=<net>,alias=<alias>`,
+// the docker syntax that registers a per-network DNS alias for the
+// service. This is the load-bearing case: cross-project env vars like
+// `REDIS_HOST=redis-redis` depend on swarm DNS resolving the alias.
+func TestCreateService_NetworkWithAlias(t *testing.T) {
+	t.Parallel()
+	r := newFakeRunner()
+	c := NewWithRunner(r)
+	err := c.CreateService(context.Background(), ServiceCreateOpts{
+		ProjectName: "redis", ServiceName: "redis", DeploymentNumber: 1,
+		Image: "redis/redis-stack:7.4.0-v8",
+		Networks: []NetworkAttachment{
+			{Name: "cobalt-project-redis-1", Alias: "redis"},
+			{Name: "cobalt-main", Alias: "redis-redis"},
+		},
+	})
+	if err != nil {
+		t.Fatalf("CreateService: %v", err)
+	}
+	args := r.lastCall().Args
+
+	if !argSequence(args, "--network", "name=cobalt-project-redis-1,alias=redis") {
+		t.Errorf("per-deploy alias missing: %v", args)
+	}
+	if !argSequence(args, "--network", "name=cobalt-main,alias=redis-redis") {
+		t.Errorf("cobalt-main alias missing: %v", args)
+	}
+}
+
+// TestCreateService_NetworkWithoutAlias verifies that a NetworkAttachment
+// with an empty Alias renders as the bare `--network <net>` form, matching
+// the pre-alias behavior for any caller that doesn't need DNS aliasing.
+func TestCreateService_NetworkWithoutAlias(t *testing.T) {
+	t.Parallel()
+	r := newFakeRunner()
+	c := NewWithRunner(r)
+	err := c.CreateService(context.Background(), ServiceCreateOpts{
+		ProjectName: "api", ServiceName: "web", DeploymentNumber: 3,
+		Image: "img:1",
+		Networks: []NetworkAttachment{
+			{Name: "cobalt-project-api-3"}, // no alias
+		},
+	})
+	if err != nil {
+		t.Fatalf("CreateService: %v", err)
+	}
+	args := r.lastCall().Args
+
+	if !argSequence(args, "--network", "cobalt-project-api-3") {
+		t.Errorf("bare network missing: %v", args)
+	}
+	// Defensive: the comma-form must NOT appear when alias is empty.
+	for _, a := range args {
+		if a == "name=cobalt-project-api-3,alias=" {
+			t.Errorf("empty alias rendered with trailing comma: %v", args)
+		}
+	}
+}
+
+// TestCreateService_NetworkMixed proves the renderer makes per-attachment
+// decisions (bare vs name+alias) independently when both forms coexist in
+// the same Networks slice. Without this, a caller with one network needing
+// an alias and another not might silently render both the same way.
+func TestCreateService_NetworkMixed(t *testing.T) {
+	t.Parallel()
+	r := newFakeRunner()
+	c := NewWithRunner(r)
+	err := c.CreateService(context.Background(), ServiceCreateOpts{
+		ProjectName: "api", ServiceName: "web", DeploymentNumber: 3,
+		Image: "img:1",
+		Networks: []NetworkAttachment{
+			{Name: "cobalt-project-api-3", Alias: "web"},
+			{Name: "cobalt-main"}, // no alias
+		},
+	})
+	if err != nil {
+		t.Fatalf("CreateService: %v", err)
+	}
+	args := r.lastCall().Args
+
+	if !argSequence(args, "--network", "name=cobalt-project-api-3,alias=web") {
+		t.Errorf("aliased entry: %v", args)
+	}
+	if !argSequence(args, "--network", "cobalt-main") {
+		t.Errorf("bare entry: %v", args)
+	}
+}
+
+// TestCreateService_NetworkOrderPreserved asserts the rendered --network
+// flags appear in the same order callers provided. Network order can
+// matter for downstream tooling (first-network primary), and silent
+// reordering would be a footgun.
+func TestCreateService_NetworkOrderPreserved(t *testing.T) {
+	t.Parallel()
+	r := newFakeRunner()
+	c := NewWithRunner(r)
+	err := c.CreateService(context.Background(), ServiceCreateOpts{
+		ProjectName: "api", ServiceName: "web", DeploymentNumber: 1,
+		Image: "img:1",
+		Networks: []NetworkAttachment{
+			{Name: "first", Alias: "alpha"},
+			{Name: "second", Alias: "beta"},
+			{Name: "third"}, // bare
+		},
+	})
+	if err != nil {
+		t.Fatalf("CreateService: %v", err)
+	}
+	args := r.lastCall().Args
+
+	// Find each --network's argument index and check ordering.
+	var idx []int
+	for i := 0; i < len(args)-1; i++ {
+		if args[i] == "--network" {
+			idx = append(idx, i+1)
+		}
+	}
+	if len(idx) != 3 {
+		t.Fatalf("expected 3 --network args, got %d: %v", len(idx), args)
+	}
+	if args[idx[0]] != "name=first,alias=alpha" {
+		t.Errorf("[0] %s", args[idx[0]])
+	}
+	if args[idx[1]] != "name=second,alias=beta" {
+		t.Errorf("[1] %s", args[idx[1]])
+	}
+	if args[idx[2]] != "third" {
+		t.Errorf("[2] %s", args[idx[2]])
+	}
+}
+
+// TestCreateService_NetworkFlagValue exercises the pure renderer directly
+// so an alias bug (e.g. forgetting the `name=` prefix, or omitting the
+// alias entirely) shows up here even if the higher-level test happens to
+// pass for unrelated reasons.
+func TestNetworkFlagValue(t *testing.T) {
+	t.Parallel()
+	cases := []struct {
+		in   NetworkAttachment
+		want string
+	}{
+		{NetworkAttachment{Name: "n"}, "n"},
+		{NetworkAttachment{Name: "n", Alias: ""}, "n"},
+		{NetworkAttachment{Name: "cobalt-main", Alias: "redis-redis"}, "name=cobalt-main,alias=redis-redis"},
+		{NetworkAttachment{Name: "n", Alias: "with-hyphens-here"}, "name=n,alias=with-hyphens-here"},
+	}
+	for _, c := range cases {
+		if got := networkFlagValue(c.in); got != c.want {
+			t.Errorf("networkFlagValue(%+v) = %q, want %q", c.in, got, c.want)
 		}
 	}
 }


### PR DESCRIPTION
## Summary

Cobalt swarm services were unreachable by stable cross-project names. Surfaced during the Disco → Cobalt cutover audit: api's `REDIS_HOST=redis-redis` could not resolve because cobalt-created services only exposed their deployment-numbered name (e.g. `redis-1-redis`), which rotates on every redeploy.

This adds per-network DNS aliases, matching disco's behavior:
- **Per-deployment network** → alias = service name (`web`, `redis`) — within-project short names.
- **cobalt-main** → `{project}-{service}` when `exposedInternally: true` (the stable cross-project hostname); full deployment-numbered name otherwise.

Public API change: `docker.ServiceCreateOpts.Networks` is `[]NetworkAttachment` instead of `[]string`. One production call site and three tests in this repo touched. `RunOpts` (one-shot containers) keeps `[]string` — matches disco's `commandruns.py` and one-shots don't need aliases.

## Test plan

- [x] 5 new tests in `docker/service_test.go` — aliased + bare rendering, mixed, ordering, pure renderer
- [x] 5 new tests + 1 table-driven (7 subcases) in `deploy/services_test.go` — exposedInternally true/false, hyphenated project names (`white-label-files`), always-two-networks contract, `mainNetAlias` direct
- [x] \`go test ./...\` green across all packages, no regressions
- [ ] Tag + release → brew install → smoke-deploy redis + api on \`server.blue.cc\` (next step in cutover)

## Refs

- Disco's pattern: \`tmp/disco-daemon/disco/utils/docker.py:258\` (\`--network name=X,alias=Y\`)
- Cutover blockers: api / files / openpanel / plunk — every cross-project env var depends on this