### PR TITLE
fix(init): write Caddyfile on --compose-file path

### DIFF
--- a/cmd/cobalt/init.go
+++ b/cmd/cobalt/init.go
@@ -116,6 +116,14 @@ Examples:
 `,
 		Args: cobra.ExactArgs(1),
 		RunE: runE(func(cmd *cobra.Command, args []string) error {
+			// --no-caddyfile only makes sense alongside --compose-file: the
+			// embedded compose template bind-mounts /opt/cobalt/Caddyfile, so
+			// suppressing the write on the default path reproduces the exact
+			// crash-loop this command fix was meant to prevent.
+			if noCaddyfile && composeFile == "" {
+				return fmt.Errorf("--no-caddyfile requires --compose-file (the embedded compose template bind-mounts /opt/cobalt/Caddyfile)")
+			}
+
 			target := args[0]
 			user, host := ssh.ParseSSHURL(target)
 			assumeYes := cmd.Flag("yes").Value.String() == "true"

--- a/cmd/cobalt/init.go
+++ b/cmd/cobalt/init.go
@@ -39,6 +39,24 @@ func caddyfileFor(publicHost string, insecureTLS bool) string {
 	return initCaddyfileAutoHTTPS
 }
 
+// caddyfileForInit returns the Caddyfile body to write to /opt/cobalt/Caddyfile
+// during `cobalt init`, or "" when the operator opted out via --no-caddyfile.
+//
+// Why this isn't gated on --compose-file: the embedded compose template
+// bind-mounts /opt/cobalt/Caddyfile, and operators who pass a custom compose
+// almost always start from a near-identical variant that keeps the same
+// mount (e.g. they only changed port bindings). Skipping the Caddyfile in
+// that path produces a Rejected restart loop on cobalt_caddy with
+// "bind source path does not exist". Writing it by default is harmless when
+// the operator's compose doesn't mount it; --no-caddyfile is the explicit
+// opt-out for operators who really do replace the Caddy setup wholesale.
+func caddyfileForInit(noCaddyfile bool, publicHost string, insecureTLS bool) string {
+	if noCaddyfile {
+		return ""
+	}
+	return caddyfileFor(publicHost, insecureTLS)
+}
+
 func isIPOrLocalhost(host string) bool {
 	if host == "" || host == "localhost" {
 		return true
@@ -58,6 +76,7 @@ func newInitCmd() *cobra.Command {
 		localImage    string
 		insecureTLS   bool
 		noGitHubApp   bool
+		noCaddyfile   bool
 	)
 
 	cmd := &cobra.Command{
@@ -91,6 +110,9 @@ Examples:
 
   # Use a custom compose file for air-gapped deployments
   cobalt init user@192.168.1.100 --compose-file ./my-compose.yml
+
+  # Custom compose + custom Caddy setup (skip writing /opt/cobalt/Caddyfile)
+  cobalt init user@192.168.1.100 --compose-file ./my-compose.yml --no-caddyfile
 `,
 		Args: cobra.ExactArgs(1),
 		RunE: runE(func(cmd *cobra.Command, args []string) error {
@@ -109,7 +131,7 @@ Examples:
 			defer conn.Close()
 
 			// 🔍 Detect environment and show what we're about to do.
-			env, err := detectEnv(ctx, conn, host, publicHost, insecureTLS, composeFile)
+			env, err := detectEnv(ctx, conn, host, publicHost, insecureTLS, composeFile, noCaddyfile)
 			if err != nil {
 				return err
 			}
@@ -272,9 +294,6 @@ Examples:
 			caddyfilePath := "/opt/cobalt/Caddyfile"
 			envPath := "/opt/cobalt/.env"
 
-			// .env is always written so substitutions resolve even when a
-			// custom compose is supplied. Variables a custom compose doesn't
-			// reference are harmless.
 			image := fmt.Sprintf("ghcr.io/heyblueteam/cobalt:%s", cobaltVersion)
 			if localImage != "" {
 				image = localImage
@@ -282,29 +301,35 @@ Examples:
 			envContent := fmt.Sprintf("COBALT_IMAGE=%s\nCOBALT_PUBLIC_HOST=%s\nCOBALT_DATA_DIR=%s\n",
 				image, publicHost, dataDir)
 
+			// Compose: operator's file via scp, otherwise the embedded template.
 			if composeFile != "" {
 				if err := conn.ScpTo(composeFile, composePath); err != nil {
 					step.Fail(err.Error())
 					return fmt.Errorf("upload compose file: %w", err)
 				}
-				if err := writeRemoteFile(conn, envPath, envContent); err != nil {
-					step.Fail(err.Error())
-					return fmt.Errorf("write .env: %w", err)
-				}
 			} else {
-				caddyfile := caddyfileFor(publicHost, insecureTLS)
 				if err := writeRemoteFile(conn, composePath, initComposeTemplate); err != nil {
 					step.Fail(err.Error())
 					return fmt.Errorf("write compose file: %w", err)
 				}
+			}
+
+			// Caddyfile written by default — including the --compose-file path,
+			// because the embedded compose template (and most operator variants
+			// of it) bind-mount /opt/cobalt/Caddyfile. Opt out with --no-caddyfile.
+			if caddyfile := caddyfileForInit(noCaddyfile, publicHost, insecureTLS); caddyfile != "" {
 				if err := writeRemoteFile(conn, caddyfilePath, caddyfile); err != nil {
 					step.Fail(err.Error())
 					return fmt.Errorf("write Caddyfile: %w", err)
 				}
-				if err := writeRemoteFile(conn, envPath, envContent); err != nil {
-					step.Fail(err.Error())
-					return fmt.Errorf("write .env: %w", err)
-				}
+			}
+
+			// .env always written so substitutions in either the embedded or
+			// operator-supplied compose resolve. Vars the compose doesn't use
+			// are harmless.
+			if err := writeRemoteFile(conn, envPath, envContent); err != nil {
+				step.Fail(err.Error())
+				return fmt.Errorf("write .env: %w", err)
 			}
 			step.OK()
 
@@ -444,6 +469,7 @@ Examples:
 	cmd.Flags().StringVar(&localImage, "local-image", "", "upload a local docker image (docker save piped to ssh docker load) and use it instead of pulling --version from the registry")
 	cmd.Flags().BoolVar(&insecureTLS, "insecure-tls", false, "allow installing against an IP / localhost with a self-signed Caddy cert (dev only; GitHub App webhooks won't work)")
 	cmd.Flags().BoolVar(&noGitHubApp, "no-github-app", false, "skip the GitHub App registration prompt and browser handoff")
+	cmd.Flags().BoolVar(&noCaddyfile, "no-caddyfile", false, "skip writing /opt/cobalt/Caddyfile (only useful with --compose-file when the operator's compose doesn't mount it)")
 
 	return cmd
 }
@@ -458,7 +484,7 @@ type envState struct {
 	proposedPublicHost string
 }
 
-func detectEnv(ctx context.Context, conn *ssh.Conn, sshHost, publicHostFlag string, insecureTLS bool, composeFile string) (envState, error) {
+func detectEnv(ctx context.Context, conn *ssh.Conn, sshHost, publicHostFlag string, insecureTLS bool, composeFile string, noCaddyfile bool) (envState, error) {
 	step := output.StartStep(output.IconDetect, "Detecting environment")
 
 	dockerCheck := conn.Run(ctx, "docker --version")
@@ -476,8 +502,11 @@ func detectEnv(ctx context.Context, conn *ssh.Conn, sshHost, publicHostFlag stri
 	if insecureTLS || isIPOrLocalhost(proposed) {
 		tlsLabel = "self-signed (tls internal)"
 	}
-	if composeFile != "" {
-		tlsLabel = "(custom compose)"
+	// --no-caddyfile means we won't write /opt/cobalt/Caddyfile, so the
+	// Caddyfile shape this label describes is moot — the operator owns
+	// TLS termination via their own compose / config.
+	if composeFile != "" && noCaddyfile {
+		tlsLabel = "(custom compose, no Caddyfile)"
 	}
 
 	dockerLabel := "not installed, will install"

--- a/cmd/cobalt/init_test.go
+++ b/cmd/cobalt/init_test.go
@@ -1,0 +1,120 @@
+package main
+
+import (
+	"bytes"
+	"context"
+	"testing"
+
+	"github.com/heyblueteam/cobalt/internal/output"
+)
+
+// caddyfileForInit is the decision function that drives whether (and which)
+// Caddyfile gets written during `cobalt init`. SSH writes are gated on the
+// returned body being non-empty. Testing this helper covers the bug fix
+// without standing up a mock SSH transport.
+//
+// Original bug: `cobalt init --compose-file <yaml>` skipped the Caddyfile
+// write entirely, even though the embedded compose template (and most
+// near-identical operator variants) bind-mount /opt/cobalt/Caddyfile.
+// cobalt_caddy then entered a Rejected restart loop with
+// "bind source path does not exist".
+func TestCaddyfileForInit(t *testing.T) {
+	cases := []struct {
+		name        string
+		noCaddyfile bool
+		host        string
+		insecureTLS bool
+		want        string // "auto-https", "internal", or "" (skip)
+	}{
+		// --compose-file + real domain → auto-https Caddyfile written
+		// (the --compose-file flag isn't an input here; this helper is
+		// always consulted, and the prod write-block bypasses the
+		// `if composeFile != ""` gate that previously suppressed it).
+		{"compose-file + real domain → auto-https", false, "cobalt.blue.cc", false, "auto-https"},
+
+		// --compose-file + --insecure-tls → internal Caddyfile
+		{"compose-file + insecure-tls → internal", false, "cobalt.blue.cc", true, "internal"},
+
+		// --compose-file + IP host → internal (no Let's Encrypt for IPs)
+		{"compose-file + IP host → internal", false, "192.168.1.100", false, "internal"},
+
+		// --no-caddyfile → suppress entirely, regardless of host
+		{"no-caddyfile + real domain", true, "cobalt.blue.cc", false, ""},
+		{"no-caddyfile + insecure-tls", true, "192.168.1.100", true, ""},
+
+		// Default path (no --compose-file, no --no-caddyfile) is also
+		// driven by this helper and must keep returning the right shape.
+		{"default + real domain → auto-https", false, "cobalt.blue.cc", false, "auto-https"},
+		{"default + IP → internal", false, "10.0.0.5", false, "internal"},
+		{"default + localhost → internal", false, "localhost", false, "internal"},
+	}
+
+	for _, c := range cases {
+		t.Run(c.name, func(t *testing.T) {
+			body := caddyfileForInit(c.noCaddyfile, c.host, c.insecureTLS)
+
+			got := ""
+			switch body {
+			case "":
+				got = ""
+			case initCaddyfileAutoHTTPS:
+				got = "auto-https"
+			case initCaddyfileInternal:
+				got = "internal"
+			default:
+				t.Fatalf("caddyfileForInit returned an unrecognized body (len=%d)", len(body))
+			}
+
+			if got != c.want {
+				t.Errorf("caddyfileForInit(noCaddyfile=%v, host=%q, insecure=%v): got %q, want %q",
+					c.noCaddyfile, c.host, c.insecureTLS, got, c.want)
+			}
+		})
+	}
+}
+
+// TestInitCommand_NoCaddyfileFlag verifies the --no-caddyfile flag is wired
+// onto the cobra command, since a missing flag would cause the build to fail
+// but a typo in the long-flag name wouldn't.
+func TestInitCommand_NoCaddyfileFlag(t *testing.T) {
+	root := newRootCmd()
+	var buf bytes.Buffer
+	root.SetOut(&buf)
+	root.SetArgs([]string{"init", "--help"})
+	if err := root.ExecuteContext(context.Background()); err != nil {
+		t.Fatalf("execute --help: %v", err)
+	}
+	got := buf.String()
+	if !contains(got, "--no-caddyfile") {
+		t.Errorf("missing --no-caddyfile in help output:\n%s", got)
+	}
+	if !contains(got, "skip writing") {
+		t.Errorf("--no-caddyfile help text missing 'skip writing':\n%s", got)
+	}
+}
+
+// TestInitCommand_ComposeFileExample verifies the help docs surface the
+// --no-caddyfile + --compose-file example, since the two flags are
+// closely linked and operators discovering one should see the other.
+func TestInitCommand_ComposeFileExample(t *testing.T) {
+	root := newRootCmd()
+	var buf bytes.Buffer
+	root.SetOut(&buf)
+	// Silence the info banner output the command may emit through
+	// output.Stderr at help time.
+	oldStderr := output.Stderr
+	output.Stderr = &bytes.Buffer{}
+	defer func() { output.Stderr = oldStderr }()
+
+	root.SetArgs([]string{"init", "--help"})
+	if err := root.ExecuteContext(context.Background()); err != nil {
+		t.Fatalf("execute --help: %v", err)
+	}
+	got := buf.String()
+	if !contains(got, "--compose-file") {
+		t.Errorf("expected --compose-file in help: %s", got)
+	}
+	if !contains(got, "--no-caddyfile") {
+		t.Errorf("expected --no-caddyfile in help: %s", got)
+	}
+}

--- a/cmd/cobalt/init_test.go
+++ b/cmd/cobalt/init_test.go
@@ -118,3 +118,26 @@ func TestInitCommand_ComposeFileExample(t *testing.T) {
 		t.Errorf("expected --no-caddyfile in help: %s", got)
 	}
 }
+
+// TestInitCommand_NoCaddyfileRequiresComposeFile guards against the footgun
+// of passing --no-caddyfile alone: the embedded compose template bind-mounts
+// /opt/cobalt/Caddyfile, so suppressing the write reproduces the exact
+// crash-loop this PR is fixing. The RunE preflight should reject it.
+func TestInitCommand_NoCaddyfileRequiresComposeFile(t *testing.T) {
+	root := newRootCmd()
+	var buf bytes.Buffer
+	root.SetOut(&buf)
+	root.SetErr(&buf)
+	oldStderr := output.Stderr
+	output.Stderr = &bytes.Buffer{}
+	defer func() { output.Stderr = oldStderr }()
+
+	root.SetArgs([]string{"init", "root@example.com", "--no-caddyfile", "--yes"})
+	err := root.ExecuteContext(context.Background())
+	if err == nil {
+		t.Fatalf("expected --no-caddyfile without --compose-file to error, got nil")
+	}
+	if !contains(err.Error(), "--no-caddyfile requires --compose-file") {
+		t.Errorf("expected error to mention --no-caddyfile requires --compose-file; got %v", err)
+	}
+}


### PR DESCRIPTION
## Summary

- `cobalt init --compose-file <yaml>` skipped writing `/opt/cobalt/Caddyfile`, but the embedded compose template (and near-identical operator variants) bind-mount that path into `cobalt_caddy`. Operators hit a Rejected restart loop with `invalid mount config for type "bind": bind source path does not exist: /opt/cobalt/Caddyfile`. Reproduced live on `server.blue.cc` during the Disco → Cobalt cutover (2026-05-23) — fixed manually by `scp`-ing the Caddyfile.
- Write the Caddyfile by default in both the embedded-compose and `--compose-file` paths, using the existing `caddyfileFor(publicHost, insecureTLS)` logic (auto-HTTPS for real domains, internal for IPs/localhost or `--insecure-tls`).
- Add `--no-caddyfile` for operators who genuinely replace the Caddy setup wholesale.

## Behavior change

| Invocation | Before | After |
| --- | --- | --- |
| `cobalt init root@host.example.com` | writes Caddyfile (auto-https) | unchanged |
| `cobalt init root@1.2.3.4 --insecure-tls` | writes Caddyfile (internal) | unchanged |
| `cobalt init root@host.example.com --compose-file foo.yml` | **skips Caddyfile → cobalt_caddy crash-loops** | writes Caddyfile (auto-https) |
| `cobalt init root@1.2.3.4 --compose-file foo.yml --insecure-tls` | **skips Caddyfile** | writes Caddyfile (internal) |
| `cobalt init root@host --compose-file foo.yml --no-caddyfile` | n/a | skips Caddyfile (explicit opt-out) |

## Out of scope

- The \`healthz\` probe assumes port 443; \`--compose-file\` installs that override Caddy's port bindings still need a manual workaround. Separate concern, file an issue if it bites.

## Test plan

- [x] \`go build ./...\` clean
- [x] \`go test ./cmd/cobalt/\` clean (8 new subcases in \`TestCaddyfileForInit\`, plus flag-wiring + help-text guards)
- [ ] Re-run on \`server.blue.cc\` next time we cut over a server with a custom-port compose — should boot without manual \`scp\` of Caddyfile.