### PR TITLE
fix(cobaltfile): accept pre-built image references (disco parity)

### DIFF
--- a/internal/server/cobaltfile/validate.go
+++ b/internal/server/cobaltfile/validate.go
@@ -40,18 +40,20 @@ func (cf *Cobaltfile) Validate() error {
 		}
 	}
 
-	// Every service that references an image must reference one that exists.
-	for name, s := range cf.Services {
-		if !needsImage(s) {
-			continue
-		}
-		if _, ok := cf.Images[s.Image]; !ok {
-			return fmt.Errorf(
-				"cobaltfile: service %q references unknown image %q",
-				name, s.Image,
-			)
-		}
-	}
+	// Image-reference validation: intentionally none. We don't require
+	// `s.Image` to be a key in `cf.Images` — that would reject pre-built
+	// docker registry references (e.g. `redis/redis-stack:7.4.0-v8`,
+	// `postgres:14-alpine`) which disco supports and many real
+	// cobaltfiles rely on. Matches disco's resolution in
+	// utils/docker.py:1218-1228: "in disco_file.images? build it. else?
+	// docker pull it." The builder makes the same distinction. A bogus
+	// pre-built ref surfaces as a `docker pull` failure at deploy time,
+	// which is loud and well-localized — better than a parser error
+	// blocking valid cobaltfiles.
+	//
+	// `s.Image` being empty is also fine here: applyDefaults() always
+	// backfills it with `DefaultImageName` for services that need an
+	// image, so we never see empty in practice.
 
 	return nil
 }
@@ -117,19 +119,6 @@ func validateService(name string, s Service) error {
 		return fmt.Errorf("cobaltfile: service %q health.command is required when health is set", name)
 	}
 	return nil
-}
-
-// needsImage reports whether a service will actually try to build/run from
-// an image (vs. e.g. a static-only service whose output Caddy serves
-// directly, or a service that overrides with its own build command).
-func needsImage(s Service) bool {
-	if s.Build != "" {
-		return false
-	}
-	if s.Type == TypeStatic && s.Command == "" {
-		return false
-	}
-	return true
 }
 
 // cronField matches a single field of a 5-field cron expression.

--- a/internal/server/cobaltfile/validate_test.go
+++ b/internal/server/cobaltfile/validate_test.go
@@ -178,14 +178,57 @@ func TestValidate_CronServiceNeedsCommand(t *testing.T) {
 	mustContain(t, err, "requires a command")
 }
 
-func TestValidate_UnknownImageReference(t *testing.T) {
+// TestValidate_PrebuiltImageReference proves we accept a service whose
+// image string is NOT a key in `cf.Images` — it's a pre-built docker
+// registry reference (e.g. `postgres:14-alpine`, `redis/redis-stack:7.4.0-v8`).
+// Matches disco's resolution rule in utils/docker.py:1218-1228: "in
+// disco_file.images? build it. else? pass through to docker pull." A bad
+// ref surfaces at deploy time, not at parse time.
+func TestValidate_PrebuiltImageReference(t *testing.T) {
 	t.Parallel()
 	src := `{
         "version": "1.0",
-        "services": {"web": {"image": "ghost"}}
+        "services": {"web": {"image": "postgres:14-alpine"}}
     }`
-	_, err := Parse([]byte(src))
-	mustContain(t, err, "unknown image")
+	if _, err := Parse([]byte(src)); err != nil {
+		t.Errorf("pre-built image reference should be accepted: %v", err)
+	}
+}
+
+// TestValidate_PrebuiltImageReference_WithRegistryPath covers the
+// org/repo:tag shape (full registry path with a slash) — distinct from
+// the library-image shape (`postgres:14-alpine`). We treat both
+// identically.
+func TestValidate_PrebuiltImageReference_WithRegistryPath(t *testing.T) {
+	t.Parallel()
+	src := `{
+        "version": "1.0",
+        "services": {"redis": {"image": "redis/redis-stack:7.4.0-v8"}}
+    }`
+	if _, err := Parse([]byte(src)); err != nil {
+		t.Errorf("registry/org image reference should be accepted: %v", err)
+	}
+}
+
+// TestValidate_EmptyImageFilledByDefaults documents the
+// belt-and-braces: an explicit `image: ""` goes through applyDefaults,
+// gets backfilled to `DefaultImageName`, and validation passes. We don't
+// surface an error for this because it's unreachable in the Parse flow
+// (defaults always run first) and matching disco's parse-time
+// permissiveness is the point of this whole change.
+func TestValidate_EmptyImageFilledByDefaults(t *testing.T) {
+	t.Parallel()
+	src := `{
+        "version": "1.0",
+        "services": {"web": {"image": ""}}
+    }`
+	cf, err := Parse([]byte(src))
+	if err != nil {
+		t.Fatalf("empty image should be backfilled, not error: %v", err)
+	}
+	if got := cf.Services["web"].Image; got != DefaultImageName {
+		t.Errorf("web.Image = %q, want backfilled %q", got, DefaultImageName)
+	}
 }
 
 func TestValidate_StaticServiceCanReferenceMissingImage(t *testing.T) {

--- a/internal/server/deploy/build.go
+++ b/internal/server/deploy/build.go
@@ -74,7 +74,13 @@ func (b *dockerBuilder) Build(ctx context.Context, project store.Project, dep st
 		cacheDir = filepath.Join(b.dataDir, "buildkit-cache", strconv.FormatInt(project.ID, 10))
 	}
 
-	// Build each unique image only once.
+	// Build each unique image only once. Mirrors disco's resolution
+	// (utils/docker.py:1218-1228): if `svc.Image` matches a key in
+	// `cf.Images`, build from the Dockerfile spec under that key;
+	// otherwise treat `svc.Image` as a pre-built registry reference
+	// (e.g. `redis/redis-stack:7.4.0-v8`) and skip the build entirely.
+	// `BuiltService.ImageTag` ends up either as the built tag or the
+	// verbatim pre-built reference — same downstream consumer either way.
 	tagByImage := map[string]string{}
 	for _, svc := range ws.Cobaltfile.Services {
 		if !needsBuild(svc) {
@@ -85,7 +91,16 @@ func (b *dockerBuilder) Build(ctx context.Context, project store.Project, dep st
 		}
 		img, ok := ws.Cobaltfile.Images[svc.Image]
 		if !ok {
-			return nil, fmt.Errorf("deploy.Build: service references unknown image %q", svc.Image)
+			// Pre-built registry reference — no Dockerfile to build.
+			// The image string is passed through to the BuiltService
+			// ImageTag below; `docker service create --image <ref>` will
+			// `docker pull` it on first use. A bogus ref surfaces as a
+			// pull error at deploy time.
+			tagByImage[svc.Image] = svc.Image
+			if out != nil {
+				fmt.Fprintf(out, "📦 using pre-built image %q (no Dockerfile in repo)\n", svc.Image)
+			}
+			continue
 		}
 
 		if out != nil {

--- a/internal/server/deploy/build_test.go
+++ b/internal/server/deploy/build_test.go
@@ -177,22 +177,105 @@ func TestBuilder_PropagatesEnvSecrets(t *testing.T) {
 	}
 }
 
-func TestBuilder_UnknownImageErrors(t *testing.T) {
+// TestBuilder_PrebuiltImageSkipsBuild proves that when `svc.Image` is
+// NOT a key in `cf.Images`, the builder treats it as a pre-built docker
+// registry reference: no docker build is invoked, and the resulting
+// BuiltService.ImageTag is the verbatim image string. Matches disco's
+// resolution rule in utils/docker.py:1218-1228.
+//
+// Real-world this covers projects like `redis` (uses
+// `redis/redis-stack:7.4.0-v8`), `dozzle`, `grafana`, and the postgres
+// /clickhouse /redis sub-services of `openpanel` and `plunk`.
+func TestBuilder_PrebuiltImageSkipsBuild(t *testing.T) {
 	t.Parallel()
 	cf := &cobaltfile.Cobaltfile{
-		Version:  "1.0",
-		Services: map[string]cobaltfile.Service{"web": {Image: "ghost", Port: 8000}},
-		// images map missing "ghost"
+		Version: "1.0",
+		Services: map[string]cobaltfile.Service{
+			"redis": {
+				Type:  cobaltfile.TypeContainer,
+				Image: "redis/redis-stack:7.4.0-v8",
+				Port:  6379,
+			},
+		},
+		// no Images map entry — image is a pre-built ref
 	}
-	b := NewBuilder(&fakeImageBuilder{}, &fakeEnv{}, "")
-	_, err := b.Build(context.Background(),
-		store.Project{Name: "x"},
+	d := &fakeImageBuilder{}
+	b := NewBuilder(d, &fakeEnv{}, "")
+	out, err := b.Build(context.Background(),
+		store.Project{ID: 1, Name: "redis"},
 		store.Deployment{Number: 1},
 		&Workspace{Cobaltfile: cf},
 		nil,
 	)
-	if err == nil {
-		t.Error("expected error")
+	if err != nil {
+		t.Fatalf("Build: %v", err)
+	}
+	if len(d.calls) != 0 {
+		t.Errorf("expected 0 docker builds for pre-built image, got %d", len(d.calls))
+	}
+	if len(out) != 1 {
+		t.Fatalf("expected 1 BuiltService, got %d", len(out))
+	}
+	if out[0].ImageTag != "redis/redis-stack:7.4.0-v8" {
+		t.Errorf("ImageTag = %q, want verbatim pre-built ref %q", out[0].ImageTag, "redis/redis-stack:7.4.0-v8")
+	}
+}
+
+// TestBuilder_MixedPrebuiltAndBuilt covers the multi-service shape used
+// by openpanel and plunk: some services use pre-built images
+// (postgres:14-alpine, redis:7.2.5-alpine), others use repo-built ones
+// (clickhouse/Dockerfile). The builder must build only the
+// repo-Dockerfile images and pass the pre-built refs through unchanged.
+func TestBuilder_MixedPrebuiltAndBuilt(t *testing.T) {
+	t.Parallel()
+	cf := &cobaltfile.Cobaltfile{
+		Version: "1.0",
+		Services: map[string]cobaltfile.Service{
+			"postgres":   {Type: cobaltfile.TypeContainer, Image: "postgres:14-alpine", Port: 5432},
+			"redis":      {Type: cobaltfile.TypeContainer, Image: "redis:7.2.5-alpine", Port: 6379},
+			"clickhouse": {Type: cobaltfile.TypeContainer, Image: "clickhouse", Port: 8123},
+			"web":        {Type: cobaltfile.TypeContainer, Image: "web", Port: 80},
+		},
+		Images: map[string]cobaltfile.Image{
+			"clickhouse": {Dockerfile: "clickhouse/Dockerfile", Context: "clickhouse"},
+			"web":        {Dockerfile: "caddy/Dockerfile", Context: "caddy"},
+		},
+	}
+	d := &fakeImageBuilder{}
+	b := NewBuilder(d, &fakeEnv{}, "")
+	out, err := b.Build(context.Background(),
+		store.Project{ID: 1, Name: "openpanel"},
+		store.Deployment{Number: 2},
+		&Workspace{Cobaltfile: cf},
+		nil,
+	)
+	if err != nil {
+		t.Fatalf("Build: %v", err)
+	}
+	if len(d.calls) != 2 {
+		t.Errorf("expected 2 docker builds (clickhouse + web), got %d", len(d.calls))
+	}
+
+	// Each BuiltService must carry the right ImageTag — pre-built refs
+	// pass through verbatim; repo-built services get the cobalt-tagged
+	// build output (whatever the fake builder returned).
+	got := map[string]string{}
+	for _, b := range out {
+		got[b.Name] = b.ImageTag
+	}
+	wantPrebuilt := map[string]string{
+		"postgres": "postgres:14-alpine",
+		"redis":    "redis:7.2.5-alpine",
+	}
+	for name, want := range wantPrebuilt {
+		if got[name] != want {
+			t.Errorf("%s ImageTag = %q, want pre-built %q", name, got[name], want)
+		}
+	}
+	for _, name := range []string{"clickhouse", "web"} {
+		if got[name] == "" || got[name] == "clickhouse" || got[name] == "web" {
+			t.Errorf("%s ImageTag = %q, want a cobalt-tagged built image (not the source name)", name, got[name])
+		}
 	}
 }
 


### PR DESCRIPTION
## Summary

Cobalt rejected every real cobaltfile that uses a pre-built docker registry image (`postgres:14-alpine`, `redis/redis-stack:7.4.0-v8`, etc.). The validator demanded `service.image` be a key in `cf.Images`. Disco supports both modes — this brings cobalt to parity.

Hit during Blue's disco-to-cobalt cutover: `cobalt deploy --project redis` failed with `cobaltfile: service "redis" references unknown image "redis/redis-stack:7.4.0-v8"`. About 10 of 15 production cobalt projects (redis, photon, dozzle, grafana, plunk's postgres/redis/minio, openpanel's postgres/redis) would hit the same wall.

## Approach

Match disco's resolution rule from `utils/docker.py:1218-1228`:

\`\`\`python
if service.image in disco_file.images:
    return internal_image_name(...)   # build from Dockerfile
else:
    return service.image              # pre-built registry reference
\`\`\`

- **Validator** (`cobaltfile/validate.go`): drop the \`s.Image not in cf.Images\` error. Image-reference validation is now intentionally none — a bogus pre-built ref surfaces as a \`docker pull\` failure at deploy time (loud, well-localized) rather than a parse-time error that blocks valid cobaltfiles.
- **Builder** (\`deploy/build.go\`): if \`svc.Image\` isn't in \`cf.Images\`, log "📦 using pre-built image" and pass the verbatim string through to \`BuiltService.ImageTag\`. No \`docker build\` invoked. Multi-service projects with a mix of pre-built and Dockerfile-built images (openpanel, plunk) work transparently.
- Removed the now-unused \`needsImage\` helper. \`needsBuild\` in build.go covers the build-path equivalent.

## Tests

- \`TestValidate_PrebuiltImageReference\` — library-image shape (\`postgres:14-alpine\`)
- \`TestValidate_PrebuiltImageReference_WithRegistryPath\` — org/repo:tag shape
- \`TestValidate_EmptyImageFilledByDefaults\` — defaults backfill keeps working
- \`TestBuilder_PrebuiltImageSkipsBuild\` — no \`docker build\` invoked, \`ImageTag\` verbatim
- \`TestBuilder_MixedPrebuiltAndBuilt\` — openpanel/plunk shape: exactly 2 builds in a 4-service project, pre-built refs unchanged

All green locally: \`go test ./... -count=1\`. CI failures will mirror the pre-existing flaky-cleanup pattern documented in #6 (rqlite container leaves root-owned tempfiles); not from this PR.

## Refs

- Disco source: \`tmp/disco-daemon/disco/utils/docker.py:1218\`
- Surfaced during cutover described in \`/Users/manny/blue/plans/disco-to-cobalt-cutover.md\` Phase 5