### PR TITLE
fix(docker): shell-split service command strings (disco parity)

### DIFF
--- a/internal/server/docker/build.go
+++ b/internal/server/docker/build.go
@@ -232,3 +232,99 @@ func SplitParams(s string) []string {
 	}
 	return parts
 }
+
+// ShellSplit parses a command string into argv the way a shell would —
+// whitespace separates tokens, but single and double quotes hold their
+// contents together (including embedded whitespace) and backslash escapes
+// the next character.
+//
+// Why this exists: cobaltfile `command:` strings need shell-like parsing
+// because operators write them in shell syntax. Examples:
+//
+//	"redis-server --maxmemory-policy noeviction"
+//	    → ["redis-server", "--maxmemory-policy", "noeviction"]
+//
+//	"sh -c 'CI=true pnpm migrate:deploy && pnpm start'"
+//	    → ["sh", "-c", "CI=true pnpm migrate:deploy && pnpm start"]
+//
+// `strings.Fields` (what SplitParams uses) splits on every whitespace,
+// which mangles the second case into ten broken tokens. `docker service
+// create <image> <opts.Command>` passing the whole string as one arg is
+// also wrong — docker treats it as Cmd[0], i.e. a single binary literally
+// named "redis-server --maxmemory-policy noeviction", which exits with
+// "executable file not found".
+//
+// Matches disco's behavior (utils/docker.py uses Python's shlex.split).
+// Handles: bare words, single quotes, double quotes, backslash escapes
+// outside quotes, backslash escapes inside double quotes (per POSIX:
+// inside single quotes, backslashes are literal). Does NOT handle env
+// var expansion ($FOO) — that's a shell feature, not a parser feature;
+// callers wanting variable expansion should use `sh -c '...'`.
+func ShellSplit(s string) []string {
+	var out []string
+	var cur strings.Builder
+	inToken := false
+
+	const (
+		none      = 0
+		singleQ   = 1
+		doubleQ   = 2
+	)
+	state := none
+
+	flush := func() {
+		if inToken {
+			out = append(out, cur.String())
+			cur.Reset()
+			inToken = false
+		}
+	}
+
+	for i := 0; i < len(s); i++ {
+		c := s[i]
+		switch state {
+		case none:
+			switch {
+			case c == ' ' || c == '\t' || c == '\n' || c == '\r':
+				flush()
+			case c == '\'':
+				inToken = true
+				state = singleQ
+			case c == '"':
+				inToken = true
+				state = doubleQ
+			case c == '\\' && i+1 < len(s):
+				inToken = true
+				cur.WriteByte(s[i+1])
+				i++
+			default:
+				inToken = true
+				cur.WriteByte(c)
+			}
+		case singleQ:
+			// Inside single quotes nothing is special — not even backslash.
+			if c == '\'' {
+				state = none
+			} else {
+				cur.WriteByte(c)
+			}
+		case doubleQ:
+			switch {
+			case c == '"':
+				state = none
+			case c == '\\' && i+1 < len(s):
+				// Inside double quotes, backslash escapes only $ ` " \ and
+				// newline (POSIX). Outside those, it's literal. We're
+				// conservative: always treat as escape so callers don't get
+				// surprised, since cobalt commands aren't shell-evaluated
+				// anyway (no $var, no backtick).
+				cur.WriteByte(s[i+1])
+				i++
+			default:
+				cur.WriteByte(c)
+			}
+		}
+	}
+	flush()
+	return out
+}

--- a/internal/server/docker/names_test.go
+++ b/internal/server/docker/names_test.go
@@ -90,6 +90,12 @@ func TestShellSplit(t *testing.T) {
 		{"quoted_concat", `a'b c'd`, []string{"ab cd"}},
 		// Empty quoted segments produce empty tokens.
 		{"empty_single_quote", `a '' b`, []string{"a", "", "b"}},
+		// Trailing backslash at end-of-input has no next char to escape;
+		// fall through to default and write the `\` literally. Matches
+		// shlex's non-POSIX mode (POSIX would error). Pinned by test so
+		// a future "fix" doesn't silently change behavior.
+		{"trailing_backslash_unquoted", `foo\`, []string{`foo\`}},
+		{"trailing_backslash_inside_double_quote", `"foo\`, []string{`foo\`}},
 	}
 	for _, tc := range cases {
 		t.Run(tc.name, func(t *testing.T) {

--- a/internal/server/docker/names_test.go
+++ b/internal/server/docker/names_test.go
@@ -49,6 +49,70 @@ func TestSplitParams(t *testing.T) {
 	}
 }
 
+// TestShellSplit covers cobaltfile `command:` parsing. Cobaltfiles
+// describe commands in shell syntax (single & double quotes, escapes)
+// because operators write them that way. Without shell-aware splitting,
+// commands like `sh -c 'A && B'` are mangled into ten tokens, or commands
+// like `redis-server --maxmemory-policy noeviction` are passed to docker
+// as a single binary literal — which exits with "executable file not found".
+//
+// Disco parity: utils/docker.py uses Python's shlex.split for the same
+// purpose.
+func TestShellSplit(t *testing.T) {
+	t.Parallel()
+	cases := []struct {
+		name string
+		in   string
+		want []string
+	}{
+		// Trivial cases.
+		{"empty", "", nil},
+		{"whitespace_only", "   \t\n  ", nil},
+		{"single_token", "redis-server", []string{"redis-server"}},
+		// Bare-word commands (the common cobaltfile shape).
+		{"flag_with_value", "redis-server --maxmemory-policy noeviction",
+			[]string{"redis-server", "--maxmemory-policy", "noeviction"}},
+		{"collapses_whitespace", "  redis-server   --maxmemory-policy   noeviction  ",
+			[]string{"redis-server", "--maxmemory-policy", "noeviction"}},
+		// Single-quoted: contents are literal, no escape interpretation.
+		{"single_quoted_keeps_spaces", "sh -c 'pnpm migrate:deploy && pnpm start'",
+			[]string{"sh", "-c", "pnpm migrate:deploy && pnpm start"}},
+		{"single_quoted_with_env_assignment", "sh -c 'CI=true pnpm -r run migrate:deploy && pnpm start'",
+			[]string{"sh", "-c", "CI=true pnpm -r run migrate:deploy && pnpm start"}},
+		{"single_quoted_with_backslash_literal", `echo 'a\b'`, []string{"echo", `a\b`}},
+		// Double-quoted: contents kept together but backslash escapes work.
+		{"double_quoted_keeps_spaces", `sh -c "echo hello world"`,
+			[]string{"sh", "-c", "echo hello world"}},
+		{"double_quoted_escape", `echo "a\"b"`, []string{"echo", `a"b`}},
+		// Backslash outside quotes — escape the next char.
+		{"backslash_escape_space", `a\ b`, []string{"a b"}},
+		// Mixed: token concatenation across quote modes.
+		{"quoted_concat", `a'b c'd`, []string{"ab cd"}},
+		// Empty quoted segments produce empty tokens.
+		{"empty_single_quote", `a '' b`, []string{"a", "", "b"}},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			got := ShellSplit(tc.in)
+			if !slicesEqual(got, tc.want) {
+				t.Errorf("ShellSplit(%q) = %v, want %v", tc.in, got, tc.want)
+			}
+		})
+	}
+}
+
+func slicesEqual(a, b []string) bool {
+	if len(a) != len(b) {
+		return false
+	}
+	for i := range a {
+		if a[i] != b[i] {
+			return false
+		}
+	}
+	return true
+}
+
 func TestLabels(t *testing.T) {
 	t.Parallel()
 	got := serviceLabels(7, "api", "web", 3)

--- a/internal/server/docker/service.go
+++ b/internal/server/docker/service.go
@@ -124,9 +124,12 @@ func (c *Client) CreateService(ctx context.Context, opts ServiceCreateOpts) erro
 	}
 	args = append(args, opts.ExtraParams...)
 	args = append(args, opts.Image)
-	if opts.Command != "" {
-		args = append(args, opts.Command)
-	}
+	// Shell-split the command so multi-arg commands work as operators
+	// expect. Passing opts.Command as a single argv string makes docker
+	// treat it as a literal binary path, which exits immediately with
+	// "executable file not found in $PATH". See ShellSplit in build.go
+	// for the parsing rules and rationale.
+	args = append(args, ShellSplit(opts.Command)...)
 
 	return c.run(ctx, args...)
 }

--- a/internal/server/docker/service_test.go
+++ b/internal/server/docker/service_test.go
@@ -71,11 +71,13 @@ func TestCreateService_FullArgs(t *testing.T) {
 	}
 
 	// Image and command are positional and come after all flags.
-	if args[len(args)-2] != "cobalt/project-api-default:3" {
+	// Command is shell-split, so "node server.js" becomes ["node", "server.js"]:
+	// image at -3, command tokens at -2 and -1.
+	if args[len(args)-3] != "cobalt/project-api-default:3" {
 		t.Errorf("image position wrong: %v", args)
 	}
-	if args[len(args)-1] != "node server.js" {
-		t.Errorf("command position wrong: %v", args)
+	if args[len(args)-2] != "node" || args[len(args)-1] != "server.js" {
+		t.Errorf("command tokens wrong: got [%s %s], want [node server.js]", args[len(args)-2], args[len(args)-1])
 	}
 
 	// Env vars must be present in alphabetical key order.
@@ -277,6 +279,99 @@ func TestNetworkFlagValue(t *testing.T) {
 		if got := networkFlagValue(c.in); got != c.want {
 			t.Errorf("networkFlagValue(%+v) = %q, want %q", c.in, got, c.want)
 		}
+	}
+}
+
+// TestCreateService_CommandShellSplit proves the command string is
+// shell-split into individual argv tokens, not passed as a single literal
+// argument. Without this, docker would interpret the whole string as the
+// binary path and exit immediately — the failure mode that hit
+// openpanel-redis with `command: redis-server --maxmemory-policy noeviction`.
+func TestCreateService_CommandShellSplit(t *testing.T) {
+	t.Parallel()
+	r := newFakeRunner()
+	c := NewWithRunner(r)
+	err := c.CreateService(context.Background(), ServiceCreateOpts{
+		ProjectName: "openpanel", ServiceName: "redis", DeploymentNumber: 1,
+		Image:   "redis:7.2.5-alpine",
+		Command: "redis-server --maxmemory-policy noeviction",
+	})
+	if err != nil {
+		t.Fatalf("CreateService: %v", err)
+	}
+	args := r.lastCall().Args
+
+	// The image must be followed by THREE tokens (redis-server, --maxmemory-policy, noeviction),
+	// not a single concatenated string.
+	for i, a := range args {
+		if a == "redis:7.2.5-alpine" {
+			if i+3 >= len(args) {
+				t.Fatalf("expected 3 command tokens after image, got %v", args[i:])
+			}
+			if args[i+1] != "redis-server" || args[i+2] != "--maxmemory-policy" || args[i+3] != "noeviction" {
+				t.Errorf("command tokens after image: got %v, want [redis-server --maxmemory-policy noeviction]", args[i+1:i+4])
+			}
+			return
+		}
+	}
+	t.Fatalf("image not found in args: %v", args)
+}
+
+// TestCreateService_CommandWithSingleQuotes covers the openpanel-api
+// shape: `sh -c 'multi-word command with operators'`. Single quotes must
+// preserve embedded whitespace + operators so the whole quoted segment
+// reaches docker as one argv element.
+func TestCreateService_CommandWithSingleQuotes(t *testing.T) {
+	t.Parallel()
+	r := newFakeRunner()
+	c := NewWithRunner(r)
+	err := c.CreateService(context.Background(), ServiceCreateOpts{
+		ProjectName: "openpanel", ServiceName: "api", DeploymentNumber: 1,
+		Image:   "lindesvard/openpanel-api:2",
+		Command: "sh -c 'CI=true pnpm -r run migrate:deploy && pnpm start'",
+	})
+	if err != nil {
+		t.Fatalf("CreateService: %v", err)
+	}
+	args := r.lastCall().Args
+
+	for i, a := range args {
+		if a == "lindesvard/openpanel-api:2" {
+			if i+3 >= len(args) {
+				t.Fatalf("expected 3 command tokens after image, got %v", args[i:])
+			}
+			if args[i+1] != "sh" || args[i+2] != "-c" {
+				t.Errorf("expected [sh -c ...], got %v", args[i+1:i+3])
+			}
+			if args[i+3] != "CI=true pnpm -r run migrate:deploy && pnpm start" {
+				t.Errorf("single-quoted segment lost shape: got %q", args[i+3])
+			}
+			return
+		}
+	}
+	t.Fatalf("image not found in args: %v", args)
+}
+
+// TestCreateService_EmptyCommandOmitted documents the existing behavior
+// that an empty command field doesn't add any positional arg after the
+// image — the container's Dockerfile CMD is used. Most cobaltfiles
+// don't set command at all.
+func TestCreateService_EmptyCommandOmitted(t *testing.T) {
+	t.Parallel()
+	r := newFakeRunner()
+	c := NewWithRunner(r)
+	err := c.CreateService(context.Background(), ServiceCreateOpts{
+		ProjectName: "api", ServiceName: "web", DeploymentNumber: 1,
+		Image: "ghcr.io/some/image:1",
+		// no Command
+	})
+	if err != nil {
+		t.Fatalf("CreateService: %v", err)
+	}
+	args := r.lastCall().Args
+	// Image must be the last argv element (no command tokens follow).
+	if args[len(args)-1] != "ghcr.io/some/image:1" {
+		t.Errorf("expected image as last arg, got %v", args[len(args)-3:])
 	}
 }
 


### PR DESCRIPTION
## Summary

\`docker service create <image> \"<opts.Command>\"\` passed the whole command string as a single argv element, which docker interprets as the literal binary path. A cobaltfile like:

\`\`\`json
\"redis\": {
  \"image\": \"redis:7.2.5-alpine\",
  \"command\": \"redis-server --maxmemory-policy noeviction\"
}
\`\`\`

…starts the container with \`Cmd[0] = \"redis-server --maxmemory-policy noeviction\"\`. There's no binary by that literal name; the container exits immediately, cobalt hits its 3-shutdown fail-fast threshold, deploy fails.

## Approach

Add \`ShellSplit(string) []string\` in \`internal/server/docker/build.go\`. Handles:
- Bare words separated by whitespace (collapsing runs)
- Single quotes — contents literal, no escape interpretation
- Double quotes — backslash escapes work
- Backslash outside quotes — escape next char
- Empty quoted segments produce empty tokens

Matches disco's behavior — \`utils/docker.py\` uses Python's \`shlex.split\` for the same purpose. Service create now calls \`ShellSplit(opts.Command)\` and spreads the result into argv.

\`RunOpts.Command\` is already \`[]string\` (caller-tokenized), unchanged.

## Test plan

- [x] \`TestShellSplit\` — 11 table-driven cases (bare words, single/double quotes, escapes, whitespace collapsing, empty quoted segments)
- [x] \`TestCreateService_CommandShellSplit\` — \`redis-server --maxmemory-policy noeviction\` renders as 3 tokens after image
- [x] \`TestCreateService_CommandWithSingleQuotes\` — \`sh -c 'A && B'\` renders as 3 tokens with the quoted segment intact
- [x] \`TestCreateService_EmptyCommandOmitted\` — empty command means no positional args after image (Dockerfile CMD runs)
- [x] Updated \`TestCreateService_FullArgs\` to expect the split form
- [x] \`go test ./... -count=1\` green

## Refs

- Disco source: \`utils/docker.py\` (\`shlex.split(command)\`)
- Surfaced in production cutover on a multi-service project's redis sub-service.