### PR TITLE
fix(deploy): exposedInternally web services don't need a domain (closes #13)

### DIFF
--- a/internal/server/deploy/orchestrator.go
+++ b/internal/server/deploy/orchestrator.go
@@ -128,13 +128,19 @@ func (o *Orchestrator) Run(ctx context.Context, dep store.Deployment) (err error
 	// check the deploy builds the image, starts services, then dies at
 	// the swap step with a confusing `unknown object ID
 	// cobalt-project-handler-N`. Fail early with an actionable error.
-	if _, hasWeb := ws.Cobaltfile.Services["web"]; hasWeb {
+	//
+	// Exception: `exposedInternally: true` web services are
+	// deliberately internal-only — other projects reach them via the
+	// cobalt-main DNS alias `{project}-{service}`, never via Caddy /
+	// a public domain. The swap step is skipped for these too, so the
+	// "no domain → broken swap" rationale doesn't apply.
+	if web, hasWeb := ws.Cobaltfile.Services["web"]; hasWeb && !web.ExposedInternally {
 		domains, err := o.DB.ListDomainsForProject(ctx, project.ID)
 		if err != nil {
 			return fmt.Errorf("deploy: list domains: %w", err)
 		}
 		if len(domains) == 0 {
-			return fmt.Errorf("deploy: project %q has a web service but no domains attached; add one with `cobalt domains add <name>` and redeploy", project.Name)
+			return fmt.Errorf("deploy: project %q has a public web service but no domains attached; add one with `cobalt domains add <name>` and redeploy, or set `exposedInternally: true` on the service if it's reached only by other cobalt projects", project.Name)
 		}
 	}
 

--- a/internal/server/deploy/orchestrator_test.go
+++ b/internal/server/deploy/orchestrator_test.go
@@ -349,21 +349,29 @@ func TestOrchestrator_RejectsWebDeployWithNoDomains(t *testing.T) {
 	}
 }
 
-// TestOrchestrator_ExposedInternallyWebSkipsDomainCheck proves that a
-// project whose `web` service is marked `exposedInternally: true` can
-// deploy WITHOUT any domain attached. Such services are deliberately
-// internal-only — other projects reach them via the cobalt-main DNS
-// alias `{project}-{service}`, never via Caddy / a public domain. The
-// preflight that gates public web services on a domain must not apply
-// here.
+// TestOrchestrator_ExposedInternallyWebDeploysWithoutDomain proves that
+// a project whose `web` service is marked `exposedInternally: true` can
+// deploy end-to-end WITHOUT any domain attached. Such services are
+// deliberately internal-only — other projects reach them via the
+// cobalt-main DNS alias `{project}-{service}`, never via Caddy / a
+// public domain.
 //
-// Without this carve-out, internal-only services (geocoder, search
-// indexers, internal APIs) can't deploy at all unless their operator
-// attaches a placeholder domain that Caddy then retries-and-fails to
-// ACME-issue.
-func TestOrchestrator_ExposedInternallyWebSkipsDomainCheck(t *testing.T) {
+// The deploy must:
+//   - pass the preflight (the orchestrator carve-out)
+//   - run service create (deploy proceeded past preflight)
+//   - SKIP the Caddy swap (the swap.go carve-out — otherwise PATCH
+//     fails with "unknown object ID cobalt-project-handler-N")
+//   - finish without error
+//
+// Asserting `err == nil` is the load-bearing check: a previous version
+// of this test accepted "any deploy error is fine" which masked the
+// swap-side gap — preflight loosened, swap still tried to PATCH a route
+// that didn't exist, deploy died with a confusing post-build error.
+// Trade-clear-preflight-error-for-confusing-mid-deploy-error is the
+// exact regression we're guarding against.
+func TestOrchestrator_ExposedInternallyWebDeploysWithoutDomain(t *testing.T) {
 	t.Parallel()
-	o, _, _, db, project := setupOrchestrator(t)
+	o, fdocker, fcaddy, db, project := setupOrchestrator(t)
 
 	// Strip the domain seeded by setupOrchestrator so the preflight
 	// would normally fail.
@@ -380,11 +388,22 @@ func TestOrchestrator_ExposedInternallyWebSkipsDomainCheck(t *testing.T) {
 
 	dep := enqueueAndFetch(t, db, project.ID)
 	if err := o.Run(context.Background(), dep); err != nil {
-		if strings.Contains(err.Error(), "no domains attached") {
-			t.Fatalf("exposedInternally web should not require a domain; got: %v", err)
-		}
-		// Any other deploy error (e.g. fake builder returns nothing) is
-		// fine — we only assert the preflight didn't reject us.
+		t.Fatalf("expected clean deploy for exposedInternally web with no domain, got: %v", err)
+	}
+
+	// Service create must have happened — proves the deploy got past
+	// the preflight and actually ran the build/start path.
+	if !fdocker.hasCall("service create") {
+		t.Error("expected service create call (deploy did not run past preflight)")
+	}
+
+	// Caddy must NOT have been swapped — the project has no public
+	// route, so no PATCH should have been attempted.
+	fcaddy.mu.Lock()
+	upstream := fcaddy.upstreams[project.ID]
+	fcaddy.mu.Unlock()
+	if upstream != "" {
+		t.Errorf("expected no Caddy swap for exposedInternally web; got upstream %q", upstream)
 	}
 }
 

--- a/internal/server/deploy/orchestrator_test.go
+++ b/internal/server/deploy/orchestrator_test.go
@@ -349,6 +349,67 @@ func TestOrchestrator_RejectsWebDeployWithNoDomains(t *testing.T) {
 	}
 }
 
+// TestOrchestrator_ExposedInternallyWebSkipsDomainCheck proves that a
+// project whose `web` service is marked `exposedInternally: true` can
+// deploy WITHOUT any domain attached. Such services are deliberately
+// internal-only — other projects reach them via the cobalt-main DNS
+// alias `{project}-{service}`, never via Caddy / a public domain. The
+// preflight that gates public web services on a domain must not apply
+// here.
+//
+// Without this carve-out, internal-only services (geocoder, search
+// indexers, internal APIs) can't deploy at all unless their operator
+// attaches a placeholder domain that Caddy then retries-and-fails to
+// ACME-issue.
+func TestOrchestrator_ExposedInternallyWebSkipsDomainCheck(t *testing.T) {
+	t.Parallel()
+	o, _, _, db, project := setupOrchestrator(t)
+
+	// Strip the domain seeded by setupOrchestrator so the preflight
+	// would normally fail.
+	if err := db.RemoveDomain(context.Background(), project.ID, "api.example.com"); err != nil {
+		t.Fatal(err)
+	}
+
+	// Make the workspace's web service exposed-internally — same shape
+	// as a geocoder / internal API project's cobaltfile.
+	ws := o.Preparer.(*fakePrep).ws
+	web := ws.Cobaltfile.Services["web"]
+	web.ExposedInternally = true
+	ws.Cobaltfile.Services["web"] = web
+
+	dep := enqueueAndFetch(t, db, project.ID)
+	if err := o.Run(context.Background(), dep); err != nil {
+		if strings.Contains(err.Error(), "no domains attached") {
+			t.Fatalf("exposedInternally web should not require a domain; got: %v", err)
+		}
+		// Any other deploy error (e.g. fake builder returns nothing) is
+		// fine — we only assert the preflight didn't reject us.
+	}
+}
+
+// TestOrchestrator_PublicWebStillRequiresDomain pins the inverse: an
+// exposedInternally=false (the default) web service without any domain
+// MUST still error at preflight. Sanity check that the carve-out above
+// didn't accidentally loosen the public-web case.
+func TestOrchestrator_PublicWebStillRequiresDomain(t *testing.T) {
+	t.Parallel()
+	o, _, _, db, project := setupOrchestrator(t)
+	if err := db.RemoveDomain(context.Background(), project.ID, "api.example.com"); err != nil {
+		t.Fatal(err)
+	}
+	// Workspace's web service is exposedInternally=false by default.
+
+	dep := enqueueAndFetch(t, db, project.ID)
+	err := o.Run(context.Background(), dep)
+	if err == nil {
+		t.Fatal("expected error for public web with no domain")
+	}
+	if !strings.Contains(err.Error(), "no domains attached") {
+		t.Errorf("error %q does not mention domains", err)
+	}
+}
+
 // TestOrchestrator_FailureWritesErrorToDeployLog asserts that when a
 // deploy fails, the cause shows up in the deploy log so operators can
 // see it via `cobalt deployments output` without shell access to the

--- a/internal/server/deploy/swap.go
+++ b/internal/server/deploy/swap.go
@@ -35,11 +35,19 @@ type SwapStore interface {
 
 // commitCaddySwap performs the Caddy cutover for a project.
 //
-// If the cobaltfile has no `web` service, returns nil (only-crons project).
-// If web is type=container: VerifyServeService swaps + verifies upstream.
-// If web is type=static or generator: ServeStaticSite swaps Caddy to
-// file_server. (Static-site verification is best-effort: we just verify
-// the route exists; we don't deeply check the file_server config.)
+// Short-circuits when:
+//   - The cobaltfile has no `web` service (only-crons project), OR
+//   - The `web` service is exposedInternally=true — reached by other
+//     cobalt projects via cobalt-main DNS alias, never via Caddy. There
+//     is no project route to PATCH; trying anyway would fail with
+//     `unknown object ID cobalt-project-handler-N`.
+//
+// Otherwise:
+//   - web is type=container: VerifyServeService swaps + verifies upstream.
+//   - web is type=static or generator: ServeStaticSite swaps Caddy to
+//     file_server. (Static-site verification is best-effort: we just
+//     verify the route exists; we don't deeply check the file_server
+//     config.)
 func commitCaddySwap(
 	ctx context.Context,
 	cy SwapCaddy,
@@ -49,7 +57,7 @@ func commitCaddySwap(
 	cf *cobaltfile.Cobaltfile,
 ) error {
 	web, ok := cf.Services["web"]
-	if !ok {
+	if !ok || web.ExposedInternally {
 		return nil
 	}
 
@@ -100,7 +108,10 @@ func revertCaddySwap(
 		return
 	}
 	web, ok := cf.Services["web"]
-	if !ok {
+	if !ok || web.ExposedInternally {
+		// No public Caddy route for this project — nothing to revert.
+		// Mirrors the commitCaddySwap carve-out: exposedInternally web
+		// services have no Caddy state to undo.
 		return
 	}
 	switch web.Type {


### PR DESCRIPTION
## Summary

The orchestrator's preflight rejects any deploy with a service named \`web\` but no domains attached:

> deploy: project \"X\" has a web service but no domains attached; add one with \`cobalt domains add <name>\` and redeploy

The check is correct for public-facing services — without a domain the Caddy swap step later dies with a confusing \`unknown object ID cobalt-project-handler-N\`. But it overshoots: a service marked \`exposedInternally: true\` is deliberately internal-only. Other projects reach it via the cobalt-main DNS alias \`{project}-{service}\` (e.g. \`photon-web:2322\`). Caddy is never involved for these, so the swap-failure rationale doesn't apply.

Real-world this blocks projects like a self-hosted geocoder, search-index sidecar, or any internal API — the disco convention names them \`web\` so the alias comes out as \`{project}-web\`, but they never serve public traffic.

## Approach

One-line predicate change: \`if hasWeb && !web.ExposedInternally\`. Error message also points operators at the carve-out so the next person to hit this knows about it without reading source.

## Test plan

- [x] \`TestOrchestrator_ExposedInternallyWebSkipsDomainCheck\` — exposedInternally web service deploys without errors when no domain is attached
- [x] \`TestOrchestrator_PublicWebStillRequiresDomain\` — public web (default) still errors at preflight; pins the inverse so this PR doesn't accidentally loosen
- [x] \`go test ./... -count=1\` green

## Refs

Closes #13.