### PR TITLE
feat(cobaltfile): add minReplicas service field

### DIFF
--- a/docs/commands.md
+++ b/docs/commands.md
@@ -83,7 +83,7 @@ the aggregate so the file stays parseable.
 | Command | v1 | Notes |
 |---|---|---|
 | `cobalt scale get --project <p>` | YES | Show current replicas per service |
-| `cobalt scale set --project <p> web=3 [worker=2 ...]` | YES | Set replica counts |
+| `cobalt scale set --project <p> web=3 [worker=2 ...]` | YES | Set replica counts (current deployment only — for a persistent floor across deploys, set `minReplicas` in `cobalt.json`) |
 
 ## github
 

--- a/internal/server/cobaltfile/cobaltfile.go
+++ b/internal/server/cobaltfile/cobaltfile.go
@@ -89,6 +89,13 @@ type Service struct {
 	Health            *Health         `json:"health,omitempty"`
 	ExtraSwarmParams  string          `json:"extraSwarmParams,omitempty"`
 	ExtraRunParams    string          `json:"extraRunParams,omitempty"`
+	// MinReplicas is the baseline replica count a new deployment of this
+	// container service starts with. Zero means "use docker's default of
+	// 1". `cobalt scale set` can still raise the count above the floor for
+	// the current deployment, but the next deploy starts fresh from
+	// MinReplicas — so this is how you encode "api needs 4 to survive prod
+	// load" in the repo rather than only in operator memory.
+	MinReplicas int `json:"minReplicas,omitempty"`
 }
 
 // Image describes how to build a docker image.

--- a/internal/server/cobaltfile/validate.go
+++ b/internal/server/cobaltfile/validate.go
@@ -74,6 +74,12 @@ func validateService(name string, s Service) error {
 	if s.Timeout < 0 {
 		return fmt.Errorf("cobaltfile: service %q timeout %d must be non-negative", name, s.Timeout)
 	}
+	if s.MinReplicas < 0 {
+		return fmt.Errorf("cobaltfile: service %q minReplicas %d must be non-negative", name, s.MinReplicas)
+	}
+	if s.MinReplicas > 0 && s.Type != TypeContainer {
+		return fmt.Errorf("cobaltfile: service %q minReplicas only valid for type=container (got %q)", name, s.Type)
+	}
 	if s.Type == TypeCron {
 		if err := validateCronSchedule(s.Schedule); err != nil {
 			return fmt.Errorf("cobaltfile: service %q schedule: %w", name, err)

--- a/internal/server/cobaltfile/validate_test.go
+++ b/internal/server/cobaltfile/validate_test.go
@@ -75,6 +75,46 @@ func TestValidate_PortRange(t *testing.T) {
 	}
 }
 
+func TestValidate_MinReplicasNegative(t *testing.T) {
+	t.Parallel()
+	src := `{
+        "version": "1.0",
+        "services": {"web": {"minReplicas": -1}}
+    }`
+	_, err := Parse([]byte(src))
+	mustContain(t, err, "minReplicas")
+}
+
+func TestValidate_MinReplicasContainerOnly(t *testing.T) {
+	t.Parallel()
+	src := `{
+        "version": "1.0",
+        "services": {"worker": {
+            "type": "cron",
+            "schedule": "* * * * *",
+            "command": "echo hi",
+            "minReplicas": 2
+        }}
+    }`
+	_, err := Parse([]byte(src))
+	mustContain(t, err, "minReplicas only valid for type=container")
+}
+
+func TestValidate_MinReplicasAccepted(t *testing.T) {
+	t.Parallel()
+	src := `{
+        "version": "1.0",
+        "services": {"web": {"minReplicas": 4}}
+    }`
+	cf, err := Parse([]byte(src))
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if got := cf.Services["web"].MinReplicas; got != 4 {
+		t.Errorf("MinReplicas = %d, want 4", got)
+	}
+}
+
 func TestValidate_PublishedPortRange(t *testing.T) {
 	t.Parallel()
 	src := `{

--- a/internal/server/deploy/services.go
+++ b/internal/server/deploy/services.go
@@ -75,7 +75,7 @@ func waitHealthyAll(
 			first = false
 		}
 		name := docker.ServiceName(project.Name, dep.Number, b.Name)
-		replicas := 1 // cobaltfile services don't expose replica count yet; default 1
+		replicas := replicaCount(b.Service)
 		t0 := time.Now()
 		if err := d.WaitForServiceHealthy(ctx, name, replicas, HealthcheckTimeout); err != nil {
 			return fmt.Errorf("deploy: wait healthy %q: %w", b.Name, err)
@@ -96,6 +96,16 @@ func stopServices(ctx context.Context, d ServiceDocker, names []string) error {
 		}
 	}
 	return firstErr
+}
+
+// replicaCount returns the replica count a new deployment of s should be
+// created with. Falls back to 1 when minReplicas is unset, matching
+// docker's default and preserving prior behavior.
+func replicaCount(s cobaltfile.Service) int {
+	if s.MinReplicas > 0 {
+		return s.MinReplicas
+	}
+	return 1
 }
 
 // runsAsService reports whether a cobaltfile service should be started as
@@ -147,7 +157,7 @@ func serviceCreateOpts(
 			{Name: deploymentNetwork, Alias: b.Name},
 			{Name: MainNetworkName, Alias: mainNetAlias(project, b, dep)},
 		},
-		Replicas:    1,
+		Replicas:    replicaCount(b.Service),
 		ExtraParams: docker.SplitParams(b.Service.ExtraSwarmParams),
 	}
 	if b.Service.Health != nil && b.Service.Health.Command != "" {

--- a/internal/server/deploy/services_test.go
+++ b/internal/server/deploy/services_test.go
@@ -1,12 +1,51 @@
 package deploy
 
 import (
+	"context"
+	"io"
 	"testing"
+	"time"
 
 	"github.com/heyblueteam/cobalt/internal/server/cobaltfile"
 	"github.com/heyblueteam/cobalt/internal/server/docker"
 	"github.com/heyblueteam/cobalt/internal/server/store"
 )
+
+type serviceDockerFake struct {
+	created        []docker.ServiceCreateOpts
+	healthChecks   []healthCheckCall
+	removed        []string
+	services       []docker.ServiceInfo
+	createErr      error
+	healthCheckErr error
+	removeErr      error
+	listErr        error
+}
+
+type healthCheckCall struct {
+	name     string
+	replicas int
+	timeout  time.Duration
+}
+
+func (f *serviceDockerFake) CreateService(_ context.Context, opts docker.ServiceCreateOpts) error {
+	f.created = append(f.created, opts)
+	return f.createErr
+}
+
+func (f *serviceDockerFake) WaitForServiceHealthy(_ context.Context, name string, replicas int, timeout time.Duration) error {
+	f.healthChecks = append(f.healthChecks, healthCheckCall{name: name, replicas: replicas, timeout: timeout})
+	return f.healthCheckErr
+}
+
+func (f *serviceDockerFake) RemoveService(_ context.Context, name string) error {
+	f.removed = append(f.removed, name)
+	return f.removeErr
+}
+
+func (f *serviceDockerFake) ListServicesForDeployment(_ context.Context, _ int64, _ int) ([]docker.ServiceInfo, error) {
+	return f.services, f.listErr
+}
 
 // findAttachment returns the NetworkAttachment matching name, or fails the
 // test if absent. Centralizes the "ordering is implementation detail, but
@@ -141,6 +180,70 @@ func TestServiceCreateOpts_AttachesBothNetworks(t *testing.T) {
 	}
 	if opts.Networks[1].Name != MainNetworkName {
 		t.Errorf("Networks[1] = %q, want cobalt-main second", opts.Networks[1].Name)
+	}
+}
+
+func TestServiceCreateOpts_UsesMinReplicas(t *testing.T) {
+	t.Parallel()
+	project := store.Project{ID: 1, Name: "api"}
+	dep := store.Deployment{Number: 1}
+	b := BuiltService{
+		Name: "web",
+		Service: cobaltfile.Service{
+			MinReplicas: 4,
+		},
+	}
+
+	opts := serviceCreateOpts(project, dep, b, nil, "cobalt-project-api-1")
+
+	if opts.Replicas != 4 {
+		t.Errorf("Replicas = %d, want 4", opts.Replicas)
+	}
+}
+
+func TestServiceCreateOpts_DefaultsReplicasToOne(t *testing.T) {
+	t.Parallel()
+	project := store.Project{ID: 1, Name: "api"}
+	dep := store.Deployment{Number: 1}
+	b := BuiltService{Name: "web"}
+
+	opts := serviceCreateOpts(project, dep, b, nil, "cobalt-project-api-1")
+
+	if opts.Replicas != 1 {
+		t.Errorf("Replicas = %d, want 1", opts.Replicas)
+	}
+}
+
+func TestWaitHealthyAll_UsesMinReplicas(t *testing.T) {
+	t.Parallel()
+	project := store.Project{ID: 1, Name: "api"}
+	dep := store.Deployment{Number: 3}
+	d := &serviceDockerFake{}
+	built := []BuiltService{
+		{
+			Name: "web",
+			Service: cobaltfile.Service{
+				Type:        cobaltfile.TypeContainer,
+				MinReplicas: 4,
+			},
+		},
+	}
+
+	if err := waitHealthyAll(context.Background(), d, project, dep, built, io.Discard); err != nil {
+		t.Fatalf("waitHealthyAll: %v", err)
+	}
+	if len(d.healthChecks) != 1 {
+		t.Fatalf("health checks = %d, want 1", len(d.healthChecks))
+	}
+	got := d.healthChecks[0]
+	if got.name != "api-3-web" {
+		t.Errorf("health check name = %q, want api-3-web", got.name)
+	}
+	if got.replicas != 4 {
+		t.Errorf("health check replicas = %d, want 4", got.replicas)
+	}
+	if got.timeout != HealthcheckTimeout {
+		t.Errorf("health check timeout = %s, want %s", got.timeout, HealthcheckTimeout)
 	}
 }
 


### PR DESCRIPTION
## Summary

- Adds `minReplicas` to a cobaltfile service so the desired baseline replica count lives in the repo, applied on every deploy
- `cobalt scale set` continues to work as an operational override above the floor

## Why

Today every new deployment creates services with `replicas=1`. `cobalt scale set` raises the count for the live service, but the next deploy creates a fresh `<project>-<N>-<service>` and resets to 1 — so the "api needs 4 to survive prod load" fact only lives in operator memory.

We hit this in prod today: `api-4-web` was running 1/1 instead of 4/4, TTFB on `api.blue.cc` was 1.6-2.3s, and nothing in the repo signaled the desired baseline. Scaling fixed it, but the only durable answer is config-as-code.

## Changes

- `cobaltfile.Service.MinReplicas` (int) — container-only, non-negative, zero = "no floor / docker default of 1"
- `deploy.startServicesPhase` and `waitHealthyAll` consult `MinReplicas` via a new `replicaCount()` helper
- `validate.validateService` rejects negative values and non-container usage
- 3 new validate tests + docs note on the scale command

## Example

```json
{
  "version": "1.0",
  "services": {
    "web": {
      "port": 4000,
      "minReplicas": 4
    }
  }
}
```

## Test plan

- [x] `go test ./internal/server/cobaltfile/... ./internal/server/deploy/...` passes
- [ ] Manual: add `minReplicas: 4` to api/cobalt.json, deploy, confirm `docker service ls` shows 4/4 from the first deploy