### PR TITLE
fix(ci): unblock tempdir cleanup + lint version mismatch

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -27,6 +27,6 @@ jobs:
         with:
           go-version: "1.25"
           cache: true
-      - uses: golangci/golangci-lint-action@v6
+      - uses: golangci/golangci-lint-action@v9
         with:
-          version: latest
+          version: v2.12.2

--- a/internal/server/store/testutils_test.go
+++ b/internal/server/store/testutils_test.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"crypto/rand"
 	"encoding/hex"
+	"fmt"
 	"net"
 	"os"
 	"os/exec"
@@ -60,11 +61,18 @@ func openTestDB(t *testing.T) *DB {
 }
 
 func startRqlitedContainer(name, dataDir, hostPort string) error {
+	// Match the host UID/GID so files rqlite writes into the
+	// bind-mounted dataDir (t.TempDir) are owned by the test process
+	// and can be cleaned up. The official rqlite image runs as a
+	// non-root user by default; on Linux CI that left t.TempDir
+	// unable to unlinkat the wsnapshots/*.crc32 files at test end
+	// (root- or container-user-owned, not test-user-owned), failing
+	// every rqlite-backed test with "permission denied".
 	cmd := exec.Command("docker", "run",
 		"--name", name,
 		"--rm",
 		"--detach",
-		"--user", "root",
+		"--user", fmt.Sprintf("%d:%d", os.Getuid(), os.Getgid()),
 		"-v", dataDir+":/rqlite/data",
 		"-p", hostPort+":4001",
 		"rqlite/rqlite:latest",

--- a/internal/storetest/storetest.go
+++ b/internal/storetest/storetest.go
@@ -12,6 +12,7 @@ import (
 	"context"
 	"crypto/rand"
 	"encoding/hex"
+	"fmt"
 	"net"
 	"os"
 	"os/exec"
@@ -74,11 +75,18 @@ func OpenDB(t *testing.T) *store.DB {
 }
 
 func startRqlitedContainer(name, dataDir, hostPort string) error {
+	// Match the host UID/GID so files rqlite writes into the
+	// bind-mounted dataDir (t.TempDir) are owned by the test process
+	// and can be cleaned up. The official rqlite image runs as a
+	// non-root user by default; on Linux CI that left t.TempDir
+	// unable to unlinkat the wsnapshots/*.crc32 files at test end
+	// (root- or container-user-owned, not test-user-owned), failing
+	// every rqlite-backed test with "permission denied".
 	cmd := exec.Command("docker", "run",
 		"--name", name,
 		"--rm",
 		"--detach",
-		"--user", "root",
+		"--user", fmt.Sprintf("%d:%d", os.Getuid(), os.Getgid()),
 		"-v", dataDir+":/rqlite/data",
 		"-p", hostPort+":4001",
 		"rqlite/rqlite:latest",


### PR DESCRIPTION
## Summary

Two infra bugs that have kept CI red since the Go 1.25.1 bump. Bundled because they're both "unblock CI" fixes.

### 1. rqlited test container leaves root-owned files in `t.TempDir`

`startRqlitedContainer` ran with `--user root`, so rqlited wrote `wsnapshots/*/data.db.crc32` into the bind-mounted `t.TempDir` owned by root. At test end, `t.TempDir`'s `RemoveAll` cleanup ran as the test process (uid 1001 on Linux runners) and couldn't `unlinkat` those files — *permission denied* — failing every rqlite-backed test. macOS was unaffected because Docker Desktop's VirtioFS maps container UIDs to the host user.

**Fix:** pass `--user $(uid):$(gid)` so files are written as the test process from the start. Applied in both helpers (`internal/storetest/storetest.go` and `internal/server/store/testutils_test.go`).

### 2. golangci-lint version mismatch with Go 1.25.1

`golangci/golangci-lint-action@v6` with `version: latest` resolved to v1.64.8 (built with Go 1.24), which rejects the v2 config schema and the Go 1.25.1 module target:

```
Error: can't load config: the Go language version (go1.24) used to
build golangci-lint is lower than the targeted Go version (1.25.1)
```

The repo's `.golangci.yaml` is already on v2 schema (`version: "2"`).

**Fix:** bump action to `@v9` (v2-aware) and pin `version: v2.12.2`.

## Test plan

- [x] `go test ./internal/server/store/ ./internal/server/api/ ./internal/server/deploy/ -count=1` — all green locally on Mac with the new UID flag (proves we didn't break the existing Mac path).
- [ ] Watch this PR's CI run — both `test` and `lint` should go green.

## Risk

Low. Test infra only — no production code change. The `--user` flag is supported on Docker on every platform. If the host UID can't be looked up in `/etc/passwd` inside the container, that's fine — rqlited doesn't need the user resolved, only the numeric ID.