### PR TITLE
chore(lint): PR B — real fixes + judgment-call suppressions

### DIFF
--- a/.golangci.yml
+++ b/.golangci.yml
@@ -14,20 +14,65 @@ linters:
     - unconvert
     - unparam
   settings:
+    gosec:
+      # Excluded rules:
+      # - G104: duplicate of errcheck.
+      # - G204: cobalt IS a process supervisor — exec.Command with
+      #   variable args (git, docker, ssh) is the whole job. Daemon
+      #   inputs come from trusted sources (rqlite store, GitHub
+      #   webhook after HMAC verify, operator CLI).
+      # - G301/G302/G306: cobalt writes operator-readable log files,
+      #   generated config artifacts, and upgrade tooling. 0644 / 0755
+      #   are intentional; the security boundary is the host's user
+      #   account, not file modes.
+      # - G304: deploy paths come from the cobalt store (project name,
+      #   cobalt.json from a freshly cloned repo). Variable-path file
+      #   reads are the design, and inputs are trusted.
+      excludes:
+        - G104
+        - G204
+        - G301
+        - G302
+        - G304
+        - G306
     errcheck:
       # Excluded functions whose errors are conventionally ignored.
       # Close() in defers (can't usefully act on a close error during
       # teardown), buffered Fprint* / Encode (writing to in-memory
       # buffers never fails), and best-effort os.Remove in cleanup
       # paths. Anything outside these patterns still gets flagged.
+      #
+      # Close-method receivers are listed by concrete type because
+      # errcheck matches the static type, not the io.Closer interface:
+      # `defer conn.Close()` where conn is *ssh.Conn doesn't match the
+      # `(io.Closer).Close` pattern.
       exclude-functions:
         - (io.Closer).Close
+        - (*os.File).Close
+        - (net.Listener).Close
+        - (net.Conn).Close
+        - (io.PipeReader).Close
+        - (io.PipeWriter).Close
+        - (*io.PipeReader).Close
+        - (*io.PipeWriter).Close
+        - (io.WriteCloser).Close
+        - (*github.com/heyblueteam/cobalt/internal/ssh.Conn).Close
+        - (*golang.org/x/crypto/ssh.Session).Close
+        - (*golang.org/x/crypto/ssh.Session).Signal
+        - (*github.com/coder/websocket.Conn).Close
+        - (*github.com/coder/websocket.Conn).CloseNow
+        - (*github.com/rqlite/rqlite-go-http.Client).Close
         - fmt.Fprint
         - fmt.Fprintf
         - fmt.Fprintln
         - (*encoding/json.Encoder).Encode
         - (net/http.ResponseWriter).Write
         - os.Remove
+        # Process teardown: best-effort kill / wait in shutdown paths;
+        # nothing actionable to do with the error.
+        - (*os.Process).Kill
+        - syscall.Kill
+        - (*os/exec.Cmd).Wait
     revive:
       rules:
         # Blue's cobalt codebase doesn't enforce "every exported
@@ -42,10 +87,13 @@ linters:
       # Test files intentionally use weak crypto, hardcoded test
       # credentials, InsecureSkipVerify, etc. for fixtures. Scoping
       # gosec out of _test.go avoids ~15 false-positive flags on
-      # values that are obviously not production secrets.
+      # values that are obviously not production secrets. unparam
+      # likewise: test helpers commonly have "always-the-same-arg"
+      # signatures kept open for future flexibility.
       - path: _test\.go
         linters:
           - gosec
+          - unparam
       # e2e harness env builds an HTTP client against the local test
       # daemon with InsecureSkipVerify; not a production path.
       - path: e2e/env\.go

--- a/cmd/cobalt/common.go
+++ b/cmd/cobalt/common.go
@@ -2,6 +2,7 @@ package main
 
 import (
 	"bufio"
+	"errors"
 	"fmt"
 	"os"
 	"strings"
@@ -87,9 +88,17 @@ type confirmError struct{}
 func (confirmError) Error() string { return "aborted" }
 
 func IsConfirmAbort(err error) bool {
-	_, ok := err.(confirmError)
-	return ok
+	var ce confirmError
+	return errors.As(err, &ce)
 }
+
+// exitCodeError lets a command propagate a specific process exit code
+// up to main() without calling os.Exit mid-flow (which would skip any
+// deferred cleanup — terminal restore, signal stop, etc.). main()
+// unwraps via errors.As and calls os.Exit AFTER all defers have run.
+type exitCodeError struct{ Code int }
+
+func (e exitCodeError) Error() string { return fmt.Sprintf("exit code %d", e.Code) }
 
 func confirm(cmd *cobra.Command, msg string) error {
 	if cmd.Flag("yes").Value.String() == "true" {

--- a/cmd/cobalt/init.go
+++ b/cmd/cobalt/init.go
@@ -139,10 +139,7 @@ Examples:
 			defer conn.Close()
 
 			// 🔍 Detect environment and show what we're about to do.
-			env, err := detectEnv(ctx, conn, host, publicHost, insecureTLS, composeFile, noCaddyfile)
-			if err != nil {
-				return err
-			}
+			env := detectEnv(ctx, conn, host, publicHost, insecureTLS, composeFile, noCaddyfile)
 
 			// 🌐 Confirm public hostname (unless --public-host was supplied).
 			if publicHost == "" {
@@ -494,7 +491,7 @@ type envState struct {
 	proposedPublicHost string
 }
 
-func detectEnv(ctx context.Context, conn *ssh.Conn, sshHost, publicHostFlag string, insecureTLS bool, composeFile string, noCaddyfile bool) (envState, error) {
+func detectEnv(ctx context.Context, conn *ssh.Conn, sshHost, publicHostFlag string, insecureTLS bool, composeFile string, noCaddyfile bool) envState {
 	step := output.StartStep(output.IconDetect, "Detecting environment")
 
 	dockerCheck := conn.Run(ctx, "docker --version")
@@ -541,7 +538,7 @@ func detectEnv(ctx context.Context, conn *ssh.Conn, sshHost, publicHostFlag stri
 		dockerInstalled:    dockerInstalled,
 		swarmActive:        swarmActive,
 		proposedPublicHost: proposed,
-	}, nil
+	}
 }
 
 // dialSSH wraps the auth selection and connect into a single 🔌 step.

--- a/cmd/cobalt/main.go
+++ b/cmd/cobalt/main.go
@@ -10,15 +10,18 @@ import (
 
 func main() {
 	if err := newRootCmd().Execute(); err != nil {
+		// A propagated exit code (from `cobalt run` etc.) wins over
+		// the generic 1 — and we suppress the error print for it
+		// because the upstream command already wrote its output.
+		var exitErr exitCodeError
+		if errors.As(err, &exitErr) {
+			os.Exit(exitErr.Code)
+		}
 		var apiErr *client.APIError
 		if errors.As(err, &apiErr) {
 			output.Errf("%s", apiErr.Message)
 		} else {
 			output.Errf("%v", err)
-		}
-		if confirmErr, ok := err.(confirmError); ok {
-			_ = confirmErr
-			os.Exit(1)
 		}
 		os.Exit(1)
 	}

--- a/cmd/cobalt/run.go
+++ b/cmd/cobalt/run.go
@@ -195,7 +195,9 @@ func runClientV2(ctx context.Context, cancel context.CancelFunc, conn *websocket
 		close(writeCh)
 		<-writerDone
 		if code != 0 {
-			os.Exit(code)
+			// Propagate as an error so deferred cleanup (terminal
+			// restore, signal stop) runs before main() exits.
+			return exitCodeError{Code: code}
 		}
 		return nil
 	case <-sigCh:
@@ -229,7 +231,10 @@ func runResizeLoop(ctx context.Context, writeCh chan<- []byte) {
 		if err != nil {
 			return
 		}
-		rows, cols := uint16(h), uint16(w)
+		// Terminal cell counts safely fit in uint16 (real-world dims
+		// are bounded by display hardware; values >65535 are not a
+		// thing).
+		rows, cols := uint16(h), uint16(w) //nolint:gosec // bounded by terminal size
 		if rows == lastRows && cols == lastCols {
 			return
 		}
@@ -308,7 +313,9 @@ func runClientV1(ctx context.Context, cancel context.CancelFunc, conn *websocket
 	case code := <-exitCh:
 		cancel()
 		if code != 0 {
-			os.Exit(code)
+			// Propagate as an error so deferred cleanup (terminal
+			// restore, signal stop) runs before main() exits.
+			return exitCodeError{Code: code}
 		}
 		return nil
 	case <-sigCh:

--- a/cmd/cobalt/upgrade.go
+++ b/cmd/cobalt/upgrade.go
@@ -126,7 +126,7 @@ func followUpgrade(ctx context.Context, cl *client.Client, id string) error {
 		// Stream may have closed mid-restart; surface the streamErr if
 		// it's the more useful one.
 		if streamErr != nil {
-			return fmt.Errorf("upgrade follow: %w (stream error: %v)", err, streamErr)
+			return fmt.Errorf("upgrade follow: %w (stream error: %w)", err, streamErr)
 		}
 		return fmt.Errorf("post-stream status fetch: %w", err)
 	}

--- a/internal/client/client_test.go
+++ b/internal/client/client_test.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"encoding/json"
 	"encoding/pem"
+	"errors"
 	"net/http"
 	"net/http/httptest"
 	"strings"
@@ -79,8 +80,8 @@ func TestClientAPIError(t *testing.T) {
 	if err == nil {
 		t.Fatal("expected error")
 	}
-	apiErr, ok := err.(*APIError)
-	if !ok {
+	var apiErr *APIError
+	if !errors.As(err, &apiErr) {
 		t.Fatalf("got %T, want *APIError", err)
 	}
 	if apiErr.Message != "project not found" {
@@ -105,8 +106,8 @@ func TestClientAPIErrorNonJSON(t *testing.T) {
 	if err == nil {
 		t.Fatal("expected error")
 	}
-	apiErr, ok := err.(*APIError)
-	if !ok {
+	var apiErr *APIError
+	if !errors.As(err, &apiErr) {
 		t.Fatalf("got %T, want *APIError", err)
 	}
 	if apiErr.StatusCode != 500 {

--- a/internal/client/logs_run.go
+++ b/internal/client/logs_run.go
@@ -93,7 +93,7 @@ func readUpgradeErrorBody(resp *http.Response) string {
 	defer resp.Body.Close()
 	body, _ := io.ReadAll(io.LimitReader(resp.Body, 4096))
 	if len(body) == 0 {
-		return fmt.Sprintf("%s", resp.Status)
+		return resp.Status
 	}
 	// Daemon wraps errors in {"error": "..."}. Decode + return the
 	// inner string when present; fall back to the raw body otherwise.

--- a/internal/llm/render.go
+++ b/internal/llm/render.go
@@ -136,7 +136,7 @@ func renderCommand(cmd *cobra.Command) string {
 		cmd.Flags().VisitAll(func(flag *pflag.Flag) {
 			desc := flag.Usage
 			if flag.DefValue != "" {
-				desc = desc + fmt.Sprintf(" (default: %s)", flag.DefValue)
+				desc += fmt.Sprintf(" (default: %s)", flag.DefValue)
 			}
 			lines = append(lines, fmt.Sprintf("  --%s %s: %s", flag.Name, flag.Value.Type(), desc))
 		})

--- a/internal/server/api/apikeys_test.go
+++ b/internal/server/api/apikeys_test.go
@@ -122,7 +122,8 @@ func TestAPIKeys_GeneratedKeyHashesCorrectly(t *testing.T) {
 	}
 	// Confirm hex.
 	for _, c := range raw {
-		if !((c >= '0' && c <= '9') || (c >= 'a' && c <= 'f')) {
+		isHex := (c >= '0' && c <= '9') || (c >= 'a' && c <= 'f')
+		if !isHex {
 			t.Errorf("non-hex char in raw key: %q", c)
 		}
 	}

--- a/internal/server/api/logs.go
+++ b/internal/server/api/logs.go
@@ -257,7 +257,9 @@ var errOffsetInvalid = httpErr("offset must be a non-negative integer")
 func waitForFile(ctx context.Context, path string, budget time.Duration) (*os.File, error) {
 	deadline := time.Now().Add(budget)
 	for {
-		f, err := os.Open(path)
+		// path is built by the daemon from validated project name +
+		// deployment number under DataDir; not user-controlled.
+		f, err := os.Open(path) //nolint:gosec // daemon-constructed path
 		if err == nil {
 			return f, nil
 		}

--- a/internal/server/api/manifest.go
+++ b/internal/server/api/manifest.go
@@ -148,9 +148,11 @@ func (h *Handler) ManifestCreated(w http.ResponseWriter, r *http.Request) {
 	}
 
 	// Redirect the browser to GitHub's install page so the user can
-	// grant the new App access to their repos.
+	// grant the new App access to their repos. The URL is built from
+	// GitHub's own manifest-conversion response (already validated by
+	// gosec-flagged `converted` shape), not user input.
 	installURL := github.InstallationsURL(converted.HTMLURL, converted.Owner.ID, converted.Owner.Type)
-	http.Redirect(w, r, installURL, http.StatusFound)
+	http.Redirect(w, r, installURL, http.StatusFound) //nolint:gosec // URL composed from trusted GitHub response
 }
 
 // publicHost returns the daemon's public hostname for use in manifest

--- a/internal/server/api/server_upgrade.go
+++ b/internal/server/api/server_upgrade.go
@@ -279,7 +279,9 @@ func (h *Handler) streamUpgradeFile(
 	offset int64,
 	upgradeID string,
 ) error {
-	f, err := os.Open(path)
+	// path is built by the daemon from validated upgrade ID under
+	// DataDir; not user-controlled.
+	f, err := os.Open(path) //nolint:gosec // daemon-constructed path
 	if errors.Is(err, os.ErrNotExist) {
 		f, err = waitForFile(ctx, path, 5*time.Second)
 		if err != nil {

--- a/internal/server/deploy/dispatcher_test.go
+++ b/internal/server/deploy/dispatcher_test.go
@@ -232,7 +232,7 @@ func TestDispatcher_DifferentProjectsRunInParallel(t *testing.T) {
 	// Wait for both to be in flight before we release the gate.
 	var seenAPI, seenWeb atomic.Bool
 	deadline := time.Now().Add(3 * time.Second)
-	for time.Now().Before(deadline) && !(seenAPI.Load() && seenWeb.Load()) {
+	for time.Now().Before(deadline) && (!seenAPI.Load() || !seenWeb.Load()) {
 		if dep, _ := db.GetDeployment(context.Background(), idA); dep.Status == cobaltapi.StateFetching {
 			seenAPI.Store(true)
 		}
@@ -241,7 +241,7 @@ func TestDispatcher_DifferentProjectsRunInParallel(t *testing.T) {
 		}
 		time.Sleep(10 * time.Millisecond)
 	}
-	if !(seenAPI.Load() && seenWeb.Load()) {
+	if !seenAPI.Load() || !seenWeb.Load() {
 		t.Fatal("both projects should be in flight in parallel")
 	}
 	if runner.callCount() != 2 {

--- a/internal/server/docker/build.go
+++ b/internal/server/docker/build.go
@@ -165,10 +165,7 @@ func quoteDotEnvValue(v string) string {
 	if v == "" {
 		return ""
 	}
-	needsQuote := false
-	if v[0] == '#' {
-		needsQuote = true
-	}
+	needsQuote := v[0] == '#'
 	if !needsQuote {
 		switch v[0] {
 		case ' ', '\t':

--- a/internal/server/github/client.go
+++ b/internal/server/github/client.go
@@ -52,6 +52,11 @@ const (
 
 // do issues an authenticated request and decodes the response. credential
 // is consumed per the auth mode. Non-2xx responses produce *HTTPError.
+// body is currently always nil at the call sites; kept as a parameter so
+// adding POST/PUT-with-body endpoints (manifest exchange already does
+// POST) doesn't require widening the signature.
+//
+//nolint:unparam // body kept for future-write call sites
 func (c *Client) do(ctx context.Context, method, path string, mode auth, credential string, body, out any) error {
 	var buf io.Reader
 	if body != nil {

--- a/internal/server/middleware/middleware_test.go
+++ b/internal/server/middleware/middleware_test.go
@@ -118,7 +118,7 @@ func TestBearerAuth_UpdatesLastUsedAt(t *testing.T) {
 	// last_used_at write is async; poll briefly.
 	deadline := time.Now().Add(2 * time.Second)
 	for time.Now().Before(deadline) {
-		resp, err := db.Client.QuerySingle(context.Background(),
+		resp, err := db.QuerySingle(context.Background(),
 			`SELECT last_used_at FROM apikeys WHERE id=?`, id)
 		if err != nil {
 			t.Fatalf("query: %v", err)
@@ -159,7 +159,7 @@ func TestBearerAuth_UpdatesLastUsedAt_RequestCtxCanceled(t *testing.T) {
 
 	deadline := time.Now().Add(2 * time.Second)
 	for time.Now().Before(deadline) {
-		resp, err := db.Client.QuerySingle(context.Background(),
+		resp, err := db.QuerySingle(context.Background(),
 			`SELECT last_used_at FROM apikeys WHERE id=?`, id)
 		if err != nil {
 			t.Fatalf("query: %v", err)
@@ -199,7 +199,7 @@ func newTestDB(t *testing.T) *store.DB {
 
 func insertAPIKey(t *testing.T, db *store.DB, raw, name string) int64 {
 	t.Helper()
-	resp, err := db.Client.ExecuteSingle(
+	resp, err := db.ExecuteSingle(
 		context.Background(),
 		`INSERT INTO apikeys (key_hash, name, created_at) VALUES (?, ?, unixepoch())`,
 		HashAPIKey(raw), name,

--- a/internal/server/server.go
+++ b/internal/server/server.go
@@ -389,7 +389,7 @@ func waitForRqlited(url string, timeout time.Duration) bool {
 			continue
 		}
 		err = db.Ping(context.Background())
-		db.Client.Close()
+		_ = db.Close()
 		if err == nil {
 			return true
 		}

--- a/internal/server/store/deployments.go
+++ b/internal/server/store/deployments.go
@@ -187,7 +187,7 @@ func (db *DB) ListDeploymentsForProject(ctx context.Context, projectID int64, li
 		if len(results) == 0 {
 			return nil, nil
 		}
-		deps, _ := scanDeployments(results[0].Values)
+		deps := scanDeployments(results[0].Values)
 		return deps, nil
 	}
 
@@ -210,7 +210,7 @@ func (db *DB) ListDeploymentsForProject(ctx context.Context, projectID int64, li
 	if len(results) == 0 {
 		return nil, nil
 	}
-	deps, _ := scanDeployments(results[0].Values)
+	deps := scanDeployments(results[0].Values)
 	return deps, nil
 }
 
@@ -265,7 +265,7 @@ func (db *DB) QueuedDeployments(ctx context.Context) ([]Deployment, error) {
 	if len(results) == 0 {
 		return nil, nil
 	}
-	deps, _ := scanDeployments(results[0].Values)
+	deps := scanDeployments(results[0].Values)
 	return deps, nil
 }
 
@@ -426,16 +426,16 @@ func (db *DB) ActiveDeployments(ctx context.Context) ([]Deployment, error) {
 	if len(results) == 0 {
 		return nil, nil
 	}
-	deps, _ := scanDeployments(results[0].Values)
+	deps := scanDeployments(results[0].Values)
 	return deps, nil
 }
 
-func scanDeployments(rows [][]any) ([]Deployment, error) {
+func scanDeployments(rows [][]any) []Deployment {
 	var out []Deployment
 	for _, row := range rows {
 		out = append(out, *scanDeploymentRow(row))
 	}
-	return out, nil
+	return out
 }
 
 func scanDeploymentRow(row []any) *Deployment {

--- a/internal/server/store/testutils_test.go
+++ b/internal/server/store/testutils_test.go
@@ -47,13 +47,13 @@ func openTestDB(t *testing.T) *DB {
 	}
 
 	if err := db.InitSchema(context.Background()); err != nil {
-		_ = db.Client.Close()
+		_ = db.Close()
 		stopRqlitedContainer(containerName)
 		t.Fatalf("InitSchema: %v", err)
 	}
 
 	t.Cleanup(func() {
-		_ = db.Client.Close()
+		_ = db.Close()
 		stopRqlitedContainer(containerName)
 	})
 
@@ -117,7 +117,7 @@ func waitForRqlite(url string, timeout time.Duration) bool {
 		ctx, cancel := context.WithTimeout(context.Background(), time.Second)
 		err = db.Ping(ctx)
 		cancel()
-		_ = db.Client.Close()
+		_ = db.Close()
 		if err == nil {
 			return true
 		}

--- a/internal/server/worker/deploy_log_rotation.go
+++ b/internal/server/worker/deploy_log_rotation.go
@@ -77,7 +77,12 @@ func RotateDeployLogs(
 		switch {
 		case strings.HasSuffix(path, ".log.gz"):
 			if purgeAge > 0 && info.ModTime().Before(purgeBefore) {
-				if err := os.Remove(path); err != nil {
+				// TOCTOU concern: path comes from filepath.Walk inside
+				// daemon-managed DataDir; no untrusted symlinks are
+				// possible without first compromising the host's
+				// daemon user — at which point cobalt has bigger
+				// problems than log rotation.
+				if err := os.Remove(path); err != nil { //nolint:gosec // daemon-owned dir tree
 					log.Warn("rotate: purge", "path", path, "error", err)
 					if firstErr == nil {
 						firstErr = err

--- a/internal/server/worker/deploy_log_rotation_test.go
+++ b/internal/server/worker/deploy_log_rotation_test.go
@@ -111,7 +111,7 @@ func TestRotateDeployLogs_GzipPreservesContent(t *testing.T) {
 	if err != nil {
 		t.Fatalf("gzip.NewReader: %v", err)
 	}
-	defer gr.Close()
+	defer func() { _ = gr.Close() }()
 	got, err := io.ReadAll(gr)
 	if err != nil {
 		t.Fatalf("read: %v", err)

--- a/internal/ssh/ssh.go
+++ b/internal/ssh/ssh.go
@@ -4,6 +4,7 @@ import (
 	"bufio"
 	"bytes"
 	"context"
+	"errors"
 	"fmt"
 	"io"
 	"net"
@@ -49,7 +50,8 @@ func parsePrivateKey(path, passphrase string) (ssh.Signer, error) {
 	}
 	key, err := ssh.ParsePrivateKey(data)
 	if err != nil {
-		if _, ok := err.(*ssh.PassphraseMissingError); ok && passphrase != "" {
+		var missing *ssh.PassphraseMissingError
+		if errors.As(err, &missing) && passphrase != "" {
 			key, err = ssh.ParsePrivateKeyWithPassphrase(data, []byte(passphrase))
 		}
 		if err != nil {
@@ -94,9 +96,14 @@ func NewClient(user, host string, auth AuthMethod) *Client {
 	return &Client{
 		addr: fmt.Sprintf("%s:22", host),
 		config: &ssh.ClientConfig{
-			User:            user,
-			Auth:            auth.auth(),
-			HostKeyCallback: ssh.InsecureIgnoreHostKey(),
+			User: user,
+			Auth: auth.auth(),
+			// cobalt's SSH client targets hosts identified by DNS
+			// records the operator already controls. Host-key
+			// pinning would require a TOFU prompt or stored
+			// known_hosts; for this tool's scope, DNS trust is the
+			// stated security boundary.
+			HostKeyCallback: ssh.InsecureIgnoreHostKey(), //nolint:gosec // intentional: DNS-trust model
 			Timeout:         10 * time.Second,
 		},
 	}
@@ -153,7 +160,8 @@ func (c *Conn) Run(ctx context.Context, cmd string) *Result {
 	close(done)
 
 	if err != nil {
-		if exitErr, ok := err.(*ssh.ExitError); ok {
+		var exitErr *ssh.ExitError
+		if errors.As(err, &exitErr) {
 			return &Result{Stdout: stdout.String(), Stderr: stderr.String(), ExitCode: exitErr.ExitStatus()}
 		}
 		return &Result{Stdout: stdout.String(), Stderr: stderr.String(), Err: fmt.Errorf("wait: %w", err)}
@@ -244,7 +252,7 @@ func (c *Conn) ScpTo(localPath, remotePath string) error {
 	}
 
 	if err := session.Wait(); err != nil {
-		return fmt.Errorf("upload: %v: %s", err, errBuf.String())
+		return fmt.Errorf("upload: %w: %s", err, errBuf.String())
 	}
 	return nil
 }

--- a/internal/storetest/storetest.go
+++ b/internal/storetest/storetest.go
@@ -61,13 +61,13 @@ func OpenDB(t *testing.T) *store.DB {
 	}
 
 	if err := db.InitSchema(context.Background()); err != nil {
-		_ = db.Client.Close()
+		_ = db.Close()
 		stopRqlitedContainer(containerName)
 		t.Fatalf("InitSchema: %v", err)
 	}
 
 	t.Cleanup(func() {
-		_ = db.Client.Close()
+		_ = db.Close()
 		stopRqlitedContainer(containerName)
 	})
 
@@ -131,7 +131,7 @@ func waitForRqlite(url string, timeout time.Duration) bool {
 		ctx, cancel := context.WithTimeout(context.Background(), time.Second)
 		err = db.Ping(ctx)
 		cancel()
-		_ = db.Client.Close()
+		_ = db.Close()
 		if err == nil {
 			return true
 		}


### PR DESCRIPTION
Second of two lint-debt PRs. **After this lands, \`golangci-lint run\` reports 0 issues.** Depends on #20 (PR A).

## Real bug fixes

### 🐛 \`cmd/cobalt/run.go\`: exitAfterDefer

\`runClientV1\` / \`runClientV2\` called \`os.Exit(code)\` mid-flow, **skipping**:
- \`defer term.Restore(...)\` — leaving the user's terminal in raw mode after any non-zero exit
- \`defer signal.Stop(sigCh)\` — leaking the signal handler

Fix: introduce \`exitCodeError\` in \`common.go\`; the runners return it instead of calling \`os.Exit\`; \`main()\` unwraps via \`errors.As\` and exits with the propagated code **after** all defers have run. Caught by gocritic; was a real user-visible bug.

## Mechanical correctness

- **errorlint** (5): \`%v\` → \`%w\` so wrapped errors survive \`errors.Is/As\`; type-assertions on errors → \`errors.As\` (covers wrapped errors)
- **staticcheck** (8): QF1001 De Morgan / hex-check extraction, QF1008 drop redundant embedded-field selector (\`db.Client.Close()\` → \`db.Close()\` x4), QF1007 collapse \`var x = false; if cond { x = true }\`, S1025 drop \`fmt.Sprintf(\"%s\", s)\`
- **gocritic** (3): exitAfterDefer (above) + assignOp \`x = x + y\` → \`x += y\`

## Production unparam fixes

- \`store.scanDeployments\`: drop never-non-nil error return; update 4 callers to drop \`, _\`
- \`cmd/cobalt/init.go:detectEnv\`: drop never-non-nil error return
- \`github.Client.do\`: kept \`body\` param but marked \`//nolint:unparam\` — it's a deliberate API surface for the POST/PUT-with-body endpoints that already exist (manifest exchange)

## Config tuning

### \`errcheck.exclude-functions\`
Broadened to cover the concrete-type \`Close\` receivers errcheck doesn't match through \`io.Closer\` (errcheck checks static type, not interface): \`*ssh.Conn\`, \`*ssh.Session\`, \`*websocket.Conn\`, \`*os.File\`, \`net.Conn\`, \`net.Listener\`, pipe readers/writers, rqlite Client. Also: best-effort process teardown (\`*os.Process.Kill\`, \`*exec.Cmd.Wait\`, \`syscall.Kill\`) — errors during shutdown are unactionable.

### \`gosec.excludes\`
The cobalt design intent doesn't fit the assumptions some gosec rules encode. Per-rule rationale in the YAML — short version:

| Rule | Why excluded |
|---|---|
| G104 | Duplicate of errcheck |
| G204 | Cobalt IS a process supervisor — exec git/docker with variable args is the whole job, inputs are trusted (rqlite store, HMAC-verified webhooks, operator CLI) |
| G301/G302/G306 | Logs and config artifacts are operator-readable by design; security boundary is the host user account, not file mode |
| G304 | Deploy paths are daemon-constructed from validated project names + cobalt.json from cloned repos |

### Per-instance \`//nolint:gosec\` with rationale
Kept the gosec rules where the specific call needs case-by-case judgment, then annotated each true-positive-but-intentional site:
- G115 in \`run.go\` — uint16 cast of terminal dimensions (bounded)
- G703 in \`api/logs.go\` + \`api/server_upgrade.go\` — daemon-constructed paths under DataDir
- G710 in \`api/manifest.go\` — redirect URL built from GitHub's manifest-conversion response, not user input
- G122 in \`worker/deploy_log_rotation.go\` — \`filepath.Walk\` operates on the daemon-managed log tree
- G106 in \`ssh/ssh.go\` — InsecureIgnoreHostKey is the documented DNS-trust model for cobalt's SSH client

### \`unparam\` excluded from \`_test.go\`
Test helpers commonly have "always-the-same-arg-today" signatures kept open for future flexibility. Same treatment as gosec on tests.

## Result

| | Before | After |
|---|---:|---:|
| golangci-lint issues | 81 | **0** |
| go test ./... | 19/19 | 19/19 |

## Test plan

- [x] \`go test ./... -count=1\` — all 19 packages green
- [x] \`golangci-lint run\` — 0 issues
- [ ] CI: both \`test\` and \`lint\` jobs go green

## Merge order

This depends on #20 (PR A). Merge #20 first; this PR will auto-rebase or I'll do it manually.