### PR TITLE
feat(projects): retarget source in place via projects update

### DIFF
--- a/cmd/cobalt/projects.go
+++ b/cmd/cobalt/projects.go
@@ -23,6 +23,7 @@ func newProjectsCmd() *cobra.Command {
 		newProjectsAddCmd(),
 		newProjectsRemoveCmd(),
 		newProjectsRenameCmd(),
+		newProjectsUpdateCmd(),
 	)
 
 	return cmd
@@ -149,6 +150,83 @@ Examples:
 			return cl.DeleteProject(cmd.Context(), name)
 		}),
 	}
+}
+
+func newProjectsUpdateCmd() *cobra.Command {
+	cmd := &cobra.Command{
+		Use:   "update <name>",
+		Short: "Retarget a project's GitHub source (repo, branch, path)",
+		Long: `Changes which GitHub repo, branch, or sub-path a project tracks. Flags you
+do not pass keep their current values. The update is config-only — it does
+NOT trigger a deploy. Run ` + "`cobalt deploy --project <name>`" + ` separately to act on
+the new source.
+
+Existing domains, env vars, deployment history, and running services are
+unaffected by this command.
+
+Examples:
+  cobalt projects update api --github heyblueteam/blue --path api
+  cobalt projects update staging --branch develop
+  cobalt projects update web --path services/web`,
+		Args: cobra.ExactArgs(1),
+		RunE: runE(func(cmd *cobra.Command, args []string) error {
+			srv, err := resolveServer(cmd)
+			if err != nil {
+				return err
+			}
+			name := args[0]
+			cl := client.New(srv)
+
+			// Fetch current state so omitted flags keep their existing values.
+			current, err := cl.GetProject(cmd.Context(), name)
+			if err != nil {
+				return err
+			}
+
+			req := cobaltapi.ProjectUpdateSourceRequest{
+				GithubRepo: current.GithubRepo,
+				Branch:     current.Branch,
+				Path:       current.Path,
+			}
+			if cmd.Flags().Changed("github") {
+				req.GithubRepo = cmd.Flag("github").Value.String()
+				if err := validator.ValidateGitHubRepo(req.GithubRepo); err != nil {
+					return err
+				}
+			}
+			if cmd.Flags().Changed("branch") {
+				req.Branch = cmd.Flag("branch").Value.String()
+				if req.Branch == "" {
+					return fmt.Errorf("branch must not be empty")
+				}
+			}
+			if cmd.Flags().Changed("path") {
+				req.Path = cmd.Flag("path").Value.String()
+				if err := validator.ValidateProjectPath(req.Path); err != nil {
+					return err
+				}
+			}
+
+			project, err := cl.UpdateProjectSource(cmd.Context(), name, req)
+			if err != nil {
+				return err
+			}
+			pathDisplay := project.Path
+			if pathDisplay == "" {
+				pathDisplay = "(repo root)"
+			}
+			output.PrintLines(fmt.Sprintf(
+				"Project %s retargeted: %s@%s path=%s",
+				project.Name, project.GithubRepo, project.Branch, pathDisplay,
+			))
+			output.PrintLines("Run `cobalt deploy --project " + project.Name + "` to act on the new source.")
+			return nil
+		}),
+	}
+	cmd.Flags().String("github", "", "github repo as owner/repo (leave unset to keep current)")
+	cmd.Flags().String("branch", "", "git branch to deploy (leave unset to keep current)")
+	cmd.Flags().String("path", "", "sub-directory inside the repo (leave unset to keep current)")
+	return cmd
 }
 
 func newProjectsRenameCmd() *cobra.Command {

--- a/internal/client/projects.go
+++ b/internal/client/projects.go
@@ -39,6 +39,14 @@ func (c *Client) RenameProject(ctx context.Context, name string, req cobaltapi.P
 	return &p, nil
 }
 
+func (c *Client) UpdateProjectSource(ctx context.Context, name string, req cobaltapi.ProjectUpdateSourceRequest) (*cobaltapi.Project, error) {
+	var p cobaltapi.Project
+	if err := c.patch(ctx, fmt.Sprintf("/api/projects/%s/source", name), req, &p); err != nil {
+		return nil, err
+	}
+	return &p, nil
+}
+
 func (c *Client) DeleteProject(ctx context.Context, name string) error {
 	return c.del(ctx, fmt.Sprintf("/api/projects/%s", name))
 }

--- a/internal/server/api/api_test.go
+++ b/internal/server/api/api_test.go
@@ -237,6 +237,179 @@ func TestCreateProject_WithDomainAttachesIt(t *testing.T) {
 	}
 }
 
+// TestUpdateProjectSource_RetargetsRepoBranchPath proves the monorepo cutover
+// use case end-to-end: an existing project's github/branch/path can be
+// changed in place via PATCH /api/projects/{name}/source, and the response
+// reflects the new values.
+func TestUpdateProjectSource_RetargetsRepoBranchPath(t *testing.T) {
+	t.Parallel()
+	e := newEnv(t)
+	resp := e.do(http.MethodPost, "/api/projects", cobaltapi.ProjectCreateRequest{
+		Name: "api", GithubRepo: "heyblueteam/api", Branch: "main",
+	})
+	mustStatus(t, resp, http.StatusCreated)
+	resp.Body.Close()
+
+	resp = e.do(http.MethodPatch, "/api/projects/api/source", cobaltapi.ProjectUpdateSourceRequest{
+		GithubRepo: "heyblueteam/blue",
+		Branch:     "main",
+		Path:       "api",
+	})
+	mustStatus(t, resp, http.StatusOK)
+	updated := decode[cobaltapi.Project](t, resp)
+	if updated.GithubRepo != "heyblueteam/blue" {
+		t.Errorf("GithubRepo: got %q, want heyblueteam/blue", updated.GithubRepo)
+	}
+	if updated.Branch != "main" {
+		t.Errorf("Branch: got %q, want main", updated.Branch)
+	}
+	if updated.Path != "api" {
+		t.Errorf("Path: got %q, want api", updated.Path)
+	}
+	if updated.Name != "api" {
+		t.Errorf("Name leaked: got %q", updated.Name)
+	}
+}
+
+// TestUpdateProjectSource_NotFoundReturns404 proves updating a non-existent
+// project returns 404, not 500 — the handler maps store.ErrNotFound through.
+func TestUpdateProjectSource_NotFoundReturns404(t *testing.T) {
+	t.Parallel()
+	e := newEnv(t)
+	resp := e.do(http.MethodPatch, "/api/projects/ghost/source", cobaltapi.ProjectUpdateSourceRequest{
+		GithubRepo: "heyblueteam/blue", Branch: "main", Path: "api",
+	})
+	defer resp.Body.Close()
+	if resp.StatusCode != http.StatusNotFound {
+		t.Errorf("got %d, want 404", resp.StatusCode)
+	}
+}
+
+// TestUpdateProjectSource_ValidationErrors proves each bad-input case
+// returns 400, not 500 or 200.
+func TestUpdateProjectSource_ValidationErrors(t *testing.T) {
+	t.Parallel()
+	e := newEnv(t)
+	setupProject(t, e, "api")
+
+	cases := []struct {
+		name string
+		body cobaltapi.ProjectUpdateSourceRequest
+	}{
+		{"missing slash in repo", cobaltapi.ProjectUpdateSourceRequest{GithubRepo: "no-slash", Branch: "main", Path: ""}},
+		{"empty branch", cobaltapi.ProjectUpdateSourceRequest{GithubRepo: "h/x", Branch: "", Path: ""}},
+		{"leading slash path", cobaltapi.ProjectUpdateSourceRequest{GithubRepo: "h/x", Branch: "main", Path: "/api"}},
+		{"parent traversal path", cobaltapi.ProjectUpdateSourceRequest{GithubRepo: "h/x", Branch: "main", Path: "../escape"}},
+	}
+	for _, c := range cases {
+		t.Run(c.name, func(t *testing.T) {
+			resp := e.do(http.MethodPatch, "/api/projects/api/source", c.body)
+			defer resp.Body.Close()
+			if resp.StatusCode != http.StatusBadRequest {
+				t.Errorf("got %d, want 400", resp.StatusCode)
+			}
+		})
+	}
+}
+
+// TestUpdateProjectSource_PreservesDomainsAndEnv proves a source retarget is
+// non-destructive: domains and env vars attached to the project survive the
+// update untouched. This is the core invariant that makes zero-downtime
+// cutover possible — bound domains stay bound to the project regardless of
+// which repo it now watches.
+func TestUpdateProjectSource_PreservesDomainsAndEnv(t *testing.T) {
+	t.Parallel()
+	e := newEnv(t)
+
+	// Create with an initial domain.
+	resp := e.do(http.MethodPost, "/api/projects", cobaltapi.ProjectCreateRequest{
+		Name: "api", GithubRepo: "heyblueteam/api", Branch: "main",
+		Domain: "api.example.com",
+	})
+	mustStatus(t, resp, http.StatusCreated)
+	resp.Body.Close()
+
+	// Add an env var.
+	resp = e.do(http.MethodPost, "/api/projects/api/env", cobaltapi.EnvSetRequest{
+		Vars: map[string]string{"KEEP_ME": "yes"},
+	})
+	mustStatus(t, resp, http.StatusOK)
+	resp.Body.Close()
+
+	// Retarget.
+	resp = e.do(http.MethodPatch, "/api/projects/api/source", cobaltapi.ProjectUpdateSourceRequest{
+		GithubRepo: "heyblueteam/blue", Branch: "main", Path: "api",
+	})
+	mustStatus(t, resp, http.StatusOK)
+	resp.Body.Close()
+
+	// Domains: still bound.
+	resp = e.do(http.MethodGet, "/api/projects/api/domains", nil)
+	mustStatus(t, resp, http.StatusOK)
+	doms := decode[[]cobaltapi.Domain](t, resp)
+	if len(doms) != 1 || doms[0].Name != "api.example.com" {
+		t.Errorf("domain dropped during source update: %+v", doms)
+	}
+
+	// Env: still there.
+	resp = e.do(http.MethodGet, "/api/projects/api/env", nil)
+	mustStatus(t, resp, http.StatusOK)
+	envList := decode[[]cobaltapi.EnvVar](t, resp)
+	found := false
+	for _, v := range envList {
+		if v.Key == "KEEP_ME" {
+			found = true
+		}
+	}
+	if !found {
+		t.Errorf("KEEP_ME env var dropped during source update: %+v", envList)
+	}
+}
+
+// TestUpdateProjectSource_DoesNotChangeName proves the source PATCH never
+// touches the project's name even if name-like fields are present in the
+// request body (they shouldn't be — the request struct doesn't have one —
+// but this asserts that intermediary tampering can't smuggle a rename
+// through the source endpoint).
+func TestUpdateProjectSource_DoesNotChangeName(t *testing.T) {
+	t.Parallel()
+	e := newEnv(t)
+	setupProject(t, e, "api")
+
+	resp := e.do(http.MethodPatch, "/api/projects/api/source", cobaltapi.ProjectUpdateSourceRequest{
+		GithubRepo: "heyblueteam/blue", Branch: "main", Path: "api",
+	})
+	mustStatus(t, resp, http.StatusOK)
+	updated := decode[cobaltapi.Project](t, resp)
+	if updated.Name != "api" {
+		t.Errorf("name changed during source update: got %q, want api", updated.Name)
+	}
+
+	// Project is still resolvable by its original name.
+	resp = e.do(http.MethodGet, "/api/projects/api", nil)
+	mustStatus(t, resp, http.StatusOK)
+	resp.Body.Close()
+}
+
+// TestUpdateProjectSource_IdempotentNoOp proves PATCHing the same source as
+// the project already has succeeds and returns the unchanged project.
+// Important because the CLI's flag-merging flow can produce a no-op request
+// when the user passes flags that happen to match current values.
+func TestUpdateProjectSource_IdempotentNoOp(t *testing.T) {
+	t.Parallel()
+	e := newEnv(t)
+	setupProject(t, e, "api") // creates with h/api@main path=""
+
+	resp := e.do(http.MethodPatch, "/api/projects/api/source", cobaltapi.ProjectUpdateSourceRequest{
+		GithubRepo: "h/api", Branch: "main", Path: "",
+	})
+	mustStatus(t, resp, http.StatusOK)
+	got := decode[cobaltapi.Project](t, resp)
+	if got.GithubRepo != "h/api" || got.Branch != "main" || got.Path != "" {
+		t.Errorf("no-op update changed something: %+v", got)
+	}
+}
+
 // --- env ---
 
 func setupProject(t *testing.T, e *testEnv, name string) {

--- a/internal/server/api/projects.go
+++ b/internal/server/api/projects.go
@@ -88,6 +88,46 @@ func (h *Handler) GetProject(w http.ResponseWriter, r *http.Request) {
 	writeJSON(w, projectToAPI(*p))
 }
 
+// UpdateProjectSource implements PATCH /api/projects/{name}/source.
+// Retargets which GitHub repo, branch, and sub-path the project tracks.
+// Domains, env vars, deployment history, and running services are
+// unaffected — the next `cobalt deploy --project <name>` reads from
+// the new source.
+//
+// All three source fields are required. The CLI's `cobalt projects update`
+// supplies partial-update ergonomics by fetching current state and
+// merging user flags before sending the full request.
+func (h *Handler) UpdateProjectSource(w http.ResponseWriter, r *http.Request) {
+	p, ok := h.projectFromPath(w, r)
+	if !ok {
+		return
+	}
+	var req cobaltapi.ProjectUpdateSourceRequest
+	if err := readJSON(w, r, &req); err != nil {
+		return
+	}
+	if err := validateProjectUpdateSource(req); err != nil {
+		writeError(w, http.StatusBadRequest, err.Error())
+		return
+	}
+	if err := h.DB.UpdateProjectSource(r.Context(), p.ID, req.GithubRepo, req.Branch, req.Path); err != nil {
+		if errors.Is(err, store.ErrNotFound) {
+			writeError(w, http.StatusNotFound, "project not found")
+			return
+		}
+		h.Log.Error("api: update project source", "error", err)
+		writeError(w, http.StatusInternalServerError, "internal error")
+		return
+	}
+	updated, err := h.DB.GetProjectByID(r.Context(), p.ID)
+	if err != nil {
+		h.Log.Error("api: refetch updated project", "error", err)
+		writeError(w, http.StatusInternalServerError, "internal error")
+		return
+	}
+	writeJSON(w, projectToAPI(*updated))
+}
+
 // RenameProject implements PATCH /api/projects/{name}. Updates the
 // display name and renames the on-disk project directory. Caddy state
 // is untouched (id-keyed routes don't depend on project name).
@@ -235,6 +275,19 @@ func validateProjectName(name string) error {
 	}
 	if strings.ContainsAny(name, "/\\ \t\n") {
 		return errProjectNameInvalid
+	}
+	return nil
+}
+
+func validateProjectUpdateSource(req cobaltapi.ProjectUpdateSourceRequest) error {
+	if !strings.Contains(req.GithubRepo, "/") {
+		return errProjectGitHubRepoInvalid
+	}
+	if req.Branch == "" {
+		return errProjectBranchRequired
+	}
+	if err := validator.ValidateProjectPath(req.Path); err != nil {
+		return err
 	}
 	return nil
 }

--- a/internal/server/api/router.go
+++ b/internal/server/api/router.go
@@ -12,6 +12,7 @@ func (h *Handler) Register(mux *http.ServeMux) {
 	mux.HandleFunc("POST /api/projects", h.CreateProject)
 	mux.HandleFunc("GET /api/projects/{name}", h.GetProject)
 	mux.HandleFunc("PATCH /api/projects/{name}", h.RenameProject)
+	mux.HandleFunc("PATCH /api/projects/{name}/source", h.UpdateProjectSource)
 	mux.HandleFunc("DELETE /api/projects/{name}", h.DeleteProject)
 
 	// Env vars

--- a/internal/server/store/projects.go
+++ b/internal/server/store/projects.go
@@ -174,6 +174,28 @@ func (db *DB) RenameProject(ctx context.Context, id int64, newName string) error
 	return nil
 }
 
+// UpdateProjectSource retargets which GitHub repo, branch, and sub-path
+// the project tracks. Domains, env vars, deployments, and the on-disk
+// project directory are untouched; the next `cobalt deploy` reads from
+// the new source. Running services keep serving until that deploy.
+func (db *DB) UpdateProjectSource(ctx context.Context, id int64, githubRepo, branch, path string) error {
+	if err := validator.ValidateProjectPath(path); err != nil {
+		return err
+	}
+	resp, err := db.ExecuteSingle(ctx, `
+        UPDATE projects
+        SET github_repo = ?, branch = ?, path = ?, updated_at = strftime('%s', 'now')
+        WHERE id = ?
+    `, githubRepo, branch, path, id)
+	if err != nil {
+		return err
+	}
+	if len(resp.Results) == 0 || resp.Results[0].RowsAffected == 0 {
+		return ErrNotFound
+	}
+	return nil
+}
+
 // DeleteProject removes a project. Foreign keys with ON DELETE CASCADE
 // (deployments, env_vars, domains, command_runs) clean up automatically.
 func (db *DB) DeleteProject(ctx context.Context, id int64) error {

--- a/internal/server/store/projects_test.go
+++ b/internal/server/store/projects_test.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"errors"
 	"testing"
+	"time"
 
 	"github.com/heyblueteam/cobalt/pkg/cobaltapi"
 )
@@ -304,5 +305,156 @@ func TestDeleteExpiredPendingApps(t *testing.T) {
 	}
 	if n != 2 {
 		t.Errorf("deleted: got %d, want 2", n)
+	}
+}
+
+// TestUpdateProjectSource_RoundTrip proves a project can be retargeted to a
+// different repo/branch/path in place and that the new values surface via
+// every retrieval path (GetByID + GetByName).
+func TestUpdateProjectSource_RoundTrip(t *testing.T) {
+	t.Parallel()
+	db := openTestDB(t)
+	ctx := context.Background()
+
+	id, err := db.CreateProject(ctx, Project{
+		Name: "api", GithubRepo: "heyblueteam/api", Branch: "main",
+	})
+	if err != nil {
+		t.Fatalf("Create: %v", err)
+	}
+
+	if err := db.UpdateProjectSource(ctx, id, "heyblueteam/blue", "develop", "api"); err != nil {
+		t.Fatalf("UpdateProjectSource: %v", err)
+	}
+
+	byID, err := db.GetProjectByID(ctx, id)
+	if err != nil {
+		t.Fatalf("GetByID: %v", err)
+	}
+	if byID.GithubRepo != "heyblueteam/blue" {
+		t.Errorf("GithubRepo: got %q, want heyblueteam/blue", byID.GithubRepo)
+	}
+	if byID.Branch != "develop" {
+		t.Errorf("Branch: got %q, want develop", byID.Branch)
+	}
+	if byID.Path != "api" {
+		t.Errorf("Path: got %q, want api", byID.Path)
+	}
+
+	byName, err := db.GetProjectByName(ctx, "api")
+	if err != nil {
+		t.Fatalf("GetByName: %v", err)
+	}
+	if byName.GithubRepo != "heyblueteam/blue" || byName.Path != "api" {
+		t.Errorf("GetByName drift: %+v", byName)
+	}
+}
+
+// TestUpdateProjectSource_NotFound proves updating a non-existent project
+// returns ErrNotFound — the API handler uses this to map to HTTP 404.
+func TestUpdateProjectSource_NotFound(t *testing.T) {
+	t.Parallel()
+	db := openTestDB(t)
+	err := db.UpdateProjectSource(context.Background(), 99999, "heyblueteam/blue", "main", "api")
+	if !errors.Is(err, ErrNotFound) {
+		t.Errorf("got %v, want ErrNotFound", err)
+	}
+}
+
+// TestUpdateProjectSource_InvalidPath proves the store-layer path validator
+// rejects bad paths even when the API handler validator is skipped.
+func TestUpdateProjectSource_InvalidPath(t *testing.T) {
+	t.Parallel()
+	db := openTestDB(t)
+	ctx := context.Background()
+	id, _ := db.CreateProject(ctx, Project{Name: "x", GithubRepo: "h/x", Branch: "main"})
+
+	// Leading slash is rejected by ValidateProjectPath.
+	if err := db.UpdateProjectSource(ctx, id, "h/x", "main", "/api"); err == nil {
+		t.Error("UpdateProjectSource accepted leading-slash path, want validation error")
+	}
+	// `..` is rejected.
+	if err := db.UpdateProjectSource(ctx, id, "h/x", "main", "../escape"); err == nil {
+		t.Error("UpdateProjectSource accepted parent-traversal path, want validation error")
+	}
+}
+
+// TestUpdateProjectSource_IsolatesProjects proves updating one project's
+// source does not leak into other projects' rows — the WHERE clause is
+// correctly id-scoped.
+func TestUpdateProjectSource_IsolatesProjects(t *testing.T) {
+	t.Parallel()
+	db := openTestDB(t)
+	ctx := context.Background()
+
+	idA, _ := db.CreateProject(ctx, Project{Name: "a", GithubRepo: "h/a", Branch: "main"})
+	idB, _ := db.CreateProject(ctx, Project{Name: "b", GithubRepo: "h/b", Branch: "main"})
+
+	if err := db.UpdateProjectSource(ctx, idA, "h/mono", "develop", "services/a"); err != nil {
+		t.Fatalf("UpdateProjectSource a: %v", err)
+	}
+
+	gotB, err := db.GetProjectByID(ctx, idB)
+	if err != nil {
+		t.Fatalf("GetByID b: %v", err)
+	}
+	if gotB.GithubRepo != "h/b" || gotB.Branch != "main" || gotB.Path != "" {
+		t.Errorf("project b leaked changes from a: %+v", gotB)
+	}
+}
+
+// TestUpdateProjectSource_EmptyPathClearsSubdir proves callers can move a
+// project back to repo-root by passing an empty path. Important for the
+// inverse of the monorepo cutover (un-monorepo-ing).
+func TestUpdateProjectSource_EmptyPathClearsSubdir(t *testing.T) {
+	t.Parallel()
+	db := openTestDB(t)
+	ctx := context.Background()
+	id, _ := db.CreateProject(ctx, Project{
+		Name: "x", GithubRepo: "h/mono", Branch: "main", Path: "services/x",
+	})
+
+	if err := db.UpdateProjectSource(ctx, id, "h/x", "main", ""); err != nil {
+		t.Fatalf("UpdateProjectSource: %v", err)
+	}
+	got, err := db.GetProjectByID(ctx, id)
+	if err != nil {
+		t.Fatalf("GetByID: %v", err)
+	}
+	if got.Path != "" {
+		t.Errorf("Path: got %q, want empty", got.Path)
+	}
+	if got.GithubRepo != "h/x" {
+		t.Errorf("GithubRepo: got %q, want h/x", got.GithubRepo)
+	}
+}
+
+// TestUpdateProjectSource_BumpsUpdatedAt proves the updated_at column ticks
+// forward on each update — used by external observers (UI, audit logs) to
+// detect that a config change happened even when the row's other fields
+// happen to round-trip to the same values.
+func TestUpdateProjectSource_BumpsUpdatedAt(t *testing.T) {
+	t.Parallel()
+	db := openTestDB(t)
+	ctx := context.Background()
+	id, _ := db.CreateProject(ctx, Project{Name: "x", GithubRepo: "h/x", Branch: "main"})
+
+	before, err := db.GetProjectByID(ctx, id)
+	if err != nil {
+		t.Fatalf("GetByID before: %v", err)
+	}
+
+	// sleep 1.1s so strftime('%s') ticks at least once (second resolution).
+	time.Sleep(1100 * time.Millisecond)
+
+	if err := db.UpdateProjectSource(ctx, id, "h/x", "main", ""); err != nil {
+		t.Fatalf("UpdateProjectSource: %v", err)
+	}
+	after, err := db.GetProjectByID(ctx, id)
+	if err != nil {
+		t.Fatalf("GetByID after: %v", err)
+	}
+	if after.UpdatedAt <= before.UpdatedAt {
+		t.Errorf("UpdatedAt did not advance: before=%d after=%d", before.UpdatedAt, after.UpdatedAt)
 	}
 }

--- a/pkg/cobaltapi/project.go
+++ b/pkg/cobaltapi/project.go
@@ -38,3 +38,17 @@ type ProjectCreateRequest struct {
 type ProjectRenameRequest struct {
 	Name string `json:"name"`
 }
+
+// ProjectUpdateSourceRequest is the body of PATCH /api/projects/{name}/source.
+// Retargets which GitHub repo, branch, and sub-path the project tracks. All
+// three fields are required; the CLI's `cobalt projects update` provides
+// partial-update ergonomics by fetching current state and merging user
+// flags before sending the full request.
+//
+// Existing domains, env vars, deployments, and running services are
+// unaffected — the next deploy reads from the new source.
+type ProjectUpdateSourceRequest struct {
+	GithubRepo string `json:"githubRepo"`
+	Branch     string `json:"branch"`
+	Path       string `json:"path"`
+}


### PR DESCRIPTION
## Summary

Adds `cobalt projects update <name>` and `PATCH /api/projects/{name}/source` to retarget which GitHub repo, branch, and sub-path an existing project tracks — without recreating the project.

Keeps domains, env vars, deployment history, and running services intact. Update is config-only; operator triggers the deploy with `cobalt deploy --project <name>` separately.

```bash
# What this unblocks (monorepo cutover):
cobalt projects update api         --github heyblueteam/blue --path api
cobalt projects update next        --github heyblueteam/blue --path app
cobalt projects update white-label --github heyblueteam/blue --path app
```

## Why

The v0.15.0 API has no way to change `github_repo` / `branch` / `path` on an existing project. The only option is `remove` + `add`, which tears down swarm services for the gap (~5 minutes of 502s per project, 3 projects = real customer impact during the [api-app-next monorepo cutover](https://github.com/heyblueteam/blue/blob/main/plans/api-app-next-monorepo-merge.md)).

Side effects: zero. GitHub webhooks subscribe at the installation level, not per-project; domain bindings reference projects by `id`, not by repo. Running services keep serving traffic until the next deploy reads the new source.

## What's in this PR

- `pkg/cobaltapi/project.go` — new `ProjectUpdateSourceRequest` type
- `internal/server/store/projects.go` — new `UpdateProjectSource` method
- `internal/server/api/projects.go` — new `UpdateProjectSource` handler + `validateProjectUpdateSource` helper
- `internal/server/api/router.go` — new route `PATCH /api/projects/{name}/source`
- `internal/client/projects.go` — new `UpdateProjectSource` client method
- `cmd/cobalt/projects.go` — new `newProjectsUpdateCmd()` with `--github` / `--branch` / `--path` flags. CLI fetches current state and merges user-set flags before sending the full request (API requires all 3 source fields; partial-update ergonomics live in the CLI).

## Tests

12 new tests, all passing. Full suite green.

**Store layer** (6 tests):
- `TestUpdateProjectSource_RoundTrip` — repo/branch/path round-trip through GetByID + GetByName
- `TestUpdateProjectSource_NotFound` — returns `ErrNotFound` on missing ID (handler maps to HTTP 404)
- `TestUpdateProjectSource_InvalidPath` — leading slash + parent traversal rejected at store layer
- `TestUpdateProjectSource_IsolatesProjects` — updating project A doesn't leak into project B (WHERE clause is id-scoped)
- `TestUpdateProjectSource_EmptyPathClearsSubdir` — can move a project back to repo root
- `TestUpdateProjectSource_BumpsUpdatedAt` — `updated_at` advances on every update

**HTTP handler** (6 tests):
- `TestUpdateProjectSource_RetargetsRepoBranchPath` — happy path end-to-end
- `TestUpdateProjectSource_NotFoundReturns404` — 404 not 500 on missing project
- `TestUpdateProjectSource_ValidationErrors` — 400 on bad repo / empty branch / bad path
- `TestUpdateProjectSource_PreservesDomainsAndEnv` — **the core invariant**: domains and env vars survive a source retarget
- `TestUpdateProjectSource_DoesNotChangeName` — source PATCH never touches name
- `TestUpdateProjectSource_IdempotentNoOp` — PATCHing identical values is a safe no-op

## Test plan

- [x] `go test ./...` — full suite green (api 22.3s, store 30.8s, no regressions)
- [x] `go vet ./...` — clean
- [x] `go build ./...` — clean
- [ ] Post-merge: cut v0.16.0, `cobalt upgrade --to v0.16.0` against prod
- [ ] Smoke test: `cobalt projects add e2e-update --github heyblueteam/cobalt --branch main`, then `cobalt projects update e2e-update --path docs`, verify with `cobalt projects list --json`, then remove

## Plan

Full design rationale + alternatives considered: [`plans/cobalt-project-source-update.md`](https://github.com/heyblueteam/blue/blob/main/plans/cobalt-project-source-update.md) in heyblueteam/blue.

## CI note

The repo's `lint` job is currently red on `main` (pre-existing lint debt, ~175 issues — separate fix is in flight on `fix/lint-debt-b`). This branch is built on top of that state and inherits the same red `lint` job. The `test` job passes. Same release-time judgment call as v0.15.0.