### PR TITLE
feat(builder): hybrid per-project buildx isolation (fixes #24)

### DIFF
--- a/internal/server/api/api_test.go
+++ b/internal/server/api/api_test.go
@@ -4,6 +4,7 @@ import (
 	"bytes"
 	"context"
 	"encoding/json"
+	"fmt"
 	"io"
 	"log/slog"
 	"net/http"
@@ -16,6 +17,7 @@ import (
 	"time"
 
 	"github.com/heyblueteam/cobalt/internal/server/deploy"
+	"github.com/heyblueteam/cobalt/internal/server/docker"
 	"github.com/heyblueteam/cobalt/internal/server/store"
 	"github.com/heyblueteam/cobalt/pkg/cobaltapi"
 )
@@ -136,6 +138,91 @@ func TestDeleteProject_RemovesOnDiskArtifacts(t *testing.T) {
 	if _, err := os.Stat(logDir); !os.IsNotExist(err) {
 		t.Errorf("log dir still exists after delete: err=%v", err)
 	}
+}
+
+// TestDeleteProject_TearsDownIsolatedBuilder proves DELETE
+// /api/projects/{name} fires `docker buildx rm --force cobalt-builder-<id>`
+// — the lifecycle hook for the per-project builder created at deploy
+// time by sibling-aware projects (cobalt#24).
+//
+// The call is unconditional and best-effort: we don't track whether the
+// project ever got an isolated builder. `buildx rm` against a missing
+// name is the common path for solo projects and is silently absorbed.
+func TestDeleteProject_TearsDownIsolatedBuilder(t *testing.T) {
+	t.Parallel()
+	r := &recordingRunner{}
+	tmp := t.TempDir()
+	db := openTestDB(t)
+	mux := http.NewServeMux()
+	h := &Handler{
+		DB:      db,
+		Queue:   deploy.NewQueue(db),
+		Docker:  docker.NewWithRunner(r),
+		Log:     slog.New(slog.NewTextHandler(io.Discard, nil)),
+		DataDir: tmp,
+	}
+	h.Register(mux)
+	srv := httptest.NewServer(mux)
+	t.Cleanup(srv.Close)
+
+	body, _ := json.Marshal(cobaltapi.ProjectCreateRequest{
+		Name: "api", GithubRepo: "h/api", Branch: "main",
+	})
+	resp, err := srv.Client().Post(srv.URL+"/api/projects", "application/json", bytes.NewReader(body))
+	if err != nil {
+		t.Fatalf("create: %v", err)
+	}
+	created := decode[cobaltapi.Project](t, resp)
+
+	req, _ := http.NewRequestWithContext(context.Background(), http.MethodDelete, srv.URL+"/api/projects/api", nil)
+	resp, err = srv.Client().Do(req)
+	if err != nil {
+		t.Fatalf("delete: %v", err)
+	}
+	mustStatus(t, resp, http.StatusNoContent)
+	resp.Body.Close()
+
+	want := fmt.Sprintf("%s-%d", docker.BuildxBuilderName, created.ID)
+	found := false
+	for _, args := range r.argv() {
+		if len(args) >= 4 && args[0] == "buildx" && args[1] == "rm" && args[2] == "--force" && args[3] == want {
+			found = true
+			break
+		}
+	}
+	if !found {
+		t.Errorf("expected `buildx rm --force %s`; got runs %v", want, r.argv())
+	}
+}
+
+// recordingRunner is a minimal docker.Runner stand-in: records every
+// invocation, returns nil. Lives in the api package because docker's
+// fakeRunner is unexported.
+type recordingRunner struct {
+	mu    sync.Mutex
+	calls [][]string
+}
+
+func (r *recordingRunner) Run(_ context.Context, args []string, _ io.Reader, _, _ io.Writer) error {
+	r.mu.Lock()
+	defer r.mu.Unlock()
+	r.calls = append(r.calls, append([]string(nil), args...))
+	return nil
+}
+
+func (r *recordingRunner) RunWithEnv(_ context.Context, _ map[string]string, args []string, _ io.Reader, _, _ io.Writer) error {
+	r.mu.Lock()
+	defer r.mu.Unlock()
+	r.calls = append(r.calls, append([]string(nil), args...))
+	return nil
+}
+
+func (r *recordingRunner) argv() [][]string {
+	r.mu.Lock()
+	defer r.mu.Unlock()
+	out := make([][]string, len(r.calls))
+	copy(out, r.calls)
+	return out
 }
 
 func TestProjectsCRUD(t *testing.T) {

--- a/internal/server/api/projects.go
+++ b/internal/server/api/projects.go
@@ -1,13 +1,16 @@
 package api
 
 import (
+	"context"
 	"database/sql"
 	"errors"
+	"fmt"
 	"net/http"
 	"os"
 	"path/filepath"
 	"strings"
 
+	"github.com/heyblueteam/cobalt/internal/server/docker"
 	"github.com/heyblueteam/cobalt/internal/server/store"
 	"github.com/heyblueteam/cobalt/pkg/cobaltapi"
 	"github.com/heyblueteam/cobalt/pkg/cobaltapi/validator"
@@ -198,23 +201,35 @@ func (h *Handler) DeleteProject(w http.ResponseWriter, r *http.Request) {
 		writeError(w, http.StatusInternalServerError, "internal error")
 		return
 	}
-	h.cleanupProjectArtifacts(p.Name)
+	h.cleanupProjectArtifacts(r.Context(), *p)
 	w.WriteHeader(http.StatusNoContent)
 }
 
-// cleanupProjectArtifacts removes the on-disk paths a project owns. Failures
-// are logged but do not fail the API call — the DB row is already gone, and
-// stale dirs are recoverable by the operator.
-func (h *Handler) cleanupProjectArtifacts(projectName string) {
-	if h.DataDir == "" {
-		return
+// cleanupProjectArtifacts removes the on-disk paths a project owns AND
+// the per-project buildx builder, if any. Failures are logged but do not
+// fail the API call — the DB row is already gone, and stale dirs or
+// builders are recoverable by the operator.
+//
+// Builder removal is best-effort: the majority of projects never get an
+// isolated builder (only those sharing source with a sibling do; see
+// cobalt#24), so `buildx rm` for a missing instance is the expected
+// case. We log at debug-ish level to avoid noise in the common path.
+func (h *Handler) cleanupProjectArtifacts(ctx context.Context, p store.Project) {
+	if h.DataDir != "" {
+		for _, path := range []string{
+			filepath.Join(h.DataDir, "projects", p.Name),
+			filepath.Join(h.DataDir, "logs", "deployments", p.Name),
+		} {
+			if err := os.RemoveAll(path); err != nil {
+				h.Log.Warn("api: delete project: remove dir", "path", path, "error", err)
+			}
+		}
 	}
-	for _, p := range []string{
-		filepath.Join(h.DataDir, "projects", projectName),
-		filepath.Join(h.DataDir, "logs", "deployments", projectName),
-	} {
-		if err := os.RemoveAll(p); err != nil {
-			h.Log.Warn("api: delete project: remove dir", "path", p, "error", err)
+	if h.Docker != nil {
+		builderName := fmt.Sprintf("%s-%d", docker.BuildxBuilderName, p.ID)
+		if err := h.Docker.RemoveBuildxBuilder(ctx, builderName); err != nil {
+			h.Log.Debug("api: delete project: remove builder (best-effort)",
+				"project", p.Name, "builder", builderName, "error", err)
 		}
 	}
 }

--- a/internal/server/api/projects.go
+++ b/internal/server/api/projects.go
@@ -209,10 +209,9 @@ func (h *Handler) DeleteProject(w http.ResponseWriter, r *http.Request) {
 // fail the API call — the DB row is already gone, and stale dirs or
 // builders are recoverable by the operator.
 //
-// Builder removal is best-effort: the majority of projects never get an
-// isolated builder (only those sharing source with a sibling do; see
-// cobalt#24), so `buildx rm` for a missing instance is the expected
-// case. We log at debug-ish level to avoid noise in the common path.
+// RemoveBuildxBuilder already absorbs the "builder doesn't exist" case
+// (the common path for solo projects), so any error here is a real
+// failure — daemon down, permissions — that an operator should see.
 func (h *Handler) cleanupProjectArtifacts(ctx context.Context, p store.Project) {
 	if h.DataDir != "" {
 		for _, path := range []string{
@@ -227,7 +226,7 @@ func (h *Handler) cleanupProjectArtifacts(ctx context.Context, p store.Project) 
 	if h.Docker != nil {
 		builderName := docker.IsolatedBuilderName(p.ID)
 		if err := h.Docker.RemoveBuildxBuilder(ctx, builderName); err != nil {
-			h.Log.Debug("api: delete project: remove builder (best-effort)",
+			h.Log.Warn("api: delete project: remove builder",
 				"project", p.Name, "builder", builderName, "error", err)
 		}
 	}

--- a/internal/server/api/projects.go
+++ b/internal/server/api/projects.go
@@ -4,7 +4,6 @@ import (
 	"context"
 	"database/sql"
 	"errors"
-	"fmt"
 	"net/http"
 	"os"
 	"path/filepath"
@@ -226,7 +225,7 @@ func (h *Handler) cleanupProjectArtifacts(ctx context.Context, p store.Project) 
 		}
 	}
 	if h.Docker != nil {
-		builderName := fmt.Sprintf("%s-%d", docker.BuildxBuilderName, p.ID)
+		builderName := docker.IsolatedBuilderName(p.ID)
 		if err := h.Docker.RemoveBuildxBuilder(ctx, builderName); err != nil {
 			h.Log.Debug("api: delete project: remove builder (best-effort)",
 				"project", p.Name, "builder", builderName, "error", err)

--- a/internal/server/deploy/build.go
+++ b/internal/server/deploy/build.go
@@ -41,22 +41,36 @@ type EnvLister interface {
 	EnvVarMap(ctx context.Context, projectID int64) (map[string]string, error)
 }
 
+// ProjectQuerier is the subset of *store.DB the builder uses to decide
+// whether a project needs an isolated buildx instance. Kept distinct
+// from EnvLister so a future expansion of either responsibility doesn't
+// muddle the other's contract.
+type ProjectQuerier interface {
+	OtherProjectsWithSameSource(ctx context.Context, projectID int64) (int, error)
+}
+
 // DockerImageBuilder is the docker primitive the builder shells out to.
 // Implemented by *docker.Client; defined here so tests can fake it.
 type DockerImageBuilder interface {
 	Build(ctx context.Context, opts docker.BuildOpts) (string, error)
+	EnsureBuildxBuilder(ctx context.Context, name string) error
 }
 
 // NewBuilder returns a Builder that uses the supplied docker primitive
 // and per-project BuildKit cache directory rooted at dataDir/buildkit-cache.
-func NewBuilder(d DockerImageBuilder, env EnvLister, dataDir string) Builder {
-	return &dockerBuilder{docker: d, env: env, dataDir: dataDir}
+//
+// projects is consulted on every build to pick the right buildx instance:
+// shared by default, isolated when the project shares (repo, branch,
+// path) with another (cobalt#24).
+func NewBuilder(d DockerImageBuilder, env EnvLister, projects ProjectQuerier, dataDir string) Builder {
+	return &dockerBuilder{docker: d, env: env, projects: projects, dataDir: dataDir}
 }
 
 type dockerBuilder struct {
-	docker  DockerImageBuilder
-	env     EnvLister
-	dataDir string
+	docker   DockerImageBuilder
+	env      EnvLister
+	projects ProjectQuerier
+	dataDir  string
 }
 
 func (b *dockerBuilder) Build(ctx context.Context, project store.Project, dep store.Deployment, ws *Workspace, out io.Writer) ([]BuiltService, error) {
@@ -72,6 +86,36 @@ func (b *dockerBuilder) Build(ctx context.Context, project store.Project, dep st
 	cacheDir := ""
 	if b.dataDir != "" {
 		cacheDir = filepath.Join(b.dataDir, "buildkit-cache", strconv.FormatInt(project.ID, 10))
+	}
+
+	// Pick the buildx instance for this build. Shared by default; if any
+	// other project points at the same (repo, branch, path), promote to
+	// an isolated per-project builder so the two can't poison each
+	// other's `--mount=type=secret` cache (cobalt#24).
+	//
+	// Store failure → soft-fall-back to the shared builder. We prefer
+	// availability over correctness here because the cache race is rare
+	// and a transient store error would otherwise block the deploy.
+	// EnsureBuildxBuilder failure → hard-fail: we decided isolation is
+	// needed; silently using the shared builder would re-introduce the
+	// race we set out to avoid.
+	builderName := ""
+	if b.projects != nil {
+		siblingCount, err := b.projects.OtherProjectsWithSameSource(ctx, project.ID)
+		switch {
+		case err != nil:
+			if out != nil {
+				fmt.Fprintf(out, "⚠️  could not check source siblings (%v); using shared builder\n", err)
+			}
+		case siblingCount > 0:
+			builderName = fmt.Sprintf("%s-%d", docker.BuildxBuilderName, project.ID)
+			if err := b.docker.EnsureBuildxBuilder(ctx, builderName); err != nil {
+				return nil, fmt.Errorf("deploy.Build: ensure isolated builder %q: %w", builderName, err)
+			}
+			if out != nil {
+				fmt.Fprintf(out, "🔒 isolated builder %q (%d sibling project(s) share this source)\n", builderName, siblingCount)
+			}
+		}
 	}
 
 	// Build each unique image only once. Mirrors disco's resolution
@@ -117,6 +161,7 @@ func (b *dockerBuilder) Build(ctx context.Context, project store.Project, dep st
 			EnvSecrets:       envSecrets,
 			NoCache:          dep.NoCache,
 			CacheDir:         cacheDir,
+			BuilderName:      builderName,
 			Output:           out,
 		}
 		tag, err := b.docker.Build(ctx, opts)

--- a/internal/server/deploy/build.go
+++ b/internal/server/deploy/build.go
@@ -108,7 +108,7 @@ func (b *dockerBuilder) Build(ctx context.Context, project store.Project, dep st
 				fmt.Fprintf(out, "⚠️  could not check source siblings (%v); using shared builder\n", err)
 			}
 		case siblingCount > 0:
-			builderName = fmt.Sprintf("%s-%d", docker.BuildxBuilderName, project.ID)
+			builderName = docker.IsolatedBuilderName(project.ID)
 			if err := b.docker.EnsureBuildxBuilder(ctx, builderName); err != nil {
 				return nil, fmt.Errorf("deploy.Build: ensure isolated builder %q: %w", builderName, err)
 			}

--- a/internal/server/deploy/build_test.go
+++ b/internal/server/deploy/build_test.go
@@ -5,6 +5,7 @@ import (
 	"errors"
 	"sort"
 	"strconv"
+	"strings"
 	"sync"
 	"testing"
 
@@ -23,10 +24,12 @@ func (f *fakeEnv) EnvVarMap(_ context.Context, _ int64) (map[string]string, erro
 }
 
 type fakeImageBuilder struct {
-	mu    sync.Mutex
-	calls []docker.BuildOpts
-	tag   func(opts docker.BuildOpts) string
-	err   error
+	mu             sync.Mutex
+	calls          []docker.BuildOpts
+	ensuredBuilder []string
+	ensureErr      error
+	tag            func(opts docker.BuildOpts) string
+	err            error
 }
 
 func (f *fakeImageBuilder) Build(_ context.Context, opts docker.BuildOpts) (string, error) {
@@ -40,6 +43,25 @@ func (f *fakeImageBuilder) Build(_ context.Context, opts docker.BuildOpts) (stri
 		return f.tag(opts), nil
 	}
 	return docker.InternalImageName(opts.ProjectName, opts.ImageName, opts.DeploymentNumber), nil
+}
+
+func (f *fakeImageBuilder) EnsureBuildxBuilder(_ context.Context, name string) error {
+	f.mu.Lock()
+	defer f.mu.Unlock()
+	f.ensuredBuilder = append(f.ensuredBuilder, name)
+	return f.ensureErr
+}
+
+// fakeProjectQuerier is a programmable stand-in for the store's
+// OtherProjectsWithSameSource lookup. Tests set count (or err) to drive
+// the builder's shared-vs-isolated decision.
+type fakeProjectQuerier struct {
+	count int
+	err   error
+}
+
+func (f *fakeProjectQuerier) OtherProjectsWithSameSource(_ context.Context, _ int64) (int, error) {
+	return f.count, f.err
 }
 
 func TestBuilder_BuildsEachUniqueImageOnce(t *testing.T) {
@@ -58,7 +80,7 @@ func TestBuilder_BuildsEachUniqueImageOnce(t *testing.T) {
 	}
 	ws := &Workspace{Path: "/tmp/repo", Cobaltfile: cf, Commit: "abc"}
 	d := &fakeImageBuilder{}
-	b := NewBuilder(d, &fakeEnv{}, "/data")
+	b := NewBuilder(d, &fakeEnv{}, &fakeProjectQuerier{}, "/data")
 
 	out, err := b.Build(context.Background(), store.Project{ID: 7, Name: "api"},
 		store.Deployment{Number: 3}, ws, nil)
@@ -93,7 +115,7 @@ func TestBuilder_PassesCacheDir(t *testing.T) {
 		Images:   map[string]cobaltfile.Image{"default": {Dockerfile: "Dockerfile", Context: "."}},
 	}
 	d := &fakeImageBuilder{}
-	b := NewBuilder(d, &fakeEnv{}, "/data")
+	b := NewBuilder(d, &fakeEnv{}, &fakeProjectQuerier{}, "/data")
 
 	_, err := b.Build(
 		context.Background(),
@@ -124,7 +146,7 @@ func TestBuilder_StaticOnlySkipsBuild(t *testing.T) {
 		Images: map[string]cobaltfile.Image{"default": {Dockerfile: "Dockerfile", Context: "."}},
 	}
 	d := &fakeImageBuilder{}
-	b := NewBuilder(d, &fakeEnv{}, "")
+	b := NewBuilder(d, &fakeEnv{}, &fakeProjectQuerier{}, "")
 
 	out, err := b.Build(context.Background(), store.Project{ID: 1, Name: "x"},
 		store.Deployment{Number: 1}, &Workspace{Cobaltfile: cf}, nil)
@@ -150,7 +172,7 @@ func TestBuilder_PropagatesEnvSecrets(t *testing.T) {
 		Images:   map[string]cobaltfile.Image{"default": {Dockerfile: "Dockerfile", Context: "."}},
 	}
 	d := &fakeImageBuilder{}
-	b := NewBuilder(d, &fakeEnv{vars: map[string]string{"API_KEY": "k", "DB_URL": "u"}}, "")
+	b := NewBuilder(d, &fakeEnv{vars: map[string]string{"API_KEY": "k", "DB_URL": "u"}}, &fakeProjectQuerier{}, "")
 
 	_, err := b.Build(
 		context.Background(),
@@ -202,7 +224,7 @@ func TestBuilder_PrebuiltImageSkipsBuild(t *testing.T) {
 		// no Images map entry — image is a pre-built ref
 	}
 	d := &fakeImageBuilder{}
-	b := NewBuilder(d, &fakeEnv{}, "")
+	b := NewBuilder(d, &fakeEnv{}, &fakeProjectQuerier{}, "")
 	out, err := b.Build(
 		context.Background(),
 		store.Project{ID: 1, Name: "redis"},
@@ -245,7 +267,7 @@ func TestBuilder_MixedPrebuiltAndBuilt(t *testing.T) {
 		},
 	}
 	d := &fakeImageBuilder{}
-	b := NewBuilder(d, &fakeEnv{}, "")
+	b := NewBuilder(d, &fakeEnv{}, &fakeProjectQuerier{}, "")
 	out, err := b.Build(
 		context.Background(),
 		store.Project{ID: 1, Name: "openpanel"},
@@ -283,6 +305,146 @@ func TestBuilder_MixedPrebuiltAndBuilt(t *testing.T) {
 	}
 }
 
+// TestBuilder_UsesSharedBuilderForSoloProject proves a project with no
+// source siblings does NOT trigger isolated-builder creation — the
+// shared builder is used by passing an empty BuilderName, and
+// EnsureBuildxBuilder is not called from the build path (the daemon
+// already bootstrapped the shared builder at boot).
+func TestBuilder_UsesSharedBuilderForSoloProject(t *testing.T) {
+	t.Parallel()
+	cf := &cobaltfile.Cobaltfile{
+		Version:  "1.0",
+		Services: map[string]cobaltfile.Service{"web": {Image: "default", Port: 8000}},
+		Images:   map[string]cobaltfile.Image{"default": {Dockerfile: "Dockerfile", Context: "."}},
+	}
+	d := &fakeImageBuilder{}
+	b := NewBuilder(d, &fakeEnv{}, &fakeProjectQuerier{count: 0}, "")
+
+	if _, err := b.Build(
+		context.Background(),
+		store.Project{ID: 7, Name: "solo"},
+		store.Deployment{Number: 1},
+		&Workspace{Cobaltfile: cf},
+		nil,
+	); err != nil {
+		t.Fatalf("Build: %v", err)
+	}
+	if len(d.calls) != 1 {
+		t.Fatalf("calls: %d", len(d.calls))
+	}
+	if d.calls[0].BuilderName != "" {
+		t.Errorf("BuilderName: got %q, want empty (shared builder)", d.calls[0].BuilderName)
+	}
+	if len(d.ensuredBuilder) != 0 {
+		t.Errorf("EnsureBuildxBuilder called %v; want no calls for solo project", d.ensuredBuilder)
+	}
+}
+
+// TestBuilder_UsesIsolatedBuilderForSharedProject proves a project that
+// shares source with at least one sibling routes its build through
+// "cobalt-builder-<projectID>" AND ensures that builder exists first.
+func TestBuilder_UsesIsolatedBuilderForSharedProject(t *testing.T) {
+	t.Parallel()
+	cf := &cobaltfile.Cobaltfile{
+		Version:  "1.0",
+		Services: map[string]cobaltfile.Service{"web": {Image: "default", Port: 8000}},
+		Images:   map[string]cobaltfile.Image{"default": {Dockerfile: "Dockerfile", Context: "."}},
+	}
+	d := &fakeImageBuilder{}
+	b := NewBuilder(d, &fakeEnv{}, &fakeProjectQuerier{count: 1}, "")
+
+	if _, err := b.Build(
+		context.Background(),
+		store.Project{ID: 42, Name: "next"},
+		store.Deployment{Number: 1},
+		&Workspace{Cobaltfile: cf},
+		nil,
+	); err != nil {
+		t.Fatalf("Build: %v", err)
+	}
+	want := "cobalt-builder-42"
+	if len(d.ensuredBuilder) != 1 || d.ensuredBuilder[0] != want {
+		t.Errorf("EnsureBuildxBuilder: got %v, want [%q]", d.ensuredBuilder, want)
+	}
+	if len(d.calls) != 1 {
+		t.Fatalf("calls: %d", len(d.calls))
+	}
+	if d.calls[0].BuilderName != want {
+		t.Errorf("BuilderName: got %q, want %q", d.calls[0].BuilderName, want)
+	}
+}
+
+// TestBuilder_SoftFailsOnStoreError proves a store query failure does
+// NOT block the deploy — we fall back to the shared builder and log a
+// warning. The build still runs because the cache race is rare and a
+// transient store error would otherwise be a deploy-fatal regression.
+func TestBuilder_SoftFailsOnStoreError(t *testing.T) {
+	t.Parallel()
+	cf := &cobaltfile.Cobaltfile{
+		Version:  "1.0",
+		Services: map[string]cobaltfile.Service{"web": {Image: "default", Port: 8000}},
+		Images:   map[string]cobaltfile.Image{"default": {Dockerfile: "Dockerfile", Context: "."}},
+	}
+	d := &fakeImageBuilder{}
+	b := NewBuilder(d, &fakeEnv{}, &fakeProjectQuerier{err: errors.New("store down")}, "")
+
+	var out strings.Builder
+	if _, err := b.Build(
+		context.Background(),
+		store.Project{ID: 99, Name: "x"},
+		store.Deployment{Number: 1},
+		&Workspace{Cobaltfile: cf},
+		&out,
+	); err != nil {
+		t.Fatalf("Build: %v", err)
+	}
+	if len(d.calls) != 1 {
+		t.Fatalf("calls: %d", len(d.calls))
+	}
+	if d.calls[0].BuilderName != "" {
+		t.Errorf("BuilderName: got %q, want empty (shared fallback)", d.calls[0].BuilderName)
+	}
+	if len(d.ensuredBuilder) != 0 {
+		t.Errorf("EnsureBuildxBuilder unexpectedly called: %v", d.ensuredBuilder)
+	}
+	if !strings.Contains(out.String(), "store down") {
+		t.Errorf("expected warning containing store error; got %q", out.String())
+	}
+}
+
+// TestBuilder_FailsHardOnEnsureBuildxBuilderError proves that once we
+// decide isolation is needed, failing to ensure the isolated builder
+// aborts the build rather than silently re-routing through the shared
+// builder (which would re-introduce the cache race we're trying to
+// prevent — cobalt#24).
+func TestBuilder_FailsHardOnEnsureBuildxBuilderError(t *testing.T) {
+	t.Parallel()
+	cf := &cobaltfile.Cobaltfile{
+		Version:  "1.0",
+		Services: map[string]cobaltfile.Service{"web": {Image: "default", Port: 8000}},
+		Images:   map[string]cobaltfile.Image{"default": {Dockerfile: "Dockerfile", Context: "."}},
+	}
+	d := &fakeImageBuilder{ensureErr: errors.New("buildx down")}
+	b := NewBuilder(d, &fakeEnv{}, &fakeProjectQuerier{count: 2}, "")
+
+	_, err := b.Build(
+		context.Background(),
+		store.Project{ID: 7, Name: "next"},
+		store.Deployment{Number: 1},
+		&Workspace{Cobaltfile: cf},
+		nil,
+	)
+	if err == nil {
+		t.Fatal("expected hard-fail when EnsureBuildxBuilder fails")
+	}
+	if !strings.Contains(err.Error(), "cobalt-builder-7") {
+		t.Errorf("error should name the failing builder: %v", err)
+	}
+	if len(d.calls) != 0 {
+		t.Errorf("Build called %d times; want 0 (must abort before image build)", len(d.calls))
+	}
+}
+
 func TestBuilder_PropagatesDockerError(t *testing.T) {
 	t.Parallel()
 	cf := &cobaltfile.Cobaltfile{
@@ -291,7 +453,7 @@ func TestBuilder_PropagatesDockerError(t *testing.T) {
 		Images:   map[string]cobaltfile.Image{"default": {Dockerfile: "Dockerfile", Context: "."}},
 	}
 	d := &fakeImageBuilder{err: errors.New("docker boom")}
-	b := NewBuilder(d, &fakeEnv{}, "")
+	b := NewBuilder(d, &fakeEnv{}, &fakeProjectQuerier{}, "")
 	_, err := b.Build(
 		context.Background(),
 		store.Project{ID: 1, Name: "x"},

--- a/internal/server/docker/build.go
+++ b/internal/server/docker/build.go
@@ -24,6 +24,13 @@ type BuildOpts struct {
 	// cache between projects, so two projects sharing a repo can't poison
 	// each other's builds (improvement E from the deploy-flow audit).
 	CacheDir string
+	// BuilderName selects the buildx instance to route the build through.
+	// Empty falls back to BuildxBuilderName (the shared builder). The
+	// deploy layer sets this to "cobalt-builder-<projectID>" for projects
+	// that share source with at least one sibling — isolating BuildKit's
+	// in-memory secret cache so two parallel builds of the same source
+	// can't cross-contaminate each other's `--secret` values (cobalt#24).
+	BuilderName string
 	// Output, when non-nil, captures buildx's stdout AND stderr (interleaved
 	// — buildkit writes its progress to stderr, image layer progress to
 	// stdout). Callers tee this into the per-deployment log file so
@@ -53,13 +60,20 @@ func (c *Client) Build(ctx context.Context, opts BuildOpts) (string, error) {
 	}
 
 	tag := InternalImageName(opts.ProjectName, opts.ImageName, opts.DeploymentNumber)
-	// "buildx build --builder cobalt-builder" routes the build through the
-	// docker-container driver instance the daemon ensures at boot. --load
-	// imports the resulting image into the host's docker engine so swarm
-	// can run it.
+	// "buildx build --builder <name>" routes the build through a
+	// docker-container driver instance. --load imports the resulting
+	// image into the host's docker engine so swarm can run it.
+	//
+	// BuilderName empty → shared builder (default). The deploy layer
+	// picks an isolated "cobalt-builder-<projectID>" builder name for
+	// projects that share source with siblings (cobalt#24).
+	builder := opts.BuilderName
+	if builder == "" {
+		builder = BuildxBuilderName
+	}
 	args := []string{
 		"buildx", "build",
-		"--builder", BuildxBuilderName,
+		"--builder", builder,
 		"--load",
 		"-t", tag,
 	}

--- a/internal/server/docker/build_test.go
+++ b/internal/server/docker/build_test.go
@@ -199,12 +199,12 @@ func TestEnsureBuildxBuilder_CustomNameThreadsThrough(t *testing.T) {
 	}
 }
 
-// TestRemoveBuildxBuilder_PassesForceFlag locks in the argv shape the
-// cleanup-on-delete path depends on: `buildx rm --force <name>` so a
-// removal never hangs waiting for an in-flight build (the dispatcher's
-// per-project serialization guarantees no real concurrent build by the
-// time cleanup runs).
-func TestRemoveBuildxBuilder_PassesForceFlag(t *testing.T) {
+// TestRemoveBuildxBuilder_InspectsThenRemoves locks in the two-step
+// shape: inspect to confirm the builder exists, then `buildx rm --force
+// <name>` to tear it down. --force so removal never hangs waiting for
+// an in-flight build (the dispatcher's per-project serialization
+// guarantees no real concurrent build by the time cleanup runs).
+func TestRemoveBuildxBuilder_InspectsThenRemoves(t *testing.T) {
 	t.Parallel()
 	r := newFakeRunner()
 	c := NewWithRunner(r)
@@ -214,6 +214,26 @@ func TestRemoveBuildxBuilder_PassesForceFlag(t *testing.T) {
 	last := r.lastCall().Args
 	if !argSequence(last, "buildx", "rm", "--force", "cobalt-builder-42") {
 		t.Errorf("expected `buildx rm --force <name>`, got %v", last)
+	}
+}
+
+// TestRemoveBuildxBuilder_MissingBuilderReturnsNil proves the
+// inspect-first guard: when the builder doesn't exist (the common path
+// for solo-project deletes), we skip `buildx rm` and return nil — the
+// caller logs nothing instead of having to classify a non-zero rm exit
+// as "expected missing" vs "real failure".
+func TestRemoveBuildxBuilder_MissingBuilderReturnsNil(t *testing.T) {
+	t.Parallel()
+	r := newFakeRunner()
+	r.answerErr("buildx inspect", staticErr("no builder found"))
+	c := NewWithRunner(r)
+	if err := c.RemoveBuildxBuilder(context.Background(), "cobalt-builder-42"); err != nil {
+		t.Fatalf("RemoveBuildxBuilder: %v", err)
+	}
+	for _, call := range r.calls {
+		if len(call.Args) >= 2 && call.Args[0] == "buildx" && call.Args[1] == "rm" {
+			t.Errorf("rm should not run when inspect fails; got %v", call.Args)
+		}
 	}
 }
 

--- a/internal/server/docker/build_test.go
+++ b/internal/server/docker/build_test.go
@@ -155,7 +155,7 @@ func TestEnsureBuildxBuilder_NoOpWhenInspectSucceeds(t *testing.T) {
 	t.Parallel()
 	r := newFakeRunner()
 	c := NewWithRunner(r)
-	if err := c.EnsureBuildxBuilder(context.Background()); err != nil {
+	if err := c.EnsureBuildxBuilder(context.Background(), BuildxBuilderName); err != nil {
 		t.Fatalf("EnsureBuildxBuilder: %v", err)
 	}
 	// Inspect succeeded (fake returns nil error by default), so create
@@ -173,12 +173,86 @@ func TestEnsureBuildxBuilder_CreatesWhenInspectFails(t *testing.T) {
 	r := newFakeRunner()
 	r.answerErr("buildx inspect", staticErr("not found"))
 	c := NewWithRunner(r)
-	if err := c.EnsureBuildxBuilder(context.Background()); err != nil {
+	if err := c.EnsureBuildxBuilder(context.Background(), BuildxBuilderName); err != nil {
 		t.Fatalf("EnsureBuildxBuilder: %v", err)
 	}
 	last := r.lastCall().Args
 	if !argSequence(last, "buildx", "create", "--name", BuildxBuilderName, "--driver", "docker-container", "--bootstrap") {
 		t.Errorf("expected buildx create with docker-container driver, got %v", last)
+	}
+}
+
+// TestEnsureBuildxBuilder_CustomNameThreadsThrough proves the name
+// argument reaches buildx unmodified — the per-project isolated builder
+// path depends on this for the hybrid scheme (cobalt#24).
+func TestEnsureBuildxBuilder_CustomNameThreadsThrough(t *testing.T) {
+	t.Parallel()
+	r := newFakeRunner()
+	r.answerErr("buildx inspect", staticErr("not found"))
+	c := NewWithRunner(r)
+	if err := c.EnsureBuildxBuilder(context.Background(), "cobalt-builder-42"); err != nil {
+		t.Fatalf("EnsureBuildxBuilder: %v", err)
+	}
+	last := r.lastCall().Args
+	if !argSequence(last, "buildx", "create", "--name", "cobalt-builder-42", "--driver", "docker-container", "--bootstrap") {
+		t.Errorf("expected create with custom name, got %v", last)
+	}
+}
+
+// TestRemoveBuildxBuilder_PassesForceFlag locks in the argv shape the
+// cleanup-on-delete path depends on: `buildx rm --force <name>` so a
+// removal never hangs waiting for an in-flight build (the dispatcher's
+// per-project serialization guarantees no real concurrent build by the
+// time cleanup runs).
+func TestRemoveBuildxBuilder_PassesForceFlag(t *testing.T) {
+	t.Parallel()
+	r := newFakeRunner()
+	c := NewWithRunner(r)
+	if err := c.RemoveBuildxBuilder(context.Background(), "cobalt-builder-42"); err != nil {
+		t.Fatalf("RemoveBuildxBuilder: %v", err)
+	}
+	last := r.lastCall().Args
+	if !argSequence(last, "buildx", "rm", "--force", "cobalt-builder-42") {
+		t.Errorf("expected `buildx rm --force <name>`, got %v", last)
+	}
+}
+
+// TestBuild_BuilderNameThreadsThrough proves opts.BuilderName lands in
+// argv as `--builder <name>`. This is the lever the deploy layer uses to
+// route a build through an isolated per-project buildx (cobalt#24).
+func TestBuild_BuilderNameThreadsThrough(t *testing.T) {
+	t.Parallel()
+	r := newFakeRunner()
+	c := NewWithRunner(r)
+	if _, err := c.Build(context.Background(), BuildOpts{
+		ProjectName:      "api",
+		ImageName:        "default",
+		DeploymentNumber: 1,
+		BuilderName:      "cobalt-builder-42",
+	}); err != nil {
+		t.Fatalf("Build: %v", err)
+	}
+	args := r.lastCall().Args
+	if !argSequence(args, "--builder", "cobalt-builder-42") {
+		t.Errorf("expected --builder cobalt-builder-42, got %v", args)
+	}
+}
+
+// TestBuild_EmptyBuilderNameFallsBackToShared keeps every existing
+// caller (and every solo project after the cobalt#24 change) on the
+// shared builder by default.
+func TestBuild_EmptyBuilderNameFallsBackToShared(t *testing.T) {
+	t.Parallel()
+	r := newFakeRunner()
+	c := NewWithRunner(r)
+	if _, err := c.Build(context.Background(), BuildOpts{
+		ProjectName: "api", ImageName: "default", DeploymentNumber: 1,
+	}); err != nil {
+		t.Fatalf("Build: %v", err)
+	}
+	args := r.lastCall().Args
+	if !argSequence(args, "--builder", BuildxBuilderName) {
+		t.Errorf("expected fallback to shared builder, got %v", args)
 	}
 }
 

--- a/internal/server/docker/client.go
+++ b/internal/server/docker/client.go
@@ -171,13 +171,18 @@ func (c *Client) EnsureBuildxBuilder(ctx context.Context, name string) error {
 	)
 }
 
-// RemoveBuildxBuilder tears down a buildx instance by name. Best-effort:
-// callers use this on project deletion, where a missing builder ("never
-// got isolated") is the expected case for the majority of projects. The
-// underlying `docker buildx rm --force` exits non-zero only on real
-// failures (docker daemon down, etc.); a missing-builder error message
-// is normal and surfaced to the caller, which logs and continues.
+// RemoveBuildxBuilder tears down a buildx instance by name. Returns nil
+// when the builder doesn't exist — that's the common path for project
+// deletes (only sibling-sharing projects ever got an isolated builder).
+//
+// We inspect first so the caller can treat any non-nil error as a real
+// failure (docker daemon down, permission issue) worth surfacing,
+// instead of guessing whether a non-zero rm exit means "missing — fine"
+// or "broken — page someone".
 func (c *Client) RemoveBuildxBuilder(ctx context.Context, name string) error {
+	if err := c.run(ctx, "buildx", "inspect", name); err != nil {
+		return nil
+	}
 	return c.run(ctx, "buildx", "rm", "--force", name)
 }
 

--- a/internal/server/docker/client.go
+++ b/internal/server/docker/client.go
@@ -115,10 +115,18 @@ func (r *ExecRunner) RunWithEnv(ctx context.Context, extraEnv map[string]string,
 // --cache-to type=local works for per-project BuildKit cache isolation.
 //
 // Projects that share (github_repo, branch, path) with another project
-// get their own builder named "<BuildxBuilderName>-<projectID>" — see
+// get their own builder named via IsolatedBuilderName — see
 // deploy/build.go and cobalt#24. The naming pattern is matched by
 // cleanupProjectArtifacts when a project is removed.
 const BuildxBuilderName = "cobalt-builder"
+
+// IsolatedBuilderName returns the buildx instance name for a project
+// that needs isolation from siblings sharing its source (cobalt#24).
+// Single source of truth so the deploy layer (which creates it) and the
+// api layer (which tears it down on project delete) can't drift.
+func IsolatedBuilderName(projectID int64) string {
+	return fmt.Sprintf("%s-%d", BuildxBuilderName, projectID)
+}
 
 // Client is the user-facing handle for everything in this package.
 type Client struct {

--- a/internal/server/docker/client.go
+++ b/internal/server/docker/client.go
@@ -109,10 +109,15 @@ func (r *ExecRunner) RunWithEnv(ctx context.Context, extraEnv map[string]string,
 	return nil
 }
 
-// BuildxBuilderName is the buildx instance the daemon creates and uses
-// for every project build. We need a docker-container driver (not the
-// default docker driver) so --cache-to type=local works for per-project
-// BuildKit cache isolation.
+// BuildxBuilderName is the shared buildx instance the daemon creates at
+// boot and uses for every build that doesn't need isolation. We need a
+// docker-container driver (not the default docker driver) so
+// --cache-to type=local works for per-project BuildKit cache isolation.
+//
+// Projects that share (github_repo, branch, path) with another project
+// get their own builder named "<BuildxBuilderName>-<projectID>" — see
+// deploy/build.go and cobalt#24. The naming pattern is matched by
+// cleanupProjectArtifacts when a project is removed.
 const BuildxBuilderName = "cobalt-builder"
 
 // Client is the user-facing handle for everything in this package.
@@ -137,22 +142,35 @@ func (c *Client) run(ctx context.Context, args ...string) error {
 	return c.runner.Run(ctx, args, nil, nil, nil)
 }
 
-// EnsureBuildxBuilder makes sure the docker-container builder named by
-// BuildxBuilderName exists, creating it if needed. Idempotent — safe to
-// call on every daemon boot.
+// EnsureBuildxBuilder makes sure the docker-container builder with the
+// given name exists, creating it if needed. Idempotent — safe to call on
+// every daemon boot and on every build.
 //
 // The docker-container driver is required so that --cache-to type=local
 // works for per-project cache isolation (improvement E in §8b).
-func (c *Client) EnsureBuildxBuilder(ctx context.Context) error {
-	if err := c.run(ctx, "buildx", "inspect", BuildxBuilderName); err == nil {
+//
+// Callers pass BuildxBuilderName for the shared builder, or
+// "<BuildxBuilderName>-<projectID>" for an isolated per-project builder.
+func (c *Client) EnsureBuildxBuilder(ctx context.Context, name string) error {
+	if err := c.run(ctx, "buildx", "inspect", name); err == nil {
 		return nil
 	}
 	return c.run(
 		ctx, "buildx", "create",
-		"--name", BuildxBuilderName,
+		"--name", name,
 		"--driver", "docker-container",
 		"--bootstrap",
 	)
+}
+
+// RemoveBuildxBuilder tears down a buildx instance by name. Best-effort:
+// callers use this on project deletion, where a missing builder ("never
+// got isolated") is the expected case for the majority of projects. The
+// underlying `docker buildx rm --force` exits non-zero only on real
+// failures (docker daemon down, etc.); a missing-builder error message
+// is normal and surfaced to the caller, which logs and continues.
+func (c *Client) RemoveBuildxBuilder(ctx context.Context, name string) error {
+	return c.run(ctx, "buildx", "rm", "--force", name)
 }
 
 // output captures stdout into a buffer and returns it, trimmed.

--- a/internal/server/server.go
+++ b/internal/server/server.go
@@ -157,7 +157,7 @@ func Run(ctx context.Context, cfg Config) error {
 	// Bootstrap the buildx builder we use for every deploy. Failure here
 	// is non-fatal: the daemon can still serve API traffic without it,
 	// only deploys will fail clearly at build time.
-	if err := dockerCli.EnsureBuildxBuilder(ctx); err != nil {
+	if err := dockerCli.EnsureBuildxBuilder(ctx, docker.BuildxBuilderName); err != nil {
 		log.Warn("ensure buildx builder failed", "name", docker.BuildxBuilderName, "error", err)
 	} else {
 		log.Info("buildx builder ready", "name", docker.BuildxBuilderName)
@@ -165,7 +165,7 @@ func Run(ctx context.Context, cfg Config) error {
 
 	tokens := deploy.NewDBTokenProvider(db, githubCli, time.Now)
 	preparer := deploy.NewPreparer(cfg.DataDir, tokens, deploy.ExecGit{})
-	builder := deploy.NewBuilder(dockerCli, db, cfg.DataDir)
+	builder := deploy.NewBuilder(dockerCli, db, db, cfg.DataDir)
 
 	sched := worker.NewScheduler(log)
 	cronMgr := worker.NewCronManager(sched, dockerCli, db, log)

--- a/internal/server/store/projects.go
+++ b/internal/server/store/projects.go
@@ -196,6 +196,35 @@ func (db *DB) UpdateProjectSource(ctx context.Context, id int64, githubRepo, bra
 	return nil
 }
 
+// OtherProjectsWithSameSource returns the count of projects (other than
+// projectID) that share the same (github_repo, branch, path) tuple as
+// projectID. Returns 0 with no error when projectID doesn't exist —
+// callers treat that as "no siblings, use the shared builder".
+//
+// Used by the deploy builder to decide whether to route a build through
+// an isolated per-project buildx instance (count > 0) or the shared one
+// (count == 0). See cobalt#24.
+func (db *DB) OtherProjectsWithSameSource(ctx context.Context, projectID int64) (int, error) {
+	resp, err := db.QuerySingle(ctx, `
+        SELECT COUNT(*) FROM projects
+        WHERE id <> ?
+          AND (github_repo, branch, path) IN (
+            SELECT github_repo, branch, path FROM projects WHERE id = ?
+          )
+    `, projectID, projectID)
+	if err != nil {
+		return 0, err
+	}
+	if hasError, _, errMsg := resp.HasError(); hasError {
+		return 0, errors.New(errMsg)
+	}
+	results := resp.GetQueryResults()
+	if len(results) == 0 || len(results[0].Values) == 0 {
+		return 0, nil
+	}
+	return int(toInt64(results[0].Values[0][0])), nil
+}
+
 // DeleteProject removes a project. Foreign keys with ON DELETE CASCADE
 // (deployments, env_vars, domains, command_runs) clean up automatically.
 func (db *DB) DeleteProject(ctx context.Context, id int64) error {

--- a/internal/server/store/projects_test.go
+++ b/internal/server/store/projects_test.go
@@ -221,6 +221,156 @@ func TestCreateProject_RejectsInvalidPath(t *testing.T) {
 	}
 }
 
+// TestOtherProjectsWithSameSource_Solo proves a project with no siblings
+// returns 0 — the deploy builder will route through the shared builder.
+func TestOtherProjectsWithSameSource_Solo(t *testing.T) {
+	t.Parallel()
+	db := openTestDB(t)
+	ctx := context.Background()
+
+	id, _ := db.CreateProject(ctx, Project{
+		Name: "solo", GithubRepo: "heyblueteam/blue", Branch: "main", Path: "api",
+	})
+	n, err := db.OtherProjectsWithSameSource(ctx, id)
+	if err != nil {
+		t.Fatalf("query: %v", err)
+	}
+	if n != 0 {
+		t.Errorf("count: got %d, want 0", n)
+	}
+}
+
+// TestOtherProjectsWithSameSource_Sibling proves two projects with the
+// same (repo, branch, path) each see the other.
+func TestOtherProjectsWithSameSource_Sibling(t *testing.T) {
+	t.Parallel()
+	db := openTestDB(t)
+	ctx := context.Background()
+
+	idA, _ := db.CreateProject(ctx, Project{
+		Name: "next", GithubRepo: "heyblueteam/blue", Branch: "main", Path: "app",
+	})
+	idB, _ := db.CreateProject(ctx, Project{
+		Name: "white-label", GithubRepo: "heyblueteam/blue", Branch: "main", Path: "app",
+	})
+
+	for _, c := range []struct {
+		id   int64
+		want int
+	}{{idA, 1}, {idB, 1}} {
+		n, err := db.OtherProjectsWithSameSource(ctx, c.id)
+		if err != nil {
+			t.Fatalf("query id=%d: %v", c.id, err)
+		}
+		if n != c.want {
+			t.Errorf("id=%d count: got %d, want %d", c.id, n, c.want)
+		}
+	}
+}
+
+// TestOtherProjectsWithSameSource_DifferentPath proves that two projects
+// sharing repo + branch but pointing at different sub-paths do NOT count
+// as siblings — they don't race on BuildKit's in-memory cache because
+// the build contexts are disjoint.
+func TestOtherProjectsWithSameSource_DifferentPath(t *testing.T) {
+	t.Parallel()
+	db := openTestDB(t)
+	ctx := context.Background()
+
+	idAPI, _ := db.CreateProject(ctx, Project{
+		Name: "api", GithubRepo: "heyblueteam/blue", Branch: "main", Path: "api",
+	})
+	_, _ = db.CreateProject(ctx, Project{
+		Name: "next", GithubRepo: "heyblueteam/blue", Branch: "main", Path: "app",
+	})
+	n, err := db.OtherProjectsWithSameSource(ctx, idAPI)
+	if err != nil {
+		t.Fatalf("query: %v", err)
+	}
+	if n != 0 {
+		t.Errorf("count: got %d, want 0 (different path)", n)
+	}
+}
+
+// TestOtherProjectsWithSameSource_DifferentBranch proves the branch
+// column participates in the match.
+func TestOtherProjectsWithSameSource_DifferentBranch(t *testing.T) {
+	t.Parallel()
+	db := openTestDB(t)
+	ctx := context.Background()
+
+	idA, _ := db.CreateProject(ctx, Project{
+		Name: "prod", GithubRepo: "heyblueteam/blue", Branch: "main", Path: "api",
+	})
+	_, _ = db.CreateProject(ctx, Project{
+		Name: "staging", GithubRepo: "heyblueteam/blue", Branch: "staging", Path: "api",
+	})
+	n, err := db.OtherProjectsWithSameSource(ctx, idA)
+	if err != nil {
+		t.Fatalf("query: %v", err)
+	}
+	if n != 0 {
+		t.Errorf("count: got %d, want 0 (different branch)", n)
+	}
+}
+
+// TestOtherProjectsWithSameSource_AfterUpdate proves the live-query
+// model — when one project's source changes via UpdateProjectSource so
+// it now matches another, both projects start reporting siblings without
+// any per-project state migration.
+func TestOtherProjectsWithSameSource_AfterUpdate(t *testing.T) {
+	t.Parallel()
+	db := openTestDB(t)
+	ctx := context.Background()
+
+	idA, _ := db.CreateProject(ctx, Project{
+		Name: "a", GithubRepo: "heyblueteam/blue", Branch: "main", Path: "api",
+	})
+	idB, _ := db.CreateProject(ctx, Project{
+		Name: "b", GithubRepo: "heyblueteam/blue", Branch: "main", Path: "app",
+	})
+
+	// Before update: different paths → no siblings.
+	if n, _ := db.OtherProjectsWithSameSource(ctx, idA); n != 0 {
+		t.Fatalf("before update, A: got %d, want 0", n)
+	}
+
+	// Retarget A to share the path with B.
+	if err := db.UpdateProjectSource(ctx, idA, "heyblueteam/blue", "main", "app"); err != nil {
+		t.Fatalf("UpdateProjectSource: %v", err)
+	}
+
+	for _, c := range []struct {
+		id   int64
+		want int
+	}{{idA, 1}, {idB, 1}} {
+		n, err := db.OtherProjectsWithSameSource(ctx, c.id)
+		if err != nil {
+			t.Fatalf("query id=%d: %v", c.id, err)
+		}
+		if n != c.want {
+			t.Errorf("after update id=%d: got %d, want %d", c.id, n, c.want)
+		}
+	}
+}
+
+// TestOtherProjectsWithSameSource_NonExistent proves a lookup against an
+// unknown ID returns (0, nil) — the caller (deploy builder) treats that
+// as "no siblings, use shared builder". Defensive: avoids surfacing a
+// transient race between project delete and an in-flight deploy as a
+// deploy-fatal error.
+func TestOtherProjectsWithSameSource_NonExistent(t *testing.T) {
+	t.Parallel()
+	db := openTestDB(t)
+	n, err := db.OtherProjectsWithSameSource(context.Background(), 99999)
+	if err != nil {
+		t.Fatalf("query: %v", err)
+	}
+	if n != 0 {
+		t.Errorf("count: got %d, want 0", n)
+	}
+}
+
 func TestActiveDeploymentNumbers(t *testing.T) {
 	t.Parallel()
 	db := openTestDB(t)

--- a/internal/server/store/projects_test.go
+++ b/internal/server/store/projects_test.go
@@ -354,6 +354,38 @@ func TestOtherProjectsWithSameSource_AfterUpdate(t *testing.T) {
 	}
 }
 
+// TestOtherProjectsWithSameSource_EmptyPath proves two projects sharing
+// repo + branch with path="" (repo-root deploys — the pre-0006-migration
+// shape, still the default) match as siblings. Guards against a future
+// schema change that makes path nullable: SQL tuple IN treats NULL as
+// non-equal to NULL, which would silently break sibling detection for
+// repo-root projects.
+func TestOtherProjectsWithSameSource_EmptyPath(t *testing.T) {
+	t.Parallel()
+	db := openTestDB(t)
+	ctx := context.Background()
+
+	idA, _ := db.CreateProject(ctx, Project{
+		Name: "root-a", GithubRepo: "heyblueteam/blue", Branch: "main", Path: "",
+	})
+	idB, _ := db.CreateProject(ctx, Project{
+		Name: "root-b", GithubRepo: "heyblueteam/blue", Branch: "main", Path: "",
+	})
+
+	for _, c := range []struct {
+		id   int64
+		want int
+	}{{idA, 1}, {idB, 1}} {
+		n, err := db.OtherProjectsWithSameSource(ctx, c.id)
+		if err != nil {
+			t.Fatalf("query id=%d: %v", c.id, err)
+		}
+		if n != c.want {
+			t.Errorf("id=%d count: got %d, want %d (empty-path siblings must match)", c.id, n, c.want)
+		}
+	}
+}
+
 // TestOtherProjectsWithSameSource_NonExistent proves a lookup against an
 // unknown ID returns (0, nil) — the caller (deploy builder) treats that
 // as "no siblings, use shared builder". Defensive: avoids surfacing a


### PR DESCRIPTION
## Summary

Closes the cross-tenant `--secret` cache leak from [#24](https://github.com/heyblueteam/cobalt/issues/24) without imposing a per-project `buildkitd` on every project.

A project is promoted to its own `cobalt-builder-<id>` only when at least one other project points at the same `(github_repo, branch, path)` tuple. Solo projects keep using the shared `cobalt-builder`, so the common case carries zero extra buildkitd overhead.

Plan: `plans/cobalt-per-project-builders-hybrid.md` in `heyblueteam/blue`.

## Changes

- **store** — `OtherProjectsWithSameSource(ctx, projectID)` runs the live `(repo, branch, path)` match. Returns `0` for a non-existent project (defensive: deploy continues with shared builder).
- **docker** — `EnsureBuildxBuilder` takes a name (was: hard-coded constant); `RemoveBuildxBuilder` added; `BuildOpts.BuilderName` threads through to `buildx build --builder <name>`. Empty → shared fallback so old callers stay on the shared builder.
- **deploy** — New `ProjectQuerier` seam (separate from `EnvLister` to keep responsibilities clean). `Builder.Build` decides shared vs isolated pre-build, ensures the isolated instance lazily, and bakes the choice into every image build for that deploy.
  - **Soft-fail** on store error: log + use shared. Cache race is rare; a transient store error shouldn't fail the deploy.
  - **Hard-fail** on `EnsureBuildxBuilder` error: we decided isolation is needed; silently using the shared builder would re-enter the race.
- **api** — `cleanupProjectArtifacts` now also `buildx rm --force cobalt-builder-<id>` on project delete (best-effort, debug-logged — missing builder is the common path for solo projects).

## Test plan

- [x] `go test ./...` green locally (all 21 packages)
- [x] New unit coverage:
  - store: solo / sibling / different-path / different-branch / after-update / non-existent
  - docker: `EnsureBuildxBuilder` custom name; `RemoveBuildxBuilder` argv; `BuildOpts.BuilderName` passthrough; empty-name fallback
  - deploy: solo uses shared; sibling triggers isolated + ensure; store error → shared + warning; ensure error → hard-fail
  - api: `DeleteProject` fires `buildx rm --force cobalt-builder-<id>`
- [ ] **Manual e2e** (post-merge, on `v0.17.0`):
  - Two projects sharing `repo@main:app`, distinct `BUILD_FLAG` env vars baked via `RUN --mount=type=secret,id=...`
  - Push commit → parallel deploys; each container's `/flag.txt` contains its project's value
  - `docker buildx ls` shows `cobalt-builder`, `cobalt-builder-<idA>`, `cobalt-builder-<idB>`
  - `cobalt projects remove` → the project's builder disappears
  - Solo project deploy uses only the shared builder

## Non-goals

- No retroactive rebuilds; next push picks up the right isolation.
- No teardown when a sibling disappears — builder lives until the project is deleted (cheap-to-keep, complexity-vs-savings).
- No CLI surface changes — `cobalt buildx prune` and `--force-isolated` listed as future enhancements in the plan.