### PR TITLE
feat(run): inject project env + COBALT_* context vars into one-off runs

### DIFF
--- a/docs/cobalt-cli-commands.md
+++ b/docs/cobalt-cli-commands.md
@@ -81,6 +81,8 @@ cobalt run [--project <p>] [--service <s>] [--timeout <secs>] "<command>"
 
 Implementation: WebSocket to the daemon, raw-mode TTY, exit code from the container is the CLI's exit code.
 
+**Container env.** The one-off container sees the project's full env (everything in `cobalt env list`) plus daemon-authoritative context vars: `COBALT_PROJECT_NAME`, `COBALT_SERVICE_NAME`, `COBALT_DEPLOYMENT_NUMBER`, `COBALT_HOST` (when the daemon has a public host configured), and `COBALT_COMMIT` (when the live deployment has a commit SHA). `COBALT_*` synthetic values override any project env of the same name for the duration of the run; the stored env is untouched.
+
 ### `cobalt init`
 
 Bootstrap a fresh server: install daemon via Docker, set up Caddy, register the first API key in local CLI config.

--- a/internal/server/api/run.go
+++ b/internal/server/api/run.go
@@ -5,8 +5,10 @@ import (
 	"encoding/json"
 	"errors"
 	"io"
+	"maps"
 	"net/http"
 	"os"
+	"strconv"
 	"sync"
 	"sync/atomic"
 	"time"
@@ -93,6 +95,34 @@ type runRequest struct {
 	deploymentNetwork string
 	extraParams       []string
 	volumes           []docker.ServiceVolume
+	// envVars is the merged env passed to the one-shot container: the
+	// project's full env (cobalt env list) overlaid by the synthetic
+	// COBALT_* context vars. Synthetic vars win on collision so the
+	// runtime identity is always daemon-authoritative.
+	envVars map[string]string
+}
+
+// cobaltSyntheticEnv builds the daemon-authoritative COBALT_* context
+// vars injected into every one-shot run container. These identify the
+// project / service / deployment the command is executing against;
+// apps that branch worker-vs-web behavior on a single image can read
+// COBALT_SERVICE_NAME instead of duplicating images.
+//
+// Optional vars are omitted (not set to "") when their source is empty
+// so shell checks like `if [ -n "$COBALT_HOST" ]` work as expected.
+func cobaltSyntheticEnv(project *store.Project, serviceName string, live *store.Deployment, publicHost string) map[string]string {
+	out := map[string]string{
+		"COBALT_PROJECT_NAME":      project.Name,
+		"COBALT_SERVICE_NAME":      serviceName,
+		"COBALT_DEPLOYMENT_NUMBER": strconv.Itoa(live.Number),
+	}
+	if publicHost != "" {
+		out["COBALT_HOST"] = publicHost
+	}
+	if live.CommitSHA != nil && *live.CommitSHA != "" {
+		out["COBALT_COMMIT"] = *live.CommitSHA
+	}
+	return out
 }
 
 // Run implements GET /api/projects/{name}/run as a WebSocket endpoint.
@@ -152,6 +182,20 @@ func (h *Handler) Run(w http.ResponseWriter, r *http.Request) {
 	// if the service isn't found or the cobaltfile is missing.
 	imageName, extraParams, volumes := resolveRunImage(live, project.ID, serviceName)
 
+	// Load the project's env (everything in `cobalt env`) and overlay
+	// the synthetic COBALT_* context vars. We soft-fail on store error
+	// because `cobalt run` is interactive — an operator should still be
+	// able to e.g. inspect a container when rqlite is having a bad
+	// time. Deploys hard-fail here; runs don't.
+	projectEnv, envErr := h.DB.EnvVarMap(r.Context(), project.ID)
+	if envErr != nil {
+		h.Log.Warn("run: env load failed; proceeding with synthetic only", "error", envErr)
+		projectEnv = map[string]string{}
+	}
+	runEnv := make(map[string]string, len(projectEnv)+5)
+	maps.Copy(runEnv, projectEnv)
+	maps.Copy(runEnv, cobaltSyntheticEnv(project, serviceName, live, h.PublicHost)) // synthetic wins on collision
+
 	conn, err := websocket.Accept(w, r, &websocket.AcceptOptions{
 		// v2 first so a client that speaks both wins v2.
 		Subprotocols: []string{
@@ -178,6 +222,7 @@ func (h *Handler) Run(w http.ResponseWriter, r *http.Request) {
 		deploymentNetwork: docker.NetworkName(project.Name, live.Number),
 		extraParams:       extraParams,
 		volumes:           volumes,
+		envVars:           runEnv,
 	}
 
 	// Audit row at handler entry. The exit code goes in once the
@@ -288,6 +333,7 @@ func (h *Handler) runV1(ctx context.Context, conn *websocket.Conn, req runReques
 		ContainerName:    docker.RunContainerName(req.project.Name, time.Now().UnixNano()),
 		Image:            req.imageTag,
 		Command:          []string{"sh", "-c", req.command},
+		EnvVars:          req.envVars,
 		Networks:         []string{req.deploymentNetwork, deploy.MainNetworkName},
 		Volumes:          req.volumes,
 		ExtraParams:      req.extraParams,

--- a/internal/server/api/run_test.go
+++ b/internal/server/api/run_test.go
@@ -41,6 +41,9 @@ type runFakeDocker struct {
 	// (echo) until stdin closes, then return runErr. Tests override
 	// onRun to do something different.
 	onRun func(stdin io.Reader, stdout, stderr io.Writer) error
+	// lastRunArgs captures the most recent `docker run` argv, so tests
+	// can assert on flags wired up by the handler (e.g. `--env K=V`).
+	lastRunArgs []string
 }
 
 func (f *runFakeDocker) Run(ctx context.Context, args []string, stdin io.Reader, stdout, stderr io.Writer) error {
@@ -50,6 +53,9 @@ func (f *runFakeDocker) Run(ctx context.Context, args []string, stdin io.Reader,
 func (f *runFakeDocker) RunWithEnv(_ context.Context, _ map[string]string, args []string, stdin io.Reader, stdout, stderr io.Writer) error {
 	f.mu.Lock()
 	cb := f.onRun
+	if len(args) > 0 && args[0] == "run" {
+		f.lastRunArgs = append([]string(nil), args...)
+	}
 	f.mu.Unlock()
 	if cb == nil {
 		// Default: echo stdin → stdout, exit 0.
@@ -64,6 +70,27 @@ func (f *runFakeDocker) RunWithEnv(_ context.Context, _ map[string]string, args 
 		return nil
 	}
 	return cb(stdin, stdout, stderr)
+}
+
+// runEnvVars returns the `KEY=VALUE` pairs that followed `--env` in
+// the most recent `docker run` invocation, parsed into a map.
+func (f *runFakeDocker) runEnvVars() map[string]string {
+	f.mu.Lock()
+	args := append([]string(nil), f.lastRunArgs...)
+	f.mu.Unlock()
+	out := map[string]string{}
+	for i := 0; i+1 < len(args); i++ {
+		if args[i] != "--env" {
+			continue
+		}
+		kv := args[i+1]
+		eq := strings.IndexByte(kv, '=')
+		if eq < 0 {
+			continue
+		}
+		out[kv[:eq]] = kv[eq+1:]
+	}
+	return out
 }
 
 func newRunEnv(t *testing.T) *runEnv {
@@ -302,6 +329,141 @@ func TestRun_RealExitCodePropagated(t *testing.T) {
 	last := frames[len(frames)-1]
 	if last.Code != 42 {
 		t.Errorf("exit code: %d, want 42", last.Code)
+	}
+}
+
+func TestCobaltSyntheticEnv(t *testing.T) {
+	t.Parallel()
+	ptr := func(s string) *string { return &s }
+	project := &store.Project{Name: "api"}
+
+	cases := []struct {
+		name       string
+		live       *store.Deployment
+		publicHost string
+		wantKeys   []string
+		notWant    []string
+		wantValues map[string]string
+	}{
+		{
+			name:       "minimal: no host, no commit",
+			live:       &store.Deployment{Number: 7},
+			publicHost: "",
+			wantKeys:   []string{"COBALT_PROJECT_NAME", "COBALT_SERVICE_NAME", "COBALT_DEPLOYMENT_NUMBER"},
+			notWant:    []string{"COBALT_HOST", "COBALT_COMMIT"},
+			wantValues: map[string]string{
+				"COBALT_PROJECT_NAME":      "api",
+				"COBALT_SERVICE_NAME":      "web",
+				"COBALT_DEPLOYMENT_NUMBER": "7",
+			},
+		},
+		{
+			name:       "with host configured",
+			live:       &store.Deployment{Number: 1},
+			publicHost: "cobalt.blue.cc",
+			wantKeys:   []string{"COBALT_HOST"},
+			wantValues: map[string]string{"COBALT_HOST": "cobalt.blue.cc"},
+		},
+		{
+			name:       "with commit set",
+			live:       &store.Deployment{Number: 1, CommitSHA: ptr("deadbeef")},
+			publicHost: "",
+			wantKeys:   []string{"COBALT_COMMIT"},
+			wantValues: map[string]string{"COBALT_COMMIT": "deadbeef"},
+		},
+		{
+			name:       "empty-string commit is treated as absent",
+			live:       &store.Deployment{Number: 1, CommitSHA: ptr("")},
+			publicHost: "",
+			notWant:    []string{"COBALT_COMMIT"},
+		},
+	}
+	for _, c := range cases {
+		t.Run(c.name, func(t *testing.T) {
+			got := cobaltSyntheticEnv(project, "web", c.live, c.publicHost)
+			for _, k := range c.wantKeys {
+				if _, ok := got[k]; !ok {
+					t.Errorf("missing key %q in %v", k, got)
+				}
+			}
+			for _, k := range c.notWant {
+				if _, ok := got[k]; ok {
+					t.Errorf("unexpected key %q in %v", k, got)
+				}
+			}
+			for k, want := range c.wantValues {
+				if got[k] != want {
+					t.Errorf("%s: got %q, want %q", k, got[k], want)
+				}
+			}
+		})
+	}
+}
+
+// drainAndClose dials the WS, lets the fake docker run-and-exit, and
+// returns once frames have flowed. Tests inspect captured argv after.
+func (e *runEnv) drainRun(t *testing.T, project, command string) {
+	t.Helper()
+	conn := e.dial(t, project, "command="+url.QueryEscape(command))
+	defer conn.CloseNow()
+	ctx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
+	defer cancel()
+	_ = readFrames(t, conn, ctx)
+}
+
+func TestRun_InjectsProjectAndSyntheticEnv(t *testing.T) {
+	t.Parallel()
+	e := newRunEnv(t)
+	e.seedLiveDeploy("api", `{"version":"1.0","services":{"web":{"port":3000}}}`)
+
+	proj, err := e.db.GetProjectByName(context.Background(), "api")
+	if err != nil {
+		t.Fatalf("GetProjectByName: %v", err)
+	}
+	if err := e.db.SetEnvVar(context.Background(), proj.ID, "FIREBASE_PRIVATE_KEY", "secret-value"); err != nil {
+		t.Fatalf("SetEnvVar: %v", err)
+	}
+
+	// Stage a benign docker invocation.
+	e.docker.onRun = func(_ io.Reader, _, _ io.Writer) error { return nil }
+
+	e.drainRun(t, "api", "true")
+
+	got := e.docker.runEnvVars()
+	if got["FIREBASE_PRIVATE_KEY"] != "secret-value" {
+		t.Errorf("project env missing: got %q", got["FIREBASE_PRIVATE_KEY"])
+	}
+	if got["COBALT_PROJECT_NAME"] != "api" {
+		t.Errorf("COBALT_PROJECT_NAME: got %q, want %q", got["COBALT_PROJECT_NAME"], "api")
+	}
+	if got["COBALT_SERVICE_NAME"] != "web" {
+		t.Errorf("COBALT_SERVICE_NAME: got %q, want %q", got["COBALT_SERVICE_NAME"], "web")
+	}
+	if got["COBALT_DEPLOYMENT_NUMBER"] != "1" {
+		t.Errorf("COBALT_DEPLOYMENT_NUMBER: got %q, want %q", got["COBALT_DEPLOYMENT_NUMBER"], "1")
+	}
+}
+
+func TestRun_SyntheticOverridesProjectEnv(t *testing.T) {
+	t.Parallel()
+	e := newRunEnv(t)
+	e.seedLiveDeploy("api", `{"version":"1.0","services":{"web":{"port":3000}}}`)
+
+	proj, err := e.db.GetProjectByName(context.Background(), "api")
+	if err != nil {
+		t.Fatalf("GetProjectByName: %v", err)
+	}
+	// User-set value that collides with a daemon-authoritative var.
+	if err := e.db.SetEnvVar(context.Background(), proj.ID, "COBALT_PROJECT_NAME", "hacked"); err != nil {
+		t.Fatalf("SetEnvVar: %v", err)
+	}
+
+	e.docker.onRun = func(_ io.Reader, _, _ io.Writer) error { return nil }
+	e.drainRun(t, "api", "true")
+
+	got := e.docker.runEnvVars()
+	if got["COBALT_PROJECT_NAME"] != "api" {
+		t.Errorf("synthetic should override project env: got %q, want %q", got["COBALT_PROJECT_NAME"], "api")
 	}
 }
 

--- a/internal/server/api/run_v2.go
+++ b/internal/server/api/run_v2.go
@@ -127,6 +127,7 @@ func (h *Handler) runV2(ctx context.Context, conn *websocket.Conn, req runReques
 		ContainerName:    docker.RunContainerName(req.project.Name, time.Now().UnixNano()),
 		Image:            req.imageTag,
 		Command:          []string{"sh", "-c", req.command},
+		EnvVars:          req.envVars,
 		Networks:         []string{req.deploymentNetwork, deploy.MainNetworkName},
 		Volumes:          req.volumes,
 		ExtraParams:      req.extraParams,

--- a/internal/server/api/run_v2_test.go
+++ b/internal/server/api/run_v2_test.go
@@ -74,6 +74,36 @@ func writeV2(t *testing.T, conn *websocket.Conn, ctx context.Context, ch byte, b
 	}
 }
 
+func TestRunV2_InjectsProjectAndSyntheticEnv(t *testing.T) {
+	t.Parallel()
+	e := newRunEnv(t)
+	e.seedLiveDeploy("api", `{"version":"1.0","services":{"web":{"port":3000}}}`)
+
+	proj, err := e.db.GetProjectByName(context.Background(), "api")
+	if err != nil {
+		t.Fatalf("GetProjectByName: %v", err)
+	}
+	if err := e.db.SetEnvVar(context.Background(), proj.ID, "FIREBASE_PRIVATE_KEY", "v2-secret"); err != nil {
+		t.Fatalf("SetEnvVar: %v", err)
+	}
+
+	e.docker.onRun = func(_ io.Reader, _, _ io.Writer) error { return nil }
+
+	conn := e.dialV2(t, "api", "command="+url.QueryEscape("true"))
+	defer conn.CloseNow()
+	ctx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
+	defer cancel()
+	_ = readV2Frames(t, conn, ctx)
+
+	got := e.docker.runEnvVars()
+	if got["FIREBASE_PRIVATE_KEY"] != "v2-secret" {
+		t.Errorf("v2: project env missing: got %q", got["FIREBASE_PRIVATE_KEY"])
+	}
+	if got["COBALT_PROJECT_NAME"] != "api" {
+		t.Errorf("v2: COBALT_PROJECT_NAME: got %q, want %q", got["COBALT_PROJECT_NAME"], "api")
+	}
+}
+
 func TestRunV2_NegotiatesV2WhenOffered(t *testing.T) {
 	t.Parallel()
 	e := newRunEnv(t)


### PR DESCRIPTION
## Summary

`cobalt run` containers now see the project's full env (everything in `cobalt env list`) plus a small set of daemon-authoritative `COBALT_*` context vars:

- `COBALT_PROJECT_NAME`
- `COBALT_SERVICE_NAME`
- `COBALT_DEPLOYMENT_NUMBER`
- `COBALT_HOST` (omitted when the daemon has no `PublicHost`)
- `COBALT_COMMIT` (omitted when the live deployment has no SHA)

## Why

Surfaced while running a password-reset Node script via `cobalt run --project api` for a support ticket. `process.env.FIREBASE_PRIVATE_KEY` came back `undefined` and the script crashed. Root cause: the run handler built `docker.RunOpts{}` without `EnvVars`, even though the docker layer fully supports it and the deploy-hook path already uses it. So one-off runs and hooks had divergent views of the world.

Also restores disco parity — disco emitted the project's env plus `DISCO_PROJECT_NAME` / `DISCO_SERVICE_NAME` / `DISCO_HOST` / `DISCO_DEPLOYMENT_NUMBER` / `DISCO_COMMIT` on every one-off run. Ported runbooks now work with a search-and-replace.

## Behavior notes

- **Synthetic wins on collision.** If a user sets `COBALT_PROJECT_NAME` via `cobalt env`, the synthetic value still wins for the duration of the run. The stored env is untouched. Daemon-authoritative because the whole point of the context vars is to be a trustworthy answer to "where am I running."
- **Optional vars are omitted, not empty.** `COBALT_HOST` and `COBALT_COMMIT` don't show up as empty strings — they're absent. So shell checks like `if [ -n "$COBALT_HOST" ]` work as expected.
- **Soft-fail on `EnvVarMap` error.** Deploys hard-fail here; runs don't. `cobalt run` is interactive — operators should still be able to inspect a container when the store is degraded. Synthetic vars work regardless.

## Test plan

- [x] `go test ./...` — full suite green
- [x] `go vet ./...` clean
- [x] Unit test `TestCobaltSyntheticEnv` covers commit/host present/absent
- [x] Integration test `TestRun_InjectsProjectAndSyntheticEnv` confirms both project env and synthetic vars reach `docker run --env`
- [x] Integration test `TestRun_SyntheticOverridesProjectEnv` confirms collision rule end-to-end
- [x] Integration test `TestRunV2_InjectsProjectAndSyntheticEnv` confirms v2 wiring matches v1
- [ ] After deploy: `cobalt run --project api 'echo \$COBALT_PROJECT_NAME'` prints `api`
- [ ] After deploy: re-run the support-agent reset flow (originally blocked by this bug) end-to-end