### PR TITLE
fix(caddy): stop reconciler reverting in-flight deploy swaps + self-heal wedged admin

### DIFF
--- a/internal/server/caddy/client.go
+++ b/internal/server/caddy/client.go
@@ -218,6 +218,35 @@ func (c *Client) doOnce(ctx context.Context, method, path string, body, out any)
 	return nil
 }
 
+// PingTimeout bounds a single admin liveness probe. Deliberately short: it's
+// a health check, not a real operation, and must surface a wedged admin
+// socket in seconds rather than inheriting the 60s operation timeout.
+const PingTimeout = 5 * time.Second
+
+// Ping reports whether Caddy's admin endpoint is responsive.
+//
+// It deliberately does NOT take adminMu. When the admin API wedges, an
+// in-flight operation can hold adminMu for minutes (60s timeout × retries),
+// so a probe that queued behind it could never observe the wedge it exists
+// to detect. Ping issues a raw round-trip with its own short deadline.
+//
+// Any HTTP response — even a 4xx/404 — means the admin API is alive and
+// answering; only a transport error (timeout, connection refused, EOF) is a
+// failure. The watchdog acts on the latter.
+func (c *Client) Ping(ctx context.Context) error {
+	ctx, cancel := context.WithTimeout(ctx, PingTimeout)
+	defer cancel()
+	err := c.doOnce(ctx, http.MethodGet, "/config/apps/http/servers", nil, nil)
+	if err == nil {
+		return nil
+	}
+	var he *HTTPError
+	if errors.As(err, &he) {
+		return nil
+	}
+	return err
+}
+
 // HTTPError is returned for non-2xx Caddy responses.
 type HTTPError struct {
 	Status int

--- a/internal/server/caddy/currentdomains_ping_test.go
+++ b/internal/server/caddy/currentdomains_ping_test.go
@@ -1,0 +1,88 @@
+package caddy
+
+import (
+	"context"
+	"net/http"
+	"net/http/httptest"
+	"reflect"
+	"testing"
+)
+
+func TestCurrentDomains_ReturnsHostList(t *testing.T) {
+	t.Parallel()
+	wantPath := "/id/" + ProjectHostsID(7) + "/host"
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.URL.Path != wantPath {
+			t.Errorf("path: got %q, want %q", r.URL.Path, wantPath)
+		}
+		w.Header().Set("Content-Type", "application/json")
+		_, _ = w.Write([]byte(`["api.example.com","www.example.com"]`))
+	}))
+	defer srv.Close()
+
+	c := NewHTTPClient(srv.URL, srv.Client())
+	got, err := c.CurrentDomains(context.Background(), 7)
+	if err != nil {
+		t.Fatalf("CurrentDomains: %v", err)
+	}
+	if want := []string{"api.example.com", "www.example.com"}; !reflect.DeepEqual(got, want) {
+		t.Errorf("hosts: got %v, want %v", got, want)
+	}
+}
+
+func TestCurrentDomains_NotFoundReturnsNil(t *testing.T) {
+	t.Parallel()
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		w.WriteHeader(http.StatusNotFound)
+	}))
+	defer srv.Close()
+
+	c := NewHTTPClient(srv.URL, srv.Client())
+	got, err := c.CurrentDomains(context.Background(), 7)
+	if err != nil {
+		t.Fatalf("CurrentDomains on 404 should be nil error, got: %v", err)
+	}
+	if got != nil {
+		t.Errorf("hosts on 404: got %v, want nil", got)
+	}
+}
+
+func TestPing_AliveOn2xx(t *testing.T) {
+	t.Parallel()
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		_, _ = w.Write([]byte(`{}`))
+	}))
+	defer srv.Close()
+
+	c := NewHTTPClient(srv.URL, srv.Client())
+	if err := c.Ping(context.Background()); err != nil {
+		t.Errorf("Ping on 2xx: %v", err)
+	}
+}
+
+func TestPing_AliveOn4xx(t *testing.T) {
+	t.Parallel()
+	// A 404 from the admin API still means it's answering → alive.
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		w.WriteHeader(http.StatusNotFound)
+	}))
+	defer srv.Close()
+
+	c := NewHTTPClient(srv.URL, srv.Client())
+	if err := c.Ping(context.Background()); err != nil {
+		t.Errorf("Ping on 404 should report alive, got: %v", err)
+	}
+}
+
+func TestPing_FailsOnTransportError(t *testing.T) {
+	t.Parallel()
+	srv := httptest.NewServer(http.HandlerFunc(func(http.ResponseWriter, *http.Request) {}))
+	url := srv.URL
+	srv.Close() // connection now refused
+
+	c := NewHTTPClient(url, &http.Client{})
+	if err := c.Ping(context.Background()); err == nil {
+		t.Error("Ping should return a transport error when the admin endpoint is unreachable")
+	}
+}

--- a/internal/server/caddy/routes.go
+++ b/internal/server/caddy/routes.go
@@ -103,3 +103,21 @@ func (c *Client) ProjectRouteExists(ctx context.Context, projectID int64) (bool,
 	}
 	return false, fmt.Errorf("caddy: project route exists check: %w", err)
 }
+
+// CurrentDomains returns the host list on the project's match block as Caddy
+// currently holds it. Implemented as a targeted GET on the hosts @id so we
+// don't walk the full config tree (mirrors CurrentUpstream).
+//
+// Returns nil (not an error) when the project has no route or no host
+// matcher yet, so callers treat "absent" as "differs from any desired set".
+func (c *Client) CurrentDomains(ctx context.Context, projectID int64) ([]string, error) {
+	var hosts []string
+	err := c.do(ctx, http.MethodGet, "/id/"+ProjectHostsID(projectID)+"/host", nil, &hosts)
+	if err != nil {
+		if IsNotFound(err) {
+			return nil, nil
+		}
+		return nil, fmt.Errorf("caddy: read current domains: %w", err)
+	}
+	return hosts, nil
+}

--- a/internal/server/docker/service.go
+++ b/internal/server/docker/service.go
@@ -154,6 +154,14 @@ func (c *Client) ScaleService(ctx context.Context, name string, replicas int) er
 	return c.run(ctx, "service", "scale", fmt.Sprintf("%s=%d", name, replicas))
 }
 
+// RestartService forces a rolling restart of an existing swarm service in
+// place — same config, fresh tasks — via `docker service update --force`.
+// The Caddy watchdog uses it to recover a wedged admin endpoint without a
+// human SSHing in to `docker restart`.
+func (c *Client) RestartService(ctx context.Context, name string) error {
+	return c.run(ctx, "service", "update", "--force", name)
+}
+
 // ServiceInfo summarizes a swarm service's identity.
 type ServiceInfo struct {
 	Name             string

--- a/internal/server/server.go
+++ b/internal/server/server.go
@@ -264,6 +264,7 @@ func newCaddyClient(cfg Config) *caddy.Client {
 //   - network cleanup         hourly  (prune overlay networks for inactive deploys)
 //   - pending app cleanup     10m     (drop expired manifest-flow rows)
 //   - caddy reconcile         30s     (root fix for upstream issue #97)
+//   - caddy watchdog          30s     (auto-restart Caddy if admin wedges)
 //   - deploy log rotation     daily   (gzip > 30d, purge gz > 1y)
 func registerScheduledJobs(
 	sched *worker.Scheduler,
@@ -294,6 +295,8 @@ func registerScheduledJobs(
 			log.Warn("caddy reconcile failed", "error", err)
 		}
 	})
+	caddyWatchdog := worker.NewCaddyWatchdog(caddyCli, dockerCli, worker.DefaultCaddyServiceName, log)
+	_ = sched.Schedule("caddy-watchdog", "@every 30s", caddyWatchdog.Tick)
 	_ = sched.Schedule("deploy-log-rotation", "@daily", func(ctx context.Context) {
 		if _, _, err := worker.RotateDeployLogs(ctx, log, dataDir, 0, 0, time.Now()); err != nil {
 			log.Warn("deploy log rotation failed", "error", err)

--- a/internal/server/worker/caddy_reconcile.go
+++ b/internal/server/worker/caddy_reconcile.go
@@ -22,6 +22,11 @@ type CaddyReconcileStore interface {
 	// by separate Caddy `cobalt-redirect-*` routes and reconciled out
 	// of band by the API domain handlers.
 	ListPrimaryDomainsForProject(ctx context.Context, projectID int64) ([]string, error)
+	// ActiveDeploymentForProject returns the project's in-flight deployment
+	// (fetching/building/swapping), or store.ErrNotFound if none. The
+	// reconciler uses it to stand down while a deploy owns the project's
+	// Caddy state — see reconcileProject.
+	ActiveDeploymentForProject(ctx context.Context, projectID int64) (*store.Deployment, error)
 }
 
 // CaddyReconcileTarget is the Caddy subset the reconciler talks to.
@@ -29,6 +34,7 @@ type CaddyReconcileTarget interface {
 	ProjectRouteExists(ctx context.Context, projectID int64) (bool, error)
 	AddProjectRoute(ctx context.Context, projectID int64, domains []string) error
 	CurrentUpstream(ctx context.Context, projectID int64) (string, error)
+	CurrentDomains(ctx context.Context, projectID int64) ([]string, error)
 	ServeService(ctx context.Context, projectID int64, container string, port int) error
 	ServeStaticSite(ctx context.Context, projectID int64, projectName string, deploymentNumber int) error
 	SetDomainsForProject(ctx context.Context, projectID int64, domains []string) error
@@ -94,6 +100,21 @@ func reconcileProject(
 	cy CaddyReconcileTarget,
 	p store.Project,
 ) (bool, error) {
+	// Stand down while a deploy is in flight. A deploy owns its project's
+	// Caddy state end-to-end (start services → swap upstream → verify →
+	// mark success). The reconciler's notion of "desired" is the LAST
+	// SUCCESSFUL deployment, which is stale during a deploy: acting on it
+	// here PATCHes the upstream back to the previous container while the
+	// deploy is swapping to the new one, so the deploy's verify reads the
+	// reverted value and fails ("serve verify drifted"). Skip until the
+	// deploy reaches a terminal state; the post-deploy state is then
+	// authoritative and we reconcile against it normally.
+	if _, err := st.ActiveDeploymentForProject(ctx, p.ID); err == nil {
+		return false, nil
+	} else if !errors.Is(err, store.ErrNotFound) {
+		return false, fmt.Errorf("check active deployment: %w", err)
+	}
+
 	live, err := st.GetLastSuccessfulDeployment(ctx, p.ID)
 	if errors.Is(err, store.ErrNotFound) {
 		return false, nil // never deployed; nothing to reconcile
@@ -139,9 +160,20 @@ func reconcileProject(
 		return reapplyHandler(ctx, cy, p, *live, web)
 	}
 
-	// Domains may have drifted since last deploy.
-	if err := cy.SetDomainsForProject(ctx, p.ID, domains); err != nil {
-		return false, fmt.Errorf("set domains: %w", err)
+	// Domains may have drifted since last deploy — but only PATCH when they
+	// actually differ. Every admin PATCH triggers a full Caddy config reload
+	// (8-12s on a busy server, re-provisioning all TLS-managed domains), so
+	// re-asserting an unchanged host list for every project every cycle is
+	// pure load on the admin endpoint and a prior contributor to its
+	// saturation. Read the live host set and skip the no-op case.
+	liveDomains, err := cy.CurrentDomains(ctx, p.ID)
+	if err != nil {
+		return false, fmt.Errorf("read current domains: %w", err)
+	}
+	if !sameHostSet(liveDomains, domains) {
+		if err := cy.SetDomainsForProject(ctx, p.ID, domains); err != nil {
+			return false, fmt.Errorf("set domains: %w", err)
+		}
 	}
 
 	switch web.Type {
@@ -194,6 +226,26 @@ func reapplyHandler(
 		return false, fmt.Errorf("unsupported web type %q", web.Type)
 	}
 	return true, nil
+}
+
+// sameHostSet reports whether a and b contain the same hosts, ignoring
+// order. Caddy's host matcher is order-independent, so a reordered list is
+// not drift and must not trigger a reload.
+func sameHostSet(a, b []string) bool {
+	if len(a) != len(b) {
+		return false
+	}
+	counts := make(map[string]int, len(a))
+	for _, h := range a {
+		counts[h]++
+	}
+	for _, h := range b {
+		counts[h]--
+		if counts[h] < 0 {
+			return false
+		}
+	}
+	return true
 }
 
 // Compile-time interface satisfaction checks. Production wiring uses

--- a/internal/server/worker/caddy_reconcile_test.go
+++ b/internal/server/worker/caddy_reconcile_test.go
@@ -17,13 +17,25 @@ import (
 type fakeReconcileStore struct {
 	projects   []store.Project
 	lastByID   map[int64]*store.Deployment
+	active     map[int64]*store.Deployment
 	domains    map[int64][]string
 	listErr    error
+	activeErr  error
 	domainsErr error
 }
 
 func (f *fakeReconcileStore) ListProjects(_ context.Context) ([]store.Project, error) {
 	return f.projects, f.listErr
+}
+
+func (f *fakeReconcileStore) ActiveDeploymentForProject(_ context.Context, projectID int64) (*store.Deployment, error) {
+	if f.activeErr != nil {
+		return nil, f.activeErr
+	}
+	if d := f.active[projectID]; d != nil {
+		return d, nil
+	}
+	return nil, store.ErrNotFound
 }
 
 func (f *fakeReconcileStore) GetLastSuccessfulDeployment(_ context.Context, projectID int64) (*store.Deployment, error) {
@@ -43,10 +55,12 @@ func (f *fakeReconcileStore) ListPrimaryDomainsForProject(_ context.Context, pro
 type fakeReconcileCaddy struct {
 	mu sync.Mutex
 
-	routeExists    map[int64]bool
-	routeExistsErr error
-	upstream       map[int64]string
-	domainsErr     error
+	routeExists      map[int64]bool
+	routeExistsErr   error
+	upstream         map[int64]string
+	currentDomains   map[int64][]string
+	currentDomainErr error
+	domainsErr       error
 
 	addCalls    []int64
 	serveCalls  []serveServiceCall
@@ -71,9 +85,16 @@ type domainCall struct {
 
 func newFakeReconcileCaddy() *fakeReconcileCaddy {
 	return &fakeReconcileCaddy{
-		routeExists: map[int64]bool{},
-		upstream:    map[int64]string{},
+		routeExists:    map[int64]bool{},
+		upstream:       map[int64]string{},
+		currentDomains: map[int64][]string{},
 	}
+}
+
+func (f *fakeReconcileCaddy) CurrentDomains(_ context.Context, id int64) ([]string, error) {
+	f.mu.Lock()
+	defer f.mu.Unlock()
+	return f.currentDomains[id], f.currentDomainErr
 }
 
 func (f *fakeReconcileCaddy) ProjectRouteExists(_ context.Context, id int64) (bool, error) {
@@ -608,6 +629,120 @@ func TestReconcile_ProjectRouteExistsError_DoesNotHaltSweep(t *testing.T) {
 	_, err := ReconcileCaddyState(context.Background(), quietLogger(), st, cy)
 	if err != nil {
 		t.Fatalf("Reconcile: error should be nil (per-project failure absorbed), got: %v", err)
+	}
+}
+
+func TestReconcile_SkipsProjectWithActiveDeployment(t *testing.T) {
+	t.Parallel()
+	cf := mustCobaltfileJSON(t, &cobaltfile.Cobaltfile{
+		Version: "1.0",
+		Services: map[string]cobaltfile.Service{
+			"web": {Type: cobaltfile.TypeContainer, Image: "default", Port: 3000},
+		},
+		Images: map[string]cobaltfile.Image{"default": {Dockerfile: "Dockerfile", Context: "."}},
+	})
+	st := &fakeReconcileStore{
+		projects: []store.Project{{ID: 1, Name: "api"}},
+		lastByID: map[int64]*store.Deployment{
+			1: {ID: 10, ProjectID: 1, Number: 7, Status: cobaltapi.StateSuccess, ResolvedCobaltfile: nullStr(cf)},
+		},
+		// A deploy is mid-swap: it owns the project's Caddy state right now.
+		active: map[int64]*store.Deployment{
+			1: {ID: 11, ProjectID: 1, Number: 8, Status: cobaltapi.StateSwapping},
+		},
+		domains: map[int64][]string{1: {"api.example.com"}},
+	}
+	cy := newFakeReconcileCaddy()
+	cy.routeExists[1] = true
+	cy.upstream[1] = "api-5-web" // drifted — would normally be "corrected" back to api-7-web
+
+	corrected, err := ReconcileCaddyState(context.Background(), quietLogger(), st, cy)
+	if err != nil {
+		t.Fatalf("Reconcile: %v", err)
+	}
+	if corrected != 0 {
+		t.Errorf("corrected: got %d, want 0 (project has an in-flight deploy)", corrected)
+	}
+	// The reconciler must not touch Caddy at all for an in-flight project —
+	// doing so is exactly what reverts the deploy's swap.
+	if len(cy.serveCalls)+len(cy.domainCalls)+len(cy.addCalls)+len(cy.staticCalls) != 0 {
+		t.Errorf("reconciler mutated Caddy for an in-flight project: serve=%d domain=%d add=%d static=%d",
+			len(cy.serveCalls), len(cy.domainCalls), len(cy.addCalls), len(cy.staticCalls))
+	}
+}
+
+func TestReconcile_DomainsInSync_SkipsSetDomains(t *testing.T) {
+	t.Parallel()
+	cf := mustCobaltfileJSON(t, &cobaltfile.Cobaltfile{
+		Version: "1.0",
+		Services: map[string]cobaltfile.Service{
+			"web": {Type: cobaltfile.TypeContainer, Image: "default", Port: 3000},
+		},
+		Images: map[string]cobaltfile.Image{"default": {Dockerfile: "Dockerfile", Context: "."}},
+	})
+	st := &fakeReconcileStore{
+		projects: []store.Project{{ID: 1, Name: "api"}},
+		lastByID: map[int64]*store.Deployment{
+			1: {ID: 10, ProjectID: 1, Number: 7, Status: cobaltapi.StateSuccess, ResolvedCobaltfile: nullStr(cf)},
+		},
+		domains: map[int64][]string{1: {"api.example.com", "www.api.example.com"}},
+	}
+	cy := newFakeReconcileCaddy()
+	cy.routeExists[1] = true
+	cy.upstream[1] = "api-7-web"
+	// Live host set matches desired (order intentionally swapped to prove the
+	// set comparison ignores ordering).
+	cy.currentDomains[1] = []string{"www.api.example.com", "api.example.com"}
+
+	corrected, err := ReconcileCaddyState(context.Background(), quietLogger(), st, cy)
+	if err != nil {
+		t.Fatalf("Reconcile: %v", err)
+	}
+	if corrected != 0 {
+		t.Errorf("corrected: got %d, want 0", corrected)
+	}
+	if len(cy.domainCalls) != 0 {
+		t.Errorf("SetDomainsForProject called %d times when domains in sync (should be 0)", len(cy.domainCalls))
+	}
+}
+
+func TestReconcile_DomainsDriftedSet_TriggersSetDomains(t *testing.T) {
+	t.Parallel()
+	cf := mustCobaltfileJSON(t, &cobaltfile.Cobaltfile{
+		Version: "1.0",
+		Services: map[string]cobaltfile.Service{
+			"web": {Type: cobaltfile.TypeContainer, Image: "default", Port: 3000},
+		},
+		Images: map[string]cobaltfile.Image{"default": {Dockerfile: "Dockerfile", Context: "."}},
+	})
+	st := &fakeReconcileStore{
+		projects: []store.Project{{ID: 1, Name: "api"}},
+		lastByID: map[int64]*store.Deployment{
+			1: {ID: 10, ProjectID: 1, Number: 7, Status: cobaltapi.StateSuccess, ResolvedCobaltfile: nullStr(cf)},
+		},
+		domains: map[int64][]string{1: {"api.example.com", "new.example.com"}},
+	}
+	cy := newFakeReconcileCaddy()
+	cy.routeExists[1] = true
+	cy.upstream[1] = "api-7-web"
+	cy.currentDomains[1] = []string{"api.example.com"} // missing new.example.com
+
+	if _, err := ReconcileCaddyState(context.Background(), quietLogger(), st, cy); err != nil {
+		t.Fatalf("Reconcile: %v", err)
+	}
+	if len(cy.domainCalls) != 1 {
+		t.Fatalf("SetDomainsForProject calls: %d, want 1 (domains drifted)", len(cy.domainCalls))
+	}
+}
+
+func TestReconcile_ActiveDeploymentCheckError_DoesNotHaltSweep(t *testing.T) {
+	t.Parallel()
+	st := &fakeReconcileStore{
+		projects:  []store.Project{{ID: 1, Name: "api"}},
+		activeErr: errors.New("rqlite unreachable"),
+	}
+	if _, err := ReconcileCaddyState(context.Background(), quietLogger(), st, newFakeReconcileCaddy()); err != nil {
+		t.Fatalf("Reconcile: per-project failure should be absorbed, got: %v", err)
 	}
 }
 

--- a/internal/server/worker/caddy_watchdog.go
+++ b/internal/server/worker/caddy_watchdog.go
@@ -1,0 +1,126 @@
+package worker
+
+import (
+	"context"
+	"log/slog"
+	"sync"
+	"time"
+)
+
+// CaddyPinger is the admin-liveness probe the watchdog calls each tick.
+type CaddyPinger interface {
+	Ping(ctx context.Context) error
+}
+
+// CaddyServiceRestarter restarts the swarm service running Caddy.
+type CaddyServiceRestarter interface {
+	RestartService(ctx context.Context, name string) error
+}
+
+// DefaultCaddyServiceName is the swarm service the watchdog restarts when
+// Caddy's admin endpoint goes unresponsive. `docker stack deploy` prefixes
+// service names with the stack name, so the cobalt stack's caddy service is
+// "cobalt_caddy".
+const DefaultCaddyServiceName = "cobalt_caddy"
+
+const (
+	// defaultWatchdogThreshold is how many consecutive failed probes must
+	// accumulate before the watchdog restarts Caddy. At the @every 30s tick
+	// this is ~90s of sustained unresponsiveness — long enough to ride out a
+	// transient blip, short enough to recover before deploys pile up.
+	defaultWatchdogThreshold = 3
+	// defaultWatchdogCooldown is the minimum gap between auto-restarts.
+	// Restarting Caddy is a ~1-2s interruption across ALL sites, so if a
+	// restart doesn't fix the wedge we back off rather than thrash a shared
+	// proxy.
+	defaultWatchdogCooldown = 5 * time.Minute
+)
+
+// CaddyWatchdog probes Caddy's admin endpoint and force-restarts the Caddy
+// swarm service when it goes unresponsive for several consecutive ticks.
+//
+// Why this exists: Caddy's data plane keeps serving traffic while its admin
+// API (a unix socket) wedges — at which point cobalt can no longer swap
+// upstreams and every deploy hangs or fails its verify. Recovery used to be
+// a manual SSH `docker restart`; this automates it. Because restarting Caddy
+// briefly interrupts every site, the watchdog is deliberately conservative:
+// it acts only after `threshold` consecutive failures and never more often
+// than `cooldown`.
+type CaddyWatchdog struct {
+	ping        CaddyPinger
+	docker      CaddyServiceRestarter
+	serviceName string
+	log         *slog.Logger
+	threshold   int
+	cooldown    time.Duration
+	now         func() time.Time
+
+	mu          sync.Mutex
+	fails       int
+	lastRestart time.Time
+}
+
+// NewCaddyWatchdog builds a watchdog with production defaults. An empty
+// serviceName falls back to DefaultCaddyServiceName.
+func NewCaddyWatchdog(ping CaddyPinger, dkr CaddyServiceRestarter, serviceName string, log *slog.Logger) *CaddyWatchdog {
+	if serviceName == "" {
+		serviceName = DefaultCaddyServiceName
+	}
+	if log == nil {
+		log = slog.Default()
+	}
+	return &CaddyWatchdog{
+		ping:        ping,
+		docker:      dkr,
+		serviceName: serviceName,
+		log:         log,
+		threshold:   defaultWatchdogThreshold,
+		cooldown:    defaultWatchdogCooldown,
+		now:         time.Now,
+	}
+}
+
+// Tick is one watchdog cycle, suitable for the scheduler. It probes the
+// admin endpoint and, on sustained failure, restarts the Caddy service.
+func (w *CaddyWatchdog) Tick(ctx context.Context) {
+	err := w.ping.Ping(ctx)
+
+	w.mu.Lock()
+	defer w.mu.Unlock()
+
+	if err == nil {
+		if w.fails > 0 {
+			w.log.Info("caddy watchdog: admin recovered", "after_failures", w.fails)
+		}
+		w.fails = 0
+		return
+	}
+
+	w.fails++
+	w.log.Warn("caddy watchdog: admin probe failed",
+		"consecutive", w.fails, "threshold", w.threshold, "error", err)
+	if w.fails < w.threshold {
+		return
+	}
+
+	if !w.lastRestart.IsZero() {
+		if since := w.now().Sub(w.lastRestart); since < w.cooldown {
+			w.log.Warn("caddy watchdog: restart suppressed by cooldown",
+				"since_last_restart", since, "cooldown", w.cooldown)
+			return
+		}
+	}
+
+	w.log.Error("🚨 caddy watchdog: admin unresponsive, restarting service",
+		"service", w.serviceName, "consecutive", w.fails)
+	if err := w.docker.RestartService(ctx, w.serviceName); err != nil {
+		// Leave fails high so we retry on the next tick; don't set
+		// lastRestart, so the cooldown doesn't gate a restart that never
+		// actually happened.
+		w.log.Error("caddy watchdog: service restart failed",
+			"service", w.serviceName, "error", err)
+		return
+	}
+	w.lastRestart = w.now()
+	w.fails = 0
+}

--- a/internal/server/worker/caddy_watchdog_test.go
+++ b/internal/server/worker/caddy_watchdog_test.go
@@ -1,0 +1,135 @@
+package worker
+
+import (
+	"context"
+	"errors"
+	"testing"
+	"time"
+)
+
+type fakePinger struct{ err error }
+
+func (f *fakePinger) Ping(_ context.Context) error { return f.err }
+
+type fakeRestarter struct {
+	calls int
+	names []string
+	err   error
+}
+
+func (f *fakeRestarter) RestartService(_ context.Context, name string) error {
+	f.calls++
+	f.names = append(f.names, name)
+	return f.err
+}
+
+func TestCaddyWatchdog_HealthyNeverRestarts(t *testing.T) {
+	t.Parallel()
+	r := &fakeRestarter{}
+	w := NewCaddyWatchdog(&fakePinger{}, r, "", quietLogger())
+	for i := 0; i < 10; i++ {
+		w.Tick(context.Background())
+	}
+	if r.calls != 0 {
+		t.Fatalf("restart calls: %d, want 0 (admin always healthy)", r.calls)
+	}
+}
+
+func TestCaddyWatchdog_RestartsAfterThreshold(t *testing.T) {
+	t.Parallel()
+	ctx := context.Background()
+	r := &fakeRestarter{}
+	w := NewCaddyWatchdog(&fakePinger{err: errors.New("admin unreachable")}, r, "", quietLogger())
+
+	w.Tick(ctx)
+	w.Tick(ctx)
+	if r.calls != 0 {
+		t.Fatalf("restart calls after 2 failures: %d, want 0 (threshold is 3)", r.calls)
+	}
+	w.Tick(ctx) // 3rd consecutive failure → restart
+	if r.calls != 1 {
+		t.Fatalf("restart calls after 3 failures: %d, want 1", r.calls)
+	}
+	if len(r.names) != 1 || r.names[0] != DefaultCaddyServiceName {
+		t.Errorf("restarted service: %v, want [%s]", r.names, DefaultCaddyServiceName)
+	}
+	// The success path resets the failure count, so the very next failing
+	// tick must NOT immediately restart again.
+	w.Tick(ctx)
+	if r.calls != 1 {
+		t.Errorf("restart calls after one post-restart failure: %d, want 1 (counter reset)", r.calls)
+	}
+}
+
+func TestCaddyWatchdog_CooldownSuppressesThenAllows(t *testing.T) {
+	t.Parallel()
+	ctx := context.Background()
+	clock := time.Now()
+	r := &fakeRestarter{}
+	w := NewCaddyWatchdog(&fakePinger{err: errors.New("down")}, r, "", quietLogger())
+	w.now = func() time.Time { return clock }
+
+	for i := 0; i < 3; i++ { // first restart
+		w.Tick(ctx)
+	}
+	if r.calls != 1 {
+		t.Fatalf("restart calls: %d, want 1", r.calls)
+	}
+	for i := 0; i < 3; i++ { // sustained failure, still within cooldown
+		w.Tick(ctx)
+	}
+	if r.calls != 1 {
+		t.Fatalf("restart calls during cooldown: %d, want 1 (suppressed)", r.calls)
+	}
+	clock = clock.Add(6 * time.Minute) // past the 5m cooldown
+	w.Tick(ctx)
+	if r.calls != 2 {
+		t.Fatalf("restart calls after cooldown elapsed: %d, want 2", r.calls)
+	}
+}
+
+func TestCaddyWatchdog_RecoveryResetsCounter(t *testing.T) {
+	t.Parallel()
+	ctx := context.Background()
+	r := &fakeRestarter{}
+	p := &fakePinger{err: errors.New("down")}
+	w := NewCaddyWatchdog(p, r, "", quietLogger())
+
+	w.Tick(ctx)
+	w.Tick(ctx) // 2 consecutive failures
+	p.err = nil
+	w.Tick(ctx) // recovery resets the counter
+	p.err = errors.New("down again")
+	w.Tick(ctx)
+	w.Tick(ctx) // only 2 fresh failures
+	if r.calls != 0 {
+		t.Fatalf("restart calls: %d, want 0 (recovery reset the counter)", r.calls)
+	}
+	w.Tick(ctx) // 3rd consecutive → restart
+	if r.calls != 1 {
+		t.Fatalf("restart calls: %d, want 1", r.calls)
+	}
+}
+
+func TestCaddyWatchdog_RestartErrorRetriesNextTick(t *testing.T) {
+	t.Parallel()
+	ctx := context.Background()
+	clock := time.Now()
+	r := &fakeRestarter{err: errors.New("docker unreachable")}
+	w := NewCaddyWatchdog(&fakePinger{err: errors.New("down")}, r, "", quietLogger())
+	w.now = func() time.Time { return clock }
+
+	for i := 0; i < 3; i++ {
+		w.Tick(ctx)
+	}
+	if r.calls != 1 {
+		t.Fatalf("restart attempts: %d, want 1", r.calls)
+	}
+	// A failed restart must not start the cooldown clock — otherwise a
+	// recovery that never happened would gate the retry. Next failing tick
+	// should attempt again immediately.
+	w.Tick(ctx)
+	if r.calls != 2 {
+		t.Fatalf("restart attempts after a failed restart: %d, want 2 (retried)", r.calls)
+	}
+}


### PR DESCRIPTION
## Summary

Production deploys intermittently failed at the Caddy cutover with `serve verify drifted`, and earlier the same day Caddy's admin socket wedged and required a manual SSH `docker restart`. The verify failures trace back to a race between the convergence reconciler and the deploy swap. This PR fixes the race, removes redundant admin load, and adds a watchdog so a wedged admin self-heals.

## Root cause (proven from the daemon log)

```
08:38:56  build complete                      deployment_id=155 number=64 project=next
08:39:07  caddy reconcile: upstream drifted    project=next want="next-60-web" got="next-64-web"
08:39:07  caddy reconcile: corrections applied  examined=15 corrected=1     ← reverts to #60
08:39:09  dispatcher: deploy ended  status=failed
          serve verify drifted: want="next-64-web" got="next-60-web"        ← deploy sees the revert
```

`ReconcileCaddyState` runs every 30s and derives each project's desired upstream from `GetLastSuccessfulDeployment`. During a deploy, the row stays the **previous** deployment until the swap verifies (`orchestrator` sets `swapping`, success is written later). So mid-swap the reconciler sees the new upstream as "drift" and PATCHes it back to the old container; the deploy's verify loop (~1.55s) then reads the reverted value and fails. The two actors log mirror-image "drift" 2s apart.

**This is a probabilistic race, not a hard failure.** A deploy fails only if a 30s reconcile tick lands inside the danger window (upstream PATCH → verify completion ≈ `reload_time + ~1.55s`). With a fast reload that window is ~2s (≈7% odds); as reloads slow with project/domain count (8–12s) it climbs to ~35–45%. So deploys fail intermittently — more often under load — and a retry often succeeds. Ironically the reconciler was built to *fix* "upstream silently reverts" (issue #97) but is itself the cause.

## Changes

1. **Reconciler stands down during an in-flight deploy** (`ActiveDeploymentForProject`). A deploy owns its project's Caddy state end-to-end; the reconciler is a *between-deploys* safety net. This removes the race entirely (not just lowers the odds).
2. **Drift-aware domain sync** — only PATCH the host matcher when it actually changed, instead of issuing a full config reload for all ~15 projects every 30s. Every `/id/` PATCH triggers a full Caddy reload (8–12s on this host, re-provisioning all TLS domains); re-asserting an unchanged host list every cycle was pure load and a likely contributor to the admin socket wedging. Also shrinks the race window above.
3. **CaddyWatchdog** (new 30s cron) — probes the admin socket with a short, *mutex-bypassing* `Ping` and force-restarts `cobalt_caddy` after 3 consecutive failures, with a 5m cooldown. Turns "admin wedged → human SSHes in to `docker restart`" into automatic recovery. Conservative by design because restarting Caddy is a ~1–2s blip across all sites.

## Notes

- The earlier admin-wedge (the timeout that forced the manual restart) is **not** definitively root-caused — Caddy was restarted before a goroutine dump. The drift-gate (#2) removes a plausible contributor and the watchdog (#3) auto-recovers if it recurs.
- `Ping` deliberately skips `adminMu`: a wedged admin holds the mutex for minutes, so a probe that queued behind it could never detect the wedge.
- Ships via `cobalt upgrade` (daemon rebuild), not a project deploy.

## Test plan

- [x] `go build ./...`, `go vet`, `gofmt` clean
- [x] `go test ./...` — 19 packages pass
- [x] Reconciler: skips in-flight project (no Caddy mutation); drift-gate skips no-op PATCH and fires on real drift; active-check error absorbed
- [x] `CurrentDomains` (host list + 404→nil); `Ping` (2xx/4xx alive, transport error → fail)
- [x] Watchdog: restart after threshold, cooldown suppress→allow, recovery resets, failed restart retries