### PR TITLE
fix(cli): keep streaming deploy output until the deploy is terminal

### DIFF
--- a/cmd/cobalt/deploy_test.go
+++ b/cmd/cobalt/deploy_test.go
@@ -5,6 +5,7 @@ import (
 	"context"
 	"encoding/json"
 	"net/http"
+	"strings"
 	"testing"
 
 	"github.com/heyblueteam/cobalt/internal/output"
@@ -180,20 +181,25 @@ func TestDeploymentsOutputLatest(t *testing.T) {
 	api := newMockAPI()
 	defer api.close()
 
-	var callCount int
 	api.handler = func(w http.ResponseWriter, r *http.Request) {
-		callCount++
-		w.Header().Set("Content-Type", "application/json")
-		if callCount == 1 {
-			// List recent deployments → return one
+		switch {
+		case strings.HasSuffix(r.URL.Path, "/output"):
+			// SSE output — emit one line then close.
+			w.Header().Set("Content-Type", "text/event-stream")
+			w.Write([]byte("data: build output line\n\n"))
+		case strings.HasPrefix(r.URL.Path, "/api/deployments/"):
+			// GET /api/deployments/{id} — terminal status, so the
+			// follower stops after the single stream.
+			w.Header().Set("Content-Type", "application/json")
+			json.NewEncoder(w).Encode(cobaltapi.Deployment{
+				ID: 10, Number: 3, Status: cobaltapi.StateSuccess,
+			})
+		default:
+			// List recent deployments → return one.
+			w.Header().Set("Content-Type", "application/json")
 			json.NewEncoder(w).Encode([]cobaltapi.Deployment{
 				{ID: 10, Number: 3, Status: cobaltapi.StateSuccess},
 			})
-		} else {
-			// SSE output — just close immediately for test
-			w.Header().Set("Content-Type", "text/event-stream")
-			w.Write([]byte("data: build output line\n\n"))
-			return
 		}
 	}
 

--- a/cmd/cobalt/logs.go
+++ b/cmd/cobalt/logs.go
@@ -38,7 +38,8 @@ Examples:
 				return fmt.Errorf("%s: %s", resp.Status, string(body))
 			}
 
-			return output.ConsumeSSE(ctx, resp.Body, output.Stdout)
+			_, err = output.ConsumeSSE(ctx, resp.Body, output.Stdout)
+			return err
 		}),
 	}
 	cmd.Flags().String("project", "", "project name")

--- a/cmd/cobalt/upgrade.go
+++ b/cmd/cobalt/upgrade.go
@@ -114,7 +114,7 @@ func followUpgrade(ctx context.Context, cl *client.Client, id string) error {
 	if resp.StatusCode < 200 || resp.StatusCode >= 300 {
 		return fmt.Errorf("log stream returned %s", resp.Status)
 	}
-	streamErr := output.ConsumeSSE(ctx, resp.Body, output.Stdout)
+	_, streamErr := output.ConsumeSSE(ctx, resp.Body, output.Stdout)
 	// SSE close happens for two reasons during a real upgrade: the
 	// daemon serving the stream got swapped (TCP reset on the old
 	// container), or the upgrade really finished. Either way we now

--- a/internal/client/client.go
+++ b/internal/client/client.go
@@ -18,6 +18,13 @@ import (
 type Client struct {
 	server cliconfig.Server
 	http   *http.Client
+	// stream is used for long-lived SSE follows (deploy output, service
+	// logs). Unlike http it has NO whole-request Timeout: an SSE stream
+	// outlives any fixed deadline (a quiet build step emits no bytes for
+	// minutes), so cancellation is driven by the request context and the
+	// server's heartbeat instead. Sharing http here is what capped deploy
+	// follows at 30s and made `cobalt deployments output` quit mid-build.
+	stream *http.Client
 }
 
 type APIError struct {
@@ -28,11 +35,17 @@ type APIError struct {
 func (e *APIError) Error() string { return e.Message }
 
 func New(s cliconfig.Server) *Client {
+	tr := transportFor(s)
 	return &Client{
 		server: s,
 		http: &http.Client{
 			Timeout:   30 * time.Second,
-			Transport: transportFor(s),
+			Transport: tr,
+		},
+		stream: &http.Client{
+			// No Timeout — see Client.stream. Same transport (so a pinned
+			// CA is honored) and context-driven cancellation.
+			Transport: tr,
 		},
 	}
 }

--- a/internal/client/deployments.go
+++ b/internal/client/deployments.go
@@ -70,7 +70,9 @@ func (c *Client) StreamGet(ctx context.Context, path string) (*http.Response, er
 	}
 	req.Header.Set("Authorization", "Bearer "+c.server.APIKey)
 	req.Header.Set("Accept", "text/event-stream")
-	return c.http.Do(req)
+	// Use the no-timeout streaming client: SSE follows outlive the 30s
+	// whole-request Timeout on c.http. Cancellation is via ctx.
+	return c.stream.Do(req)
 }
 
 func (c *Client) DeployOutputURL(deploymentID int64, offset int64) string {

--- a/internal/output/sse.go
+++ b/internal/output/sse.go
@@ -6,15 +6,77 @@ import (
 	"encoding/json"
 	"fmt"
 	"io"
+	"strconv"
 	"strings"
+	"time"
 
 	"github.com/heyblueteam/cobalt/internal/client"
 )
 
+// reconnectDelay is how long the resilient follower waits before
+// re-opening a dropped deploy-output stream. Short enough that the live
+// build view barely stutters, long enough that a genuinely unreachable
+// daemon doesn't get hammered (and GetDeployment, which we call each
+// iteration, will error out and end the loop anyway).
+const reconnectDelay = time.Second
+
+// FollowDeployOutput streams a deployment's output to out and KEEPS
+// following until the deployment reaches a terminal state — reconnecting
+// from the last byte offset whenever the SSE stream ends early.
+//
+// A single SSE connection is not a reliable proxy for "the deploy is
+// done": a long quiet build step (tsc/vite emit no stdout for minutes)
+// can trip a reverse-proxy idle timeout, a transient DB read in the
+// daemon's follow loop can end the stream, etc. When that happened we
+// used to print "Status: building" and quit mid-build. Now we ask the
+// daemon whether the deploy is actually terminal; if not, we re-open the
+// stream at the offset we'd reached (the server honors ?offset=N and
+// tags every chunk with its byte position as the SSE id) and continue.
+//
+// Returns nil once the deploy is terminal, or a non-nil error only on a
+// genuine failure or context cancellation (Ctrl+C) — preserving the
+// contract callers already check with IsContextCanceled.
 func FollowDeployOutput(ctx context.Context, cl *client.Client, deploymentID int64, offset int64, out io.Writer) error {
+	for {
+		lastID, streamErr := streamDeployOutputOnce(ctx, cl, deploymentID, offset, out)
+		if streamErr != nil && isContextCanceled(streamErr) {
+			return streamErr
+		}
+		if next, ok := parseOffset(lastID); ok && next > offset {
+			offset = next
+		}
+
+		// The stream ended. Is the deploy genuinely finished, or did the
+		// connection just drop mid-flight? Ask the daemon.
+		dep, err := cl.GetDeployment(ctx, deploymentID)
+		if err != nil {
+			// Can't reach the daemon to decide — surface the stream error
+			// if we had one, otherwise the status-check error.
+			if streamErr != nil {
+				return streamErr
+			}
+			return fmt.Errorf("check deployment status: %w", err)
+		}
+		if dep.Status.IsTerminal() {
+			return nil
+		}
+
+		// Still in flight but the stream dropped — reconnect from offset.
+		select {
+		case <-ctx.Done():
+			return ctx.Err()
+		case <-time.After(reconnectDelay):
+		}
+	}
+}
+
+// streamDeployOutputOnce opens a single SSE connection and pumps it to
+// out until the server closes it (or the context is canceled). Returns
+// the last SSE event id seen (the byte offset to resume from).
+func streamDeployOutputOnce(ctx context.Context, cl *client.Client, deploymentID int64, offset int64, out io.Writer) (string, error) {
 	resp, err := cl.DeployOutput(ctx, deploymentID, offset)
 	if err != nil {
-		return fmt.Errorf("connect to deploy output: %w", err)
+		return "", fmt.Errorf("connect to deploy output: %w", err)
 	}
 	defer resp.Body.Close()
 
@@ -24,21 +86,40 @@ func FollowDeployOutput(ctx context.Context, cl *client.Client, deploymentID int
 			Error string `json:"error"`
 		}
 		if err := json.Unmarshal(body, &apiErr); err == nil && apiErr.Error != "" {
-			return fmt.Errorf("%s", apiErr.Error)
+			return "", fmt.Errorf("%s", apiErr.Error)
 		}
-		return fmt.Errorf("%s: %s", resp.Status, strings.TrimSpace(string(body)))
+		return "", fmt.Errorf("%s: %s", resp.Status, strings.TrimSpace(string(body)))
 	}
 
 	return ConsumeSSE(ctx, resp.Body, out)
 }
 
-func ConsumeSSE(ctx context.Context, r io.Reader, out io.Writer) error {
+// parseOffset parses an SSE event id (a byte position) into an offset.
+// Returns ok=false for an empty or non-numeric id (e.g. the service-logs
+// stream, which emits no ids).
+func parseOffset(id string) (int64, bool) {
+	if id == "" {
+		return 0, false
+	}
+	n, err := strconv.ParseInt(id, 10, 64)
+	if err != nil || n < 0 {
+		return 0, false
+	}
+	return n, true
+}
+
+// ConsumeSSE parses a Server-Sent Events stream from r, writing each
+// event's data to out. It returns the last event id observed (the deploy-
+// output stream sets this to the byte offset, so a resuming caller can
+// reconnect with ?offset=N; streams that emit no ids return "").
+func ConsumeSSE(ctx context.Context, r io.Reader, out io.Writer) (string, error) {
 	scanner := bufio.NewScanner(r)
 	scanner.Buffer(make([]byte, 0, 64<<10), 1024<<10)
 
 	var (
 		dataLines []string
 		eventID   string
+		lastID    string
 	)
 
 	flush := func() {
@@ -52,7 +133,7 @@ func ConsumeSSE(ctx context.Context, r io.Reader, out io.Writer) error {
 	for scanner.Scan() {
 		select {
 		case <-ctx.Done():
-			return ctx.Err()
+			return lastID, ctx.Err()
 		default:
 		}
 
@@ -75,18 +156,19 @@ func ConsumeSSE(ctx context.Context, r io.Reader, out io.Writer) error {
 			dataLines = append(dataLines, line[5:])
 		case strings.HasPrefix(line, "id: "):
 			eventID = line[4:]
+			lastID = eventID
 		case strings.HasPrefix(line, "id:"):
 			eventID = line[3:]
+			lastID = eventID
 		}
 	}
 	// Flush any trailing event the server didn't terminate before EOF.
 	flush()
-	_ = eventID
 
 	if err := scanner.Err(); err != nil && !isContextCanceled(err) {
-		return fmt.Errorf("read sse stream: %w", err)
+		return lastID, fmt.Errorf("read sse stream: %w", err)
 	}
-	return nil
+	return lastID, nil
 }
 
 func isContextCanceled(err error) bool {

--- a/internal/output/sse_test.go
+++ b/internal/output/sse_test.go
@@ -1,9 +1,84 @@
 package output
 
 import (
+	"context"
 	"errors"
+	"fmt"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"sync/atomic"
 	"testing"
+
+	"github.com/heyblueteam/cobalt/internal/cliconfig"
+	"github.com/heyblueteam/cobalt/internal/client"
 )
+
+func TestConsumeSSEReturnsLastID(t *testing.T) {
+	stream := "id: 6\ndata: hello\n\nid: 12\ndata: world\n\n"
+	var out strings.Builder
+	lastID, err := ConsumeSSE(context.Background(), strings.NewReader(stream), &out)
+	if err != nil {
+		t.Fatalf("ConsumeSSE: %v", err)
+	}
+	if lastID != "12" {
+		t.Errorf("lastID = %q, want %q", lastID, "12")
+	}
+	if got := out.String(); got != "hello\nworld\n" {
+		t.Errorf("out = %q, want %q", got, "hello\nworld\n")
+	}
+}
+
+// TestFollowDeployOutputReconnects verifies that when the SSE stream ends
+// while the deployment is still building, the follower reconnects from the
+// last byte offset and keeps streaming until the deploy is terminal —
+// rather than quitting mid-build (the "Status: building" bug).
+func TestFollowDeployOutputReconnects(t *testing.T) {
+	var outputCalls int32
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		switch {
+		case strings.HasSuffix(r.URL.Path, "/output"):
+			n := atomic.AddInt32(&outputCalls, 1)
+			w.Header().Set("Content-Type", "text/event-stream")
+			switch n {
+			case 1:
+				// First connection: emit the first chunk (6 bytes) then
+				// drop the stream mid-build, with no offset requested.
+				if got := r.URL.Query().Get("offset"); got != "" {
+					t.Errorf("call 1 offset = %q, want empty", got)
+				}
+				fmt.Fprint(w, "id: 6\ndata: part1\n\n")
+			default:
+				// Reconnect: must resume from offset 6.
+				if got := r.URL.Query().Get("offset"); got != "6" {
+					t.Errorf("call 2 offset = %q, want 6", got)
+				}
+				fmt.Fprint(w, "id: 12\ndata: part2\n\n")
+			}
+		default:
+			// GET /api/deployments/{id} — building after the first stream,
+			// success after the second so the loop terminates.
+			status := "building"
+			if atomic.LoadInt32(&outputCalls) >= 2 {
+				status = "success"
+			}
+			fmt.Fprintf(w, `{"id":1,"status":%q}`, status)
+		}
+	}))
+	defer srv.Close()
+
+	cl := client.New(cliconfig.Server{Host: srv.URL, APIKey: "test-key"})
+	var out strings.Builder
+	if err := FollowDeployOutput(context.Background(), cl, 1, 0, &out); err != nil {
+		t.Fatalf("FollowDeployOutput: %v", err)
+	}
+	if got := out.String(); got != "part1\npart2\n" {
+		t.Errorf("out = %q, want %q (each chunk exactly once, in order)", got, "part1\npart2\n")
+	}
+	if n := atomic.LoadInt32(&outputCalls); n != 2 {
+		t.Errorf("output stream opened %d times, want 2", n)
+	}
+}
 
 func TestIsContextCanceled(t *testing.T) {
 	tests := []struct {


### PR DESCRIPTION
## Problem

`cobalt deployments output --project api` streams the live build for a few seconds, then stops and prints `Status: building` while the deploy is still running. The deploy/rollback follow paths have the same flaw.

## Root causes

1. **30s client timeout caps every stream.** `StreamGet` reused `c.http`, which has a 30s whole-request `Timeout`. SSE follows are long-lived, so the connection was killed at 30s regardless of deploy state — and a long quiet build step (tsc/vite produce no stdout for minutes) guarantees you hit it. The websocket `run` path already sidesteps this with its own no-timeout transport; the SSE path didn't.

2. **The CLI followed the stream exactly once.** The daemon already supports resume — it honors `?offset=N` and tags every chunk with an SSE `id:` equal to the byte position — but the CLI threw the id away (`_ = eventID`) and never reconnected. Any early stream end → give up → print whatever status happened to be current.

## Fix

- Add a dedicated no-timeout `stream` http.Client for SSE follows (same transport, so a pinned CA is still honored); cancellation is via context + the server's existing heartbeat.
- `ConsumeSSE` now returns the last event id (byte offset).
- `FollowDeployOutput` loops: on a clean stream end it asks the daemon whether the deploy is terminal; if not, it reconnects from the last byte offset and keeps streaming until it is. Fixes all three callers (`deployments output`, `deploy`, `rollback`) at once. Ctrl+C still exits cleanly.

## Tests

- `TestConsumeSSEReturnsLastID` — id surfaced, multi-line data preserved.
- `TestFollowDeployOutputReconnects` — stream drops mid-build while status is `building`; follower reconnects from `offset=6`, emits each chunk exactly once, stops when status flips to `success`.
- Updated `TestDeploymentsOutputLatest` mock to serve the now-exercised `GET /api/deployments/{id}` status endpoint.

Full suite + `golangci-lint` clean.