### PR TITLE
feat(caddy): verify cutovers + self-heal against the data plane

### DIFF
--- a/internal/server/caddy/client_test.go
+++ b/internal/server/caddy/client_test.go
@@ -200,7 +200,7 @@ func TestServeService_PatchesHandler(t *testing.T) {
 	f := newFakeCaddy(t)
 	c := f.client()
 	const projectID int64 = 5
-	if err := c.ServeService(context.Background(), projectID, "myapp-7-web", 3000); err != nil {
+	if err := c.ServeService(context.Background(), projectID, "myapp-7-web", 3000, 7); err != nil {
 		t.Fatalf("ServeService: %v", err)
 	}
 	call := f.lastCall(t)
@@ -212,6 +212,11 @@ func TestServeService_PatchesHandler(t *testing.T) {
 	}
 	if !strings.Contains(string(call.Body), `"dial":"myapp-7-web:3000"`) {
 		t.Errorf("body missing dial: %s", call.Body)
+	}
+	// The deployment-identity header must ride along in the same handler
+	// PATCH so the data plane can report which deployment it serves.
+	if !strings.Contains(string(call.Body), `"X-Cobalt-Deployment":["7"]`) {
+		t.Errorf("body missing X-Cobalt-Deployment header: %s", call.Body)
 	}
 }
 

--- a/internal/server/caddy/upstream.go
+++ b/internal/server/caddy/upstream.go
@@ -7,6 +7,14 @@ import (
 	"strconv"
 )
 
+// DeploymentHeader is the response header ServeService stamps on every
+// proxied response, carrying the deployment number the handler was last
+// PATCHed to serve. A data-plane probe (deploy.probeDataPlane) reads it back
+// through Caddy's own listener to learn which deployment the *running* router
+// actually routes to — which can lag the admin config tree under reload
+// pressure (the silent divergence behind the post-cutover 502 incident).
+const DeploymentHeader = "X-Cobalt-Deployment"
+
 // ServeService swaps a project's reverse-proxy upstream to point at a newly
 // started container. This is the atomic cutover point of a deploy: a single
 // PATCH against the project's handler @id flips traffic from the old
@@ -14,10 +22,26 @@ import (
 //
 // containerName + port form the docker-internal address Caddy will dial,
 // e.g. "myapp-7-web" + 3000 → "myapp-7-web:3000".
-func (c *Client) ServeService(ctx context.Context, projectID int64, containerName string, port int) error {
+//
+// deploymentNumber is stamped into the DeploymentHeader on proxied responses
+// so the running router's identity is observable from the data plane. It
+// travels in the *same* handler config as the upstream, so a lagging compiled
+// handler that still dials the old container also still emits the old number —
+// that mismatch is the divergence signal the reconciler self-heals on.
+func (c *Client) ServeService(ctx context.Context, projectID int64, containerName string, port, deploymentNumber int) error {
 	body := map[string]any{
 		"@id":     ProjectHandlerID(projectID),
 		"handler": "reverse_proxy",
+		// header_down: set on the response Caddy returns from this upstream.
+		// Must be re-sent on every PATCH — the PATCH replaces the whole
+		// handler, so omitting it would drop the header.
+		"headers": map[string]any{
+			"response": map[string]any{
+				"set": map[string]any{
+					DeploymentHeader: []any{strconv.Itoa(deploymentNumber)},
+				},
+			},
+		},
 		"upstreams": []any{
 			map[string]any{"dial": containerName + ":" + strconv.Itoa(port)},
 		},

--- a/internal/server/caddy/verify.go
+++ b/internal/server/caddy/verify.go
@@ -44,8 +44,8 @@ var defaultVerifyBackoff = []time.Duration{
 //   - Otherwise, retries with exponential backoff up to len(verifyBackoff)
 //     attempts.
 //   - On final mismatch, returns *PatchVerifyError.
-func (c *Client) VerifyServeService(ctx context.Context, projectID int64, containerName string, port int) error {
-	if err := c.ServeService(ctx, projectID, containerName, port); err != nil {
+func (c *Client) VerifyServeService(ctx context.Context, projectID int64, containerName string, port, deploymentNumber int) error {
+	if err := c.ServeService(ctx, projectID, containerName, port, deploymentNumber); err != nil {
 		return err
 	}
 	want := containerName

--- a/internal/server/caddy/verify_test.go
+++ b/internal/server/caddy/verify_test.go
@@ -26,7 +26,7 @@ func TestVerifyServeService_FirstAttemptMatches(t *testing.T) {
 	c := f.client()
 	c.PatchVerifyBackoff = fastBackoff
 
-	if err := c.VerifyServeService(context.Background(), 7, "myapp-7-web", 3000); err != nil {
+	if err := c.VerifyServeService(context.Background(), 7, "myapp-7-web", 3000, 7); err != nil {
 		t.Errorf("VerifyServeService: %v", err)
 	}
 }
@@ -54,7 +54,7 @@ func TestVerifyServeService_ConvergesAfterRetries(t *testing.T) {
 	c := NewHTTPClient(srv.URL, srv.Client())
 	c.PatchVerifyBackoff = fastBackoff
 
-	if err := c.VerifyServeService(context.Background(), 7, "myapp-7-web", 3000); err != nil {
+	if err := c.VerifyServeService(context.Background(), 7, "myapp-7-web", 3000, 7); err != nil {
 		t.Errorf("expected eventual convergence, got: %v", err)
 	}
 }
@@ -73,7 +73,7 @@ func TestVerifyServeService_PersistentDriftReturnsError(t *testing.T) {
 	c := NewHTTPClient(srv.URL, srv.Client())
 	c.PatchVerifyBackoff = fastBackoff
 
-	err := c.VerifyServeService(context.Background(), 7, "myapp-7-web", 3000)
+	err := c.VerifyServeService(context.Background(), 7, "myapp-7-web", 3000, 7)
 	var ve *PatchVerifyError
 	if !errors.As(err, &ve) {
 		t.Fatalf("want *PatchVerifyError, got %T: %v", err, err)
@@ -98,7 +98,7 @@ func TestVerifyServeService_PatchFailureBubbles(t *testing.T) {
 	c := NewHTTPClient(srv.URL, srv.Client())
 	c.PatchVerifyBackoff = fastBackoff
 
-	err := c.VerifyServeService(context.Background(), 7, "x", 80)
+	err := c.VerifyServeService(context.Background(), 7, "x", 80, 7)
 	if err == nil {
 		t.Error("expected error from PATCH failure")
 	}
@@ -120,7 +120,7 @@ func TestVerifyServeService_HonorsContextCancel(t *testing.T) {
 
 	ctx, cancel := context.WithCancel(context.Background())
 	cancel()
-	err := c.VerifyServeService(ctx, 7, "x", 80)
+	err := c.VerifyServeService(ctx, 7, "x", 80, 7)
 	if err == nil {
 		t.Error("expected context error")
 	}
@@ -152,7 +152,7 @@ func TestVerifyServeService_TransientReadFailure_RetriesAndSucceeds(t *testing.T
 	c := NewHTTPClient(srv.URL, srv.Client())
 	c.PatchVerifyBackoff = fastBackoff
 
-	if err := c.VerifyServeService(context.Background(), 7, "myapp-7-web", 3000); err != nil {
+	if err := c.VerifyServeService(context.Background(), 7, "myapp-7-web", 3000, 7); err != nil {
 		t.Errorf("expected success after transient read failure, got: %v", err)
 	}
 }

--- a/internal/server/deploy/cleanup.go
+++ b/internal/server/deploy/cleanup.go
@@ -17,10 +17,19 @@ type CleanupDocker interface {
 	RemoveService(ctx context.Context, name string) error
 }
 
-// cleanupOldServices stops every project service whose name doesn't match
-// the current deployment number's prefix `{project}-{n}-`. Best-effort:
-// per-service failures are logged and skipped. Never returns an error;
-// the deploy is already marked successful and traffic is on the new
+// cleanupOldServices stops project services from previous deployments, with
+// one deliberate exception: it keeps the most recent prior `*-web` generation
+// alive as a grace fallback. If Caddy's compiled router lags the cutover by a
+// deploy (it can, under reload pressure), that retained generation lets a
+// stale request resolve to a working old build (200) instead of a
+// since-deleted upstream (502) — the post-cutover incident this guards. The
+// convergence reconciler reaps the retained generation once the new deployment
+// is confirmed serving on the data plane (worker.reapSupersededWeb); failing
+// that, the next deploy reaps it (it's no longer the *most recent* prior), so
+// at most one extra web generation ever lingers.
+//
+// Best-effort: per-service failures are logged and skipped. Never returns an
+// error; the deploy is already marked successful and traffic is on the new
 // container.
 func cleanupOldServices(
 	ctx context.Context,
@@ -36,11 +45,21 @@ func cleanupOldServices(
 		return
 	}
 	currentPrefix := project.Name + "-" + itoaSimple(dep.Number) + "-"
+	grace := graceWebService(services, project.Name, dep.Number)
+
 	var stale []string
 	for _, s := range services {
-		if !strings.HasPrefix(s.Name, currentPrefix) {
-			stale = append(stale, s.Name)
+		if strings.HasPrefix(s.Name, currentPrefix) {
+			continue // current deployment — keep
 		}
+		if s.Name == grace {
+			continue // retained one cutover for grace
+		}
+		stale = append(stale, s.Name)
+	}
+	if grace != "" {
+		fmt.Fprintf(out, "🛟 keeping %s one cutover for grace (reaped once #%d is confirmed live)\n",
+			grace, dep.Number)
 	}
 	if len(stale) == 0 {
 		return
@@ -57,6 +76,27 @@ func cleanupOldServices(
 			"name", name, "project_id", project.ID, "current_deployment", dep.Number)
 		fmt.Fprintf(out, "✅ stopped %s\n", name)
 	}
+}
+
+// graceWebService returns the name of the most recent `*-web` service older
+// than currentNumber, or "" if there is none. That single generation is kept
+// alive briefly (see cleanupOldServices) so a router lagging the cutover serves
+// the previous build instead of 502ing. Only web services qualify — worker and
+// cron services have no public route, so there's nothing to fall back to.
+func graceWebService(services []docker.ServiceInfo, projectName string, currentNumber int) string {
+	best := -1
+	var name string
+	for _, s := range services {
+		n, ok := docker.WebGeneration(projectName, s.Name)
+		if !ok || n >= currentNumber {
+			continue
+		}
+		if n > best {
+			best = n
+			name = s.Name
+		}
+	}
+	return name
 }
 
 // itoaSimple is a tiny replacement for strconv.Itoa to avoid the import.

--- a/internal/server/deploy/cleanup_test.go
+++ b/internal/server/deploy/cleanup_test.go
@@ -1,0 +1,98 @@
+package deploy
+
+import (
+	"context"
+	"io"
+	"sort"
+	"testing"
+
+	"github.com/heyblueteam/cobalt/internal/server/docker"
+	"github.com/heyblueteam/cobalt/internal/server/store"
+)
+
+type fakeCleanupDocker struct {
+	services []docker.ServiceInfo
+	removed  []string
+	listErr  error
+}
+
+func (f *fakeCleanupDocker) ListServicesForProject(context.Context, int64) ([]docker.ServiceInfo, error) {
+	return f.services, f.listErr
+}
+
+func (f *fakeCleanupDocker) RemoveService(_ context.Context, name string) error {
+	f.removed = append(f.removed, name)
+	return nil
+}
+
+func svcs(names ...string) []docker.ServiceInfo {
+	out := make([]docker.ServiceInfo, len(names))
+	for i, n := range names {
+		out[i] = docker.ServiceInfo{Name: n}
+	}
+	return out
+}
+
+func TestCleanupOldServices_KeepsCurrentAndGraceWeb(t *testing.T) {
+	t.Parallel()
+	d := &fakeCleanupDocker{services: svcs(
+		"api-7-web", "api-7-worker", // current deployment — keep
+		"api-6-web",    // most recent prior web — keep for grace
+		"api-6-worker", // prior worker — reap (no public route)
+		"api-5-web",    // older web — reap
+	)}
+	cleanupOldServices(context.Background(), quietLog(), d,
+		store.Project{ID: 1, Name: "api"}, store.Deployment{Number: 7}, io.Discard)
+
+	got := append([]string(nil), d.removed...)
+	sort.Strings(got)
+	want := []string{"api-5-web", "api-6-worker"}
+	if len(got) != len(want) {
+		t.Fatalf("removed %v, want %v", got, want)
+	}
+	for i := range want {
+		if got[i] != want[i] {
+			t.Fatalf("removed %v, want %v", got, want)
+		}
+	}
+}
+
+func TestCleanupOldServices_FirstDeploy_NothingToReap(t *testing.T) {
+	t.Parallel()
+	d := &fakeCleanupDocker{services: svcs("api-1-web", "api-1-worker")}
+	cleanupOldServices(context.Background(), quietLog(), d,
+		store.Project{ID: 1, Name: "api"}, store.Deployment{Number: 1}, io.Discard)
+	if len(d.removed) != 0 {
+		t.Errorf("first deploy should reap nothing, removed %v", d.removed)
+	}
+}
+
+func TestCleanupOldServices_HyphenatedProjectName(t *testing.T) {
+	t.Parallel()
+	d := &fakeCleanupDocker{services: svcs(
+		"my-app-7-web", "my-app-6-web", "my-app-5-web",
+	)}
+	cleanupOldServices(context.Background(), quietLog(), d,
+		store.Project{ID: 1, Name: "my-app"}, store.Deployment{Number: 7}, io.Discard)
+	// Keep current (7) + grace (6); reap only 5.
+	if len(d.removed) != 1 || d.removed[0] != "my-app-5-web" {
+		t.Errorf("removed %v, want [my-app-5-web]", d.removed)
+	}
+}
+
+func TestGraceWebService(t *testing.T) {
+	t.Parallel()
+	services := svcs("api-7-web", "api-6-web", "api-6-worker", "api-5-web", "other-9-web")
+	got := graceWebService(services, "api", 7)
+	if got != "api-6-web" {
+		t.Errorf("graceWebService = %q, want api-6-web", got)
+	}
+	// No prior web → "".
+	if got := graceWebService(svcs("api-1-web"), "api", 1); got != "" {
+		t.Errorf("graceWebService (first deploy) = %q, want \"\"", got)
+	}
+	// Only a prior worker (no web) → "" (nothing to fall back to).
+	if got := graceWebService(svcs("api-6-worker"), "api", 7); got != "" {
+		t.Errorf("graceWebService (worker only) = %q, want \"\"", got)
+	}
+}

--- a/internal/server/deploy/dataplane.go
+++ b/internal/server/deploy/dataplane.go
@@ -1,0 +1,322 @@
+package deploy
+
+import (
+	"bytes"
+	"context"
+	"fmt"
+	"io"
+	"log/slog"
+	"strconv"
+	"strings"
+	"time"
+
+	"github.com/heyblueteam/cobalt/internal/server/caddy"
+	"github.com/heyblueteam/cobalt/internal/server/cobaltfile"
+	"github.com/heyblueteam/cobalt/internal/server/store"
+)
+
+// dataPlaneResult is what a single probe through Caddy's own listener
+// observed about the *running* (compiled) router — as opposed to the admin
+// config tree, which can lag the router under reload pressure and so lies.
+type dataPlaneResult struct {
+	// Served is the X-Cobalt-Deployment header the running router stamped,
+	// i.e. the deployment number it actually routes this host to. "" means
+	// the response carried no such header — an old/pre-header handler or a
+	// non-project response (e.g. Caddy's own redirect). Callers treat "" as
+	// "unknown", never as drift.
+	Served string
+	// Status is the HTTP status code observed (0 if no HTTP response was
+	// parsed). A gateway error (502/503/504) means the router is dialing a
+	// dead upstream — itself a divergence signal.
+	Status int
+}
+
+// dataPlaneProbeTimeout bounds a single scheme's probe (plaintext or TLS).
+const dataPlaneProbeTimeout = 5 * time.Second
+
+// probeDataPlane issues a real HTTP request through Caddy's own listener from
+// inside the cobalt-caddy container, with Host set to the project's domain,
+// and reports the X-Cobalt-Deployment header the running router emits plus the
+// HTTP status. This is the only ground truth for "which deployment does the
+// compiled router actually serve" — every admin-API read reflects the config
+// tree, which can diverge from the running router.
+//
+// It auto-detects cobalt's two topologies so the daemon needn't know its own
+// mode:
+//   - Behind a TLS-terminating tunnel (Cloudflare Tunnel et al.), Caddy
+//     listens on :80 plaintext.
+//   - Standalone, Caddy listens on :443 and terminates TLS itself (and may
+//     run an :80→:443 redirect vhost).
+//
+// It first issues a hand-built plaintext request on :80 (single, exact Host
+// header so the project's host matcher matches — busybox tooling can't be
+// trusted to set Host cleanly otherwise). If :80 is closed, or answers only
+// with Caddy's own HTTPS redirect (the standalone case, recognised as a 3xx
+// carrying no deployment header), it falls back to an HTTPS probe on :443.
+//
+// Returns an error only when neither scheme yields an HTTP response (Caddy
+// unreachable). Any HTTP answer — even a 502 — is a successful probe.
+func probeDataPlane(ctx context.Context, p ReadinessProber, domain string) (dataPlaneResult, error) {
+	if !isProbableHostname(domain) {
+		return dataPlaneResult{}, fmt.Errorf("data-plane probe: refusing to probe implausible host %q", domain)
+	}
+	container := resolveCaddyContainer(ctx, p)
+
+	// 1) plaintext :80 — the tunnel topology, and the one we can build a
+	//    clean single-Host request for.
+	if res, ok := probePlaintext(ctx, p, container, domain); ok {
+		return res, nil
+	}
+	// 2) https :443 — the standalone topology.
+	if res, ok := probeHTTPS(ctx, p, container, domain); ok {
+		return res, nil
+	}
+	return dataPlaneResult{}, fmt.Errorf(
+		"data-plane probe: caddy did not answer on :80 or :443 for host %q", domain)
+}
+
+// probePlaintext sends a raw HTTP/1.1 request to Caddy's :80 listener via nc
+// (the same busybox tool probeTCP relies on), giving us exact control over the
+// Host header. Returns ok=false when :80 is closed/unanswered, or when the
+// only answer is Caddy's own HTTPS redirect (no deployment header) — both of
+// which mean "ask :443 instead".
+func probePlaintext(ctx context.Context, p ReadinessProber, container, domain string) (dataPlaneResult, bool) {
+	probeCtx, cancel := context.WithTimeout(ctx, dataPlaneProbeTimeout)
+	defer cancel()
+	// printf with the domain as an *argument* (not in the format string), so a
+	// hostname can't smuggle format directives; isProbableHostname already
+	// bounds it to a safe charset for the surrounding single-quotes.
+	script := fmt.Sprintf(
+		`printf 'GET / HTTP/1.1\r\nHost: %%s\r\nConnection: close\r\n\r\n' '%s' | nc -w 3 localhost 80`,
+		domain,
+	)
+	var stdout bytes.Buffer
+	// nc exits non-zero on connection refused; we decide on parsed output, not
+	// exit code (mirrors the busybox-exit-code caveat on the wget path).
+	_ = p.Exec(probeCtx, container, []string{"sh", "-c", script}, &stdout, io.Discard)
+
+	res, parsed := parseHTTPHead(stdout.String())
+	if !parsed {
+		return dataPlaneResult{}, false // :80 closed / nc failed → try TLS
+	}
+	if res.Served == "" && isRedirect(res.Status) {
+		// Standalone's :80→:443 redirect vhost: a 3xx with no project header.
+		// Project-level redirects come *through* the reverse_proxy and carry
+		// the header, so they won't be misclassified here.
+		return dataPlaneResult{}, false
+	}
+	return res, true
+}
+
+// probeHTTPS probes Caddy's :443 listener with busybox wget over TLS. wget -S
+// writes the response head to stderr; we parse there. Note busybox wget exits
+// non-zero on any 4xx/5xx even when a header is present, so we never gate on
+// the exit code — only on whether a status line was parsed.
+func probeHTTPS(ctx context.Context, p ReadinessProber, container, domain string) (dataPlaneResult, bool) {
+	probeCtx, cancel := context.WithTimeout(ctx, dataPlaneProbeTimeout)
+	defer cancel()
+	cmd := []string{
+		"wget", "-S", "-O", "/dev/null", "-T", "4",
+		"--no-check-certificate",
+		"--header", "Host: " + domain,
+		"https://localhost/",
+	}
+	var stderr bytes.Buffer
+	_ = p.Exec(probeCtx, container, cmd, io.Discard, &stderr)
+	return parseHTTPHead(stderr.String())
+}
+
+// parseHTTPHead scans raw response text (an nc body or busybox `wget -S`
+// stderr) for the first HTTP status line and the X-Cobalt-Deployment header,
+// stopping at the first blank line (end of headers). Each line is left-trimmed
+// so it copes with wget's leading-space indentation. parsed is false when no
+// HTTP status line is present.
+func parseHTTPHead(raw string) (res dataPlaneResult, parsed bool) {
+	for _, rawLine := range strings.Split(raw, "\n") {
+		line := strings.TrimSpace(rawLine)
+		if line == "" {
+			if parsed {
+				break // end of header block
+			}
+			continue
+		}
+		if !parsed && strings.HasPrefix(line, "HTTP/") {
+			res.Status = parseStatusCode(line)
+			parsed = true
+			continue
+		}
+		if parsed {
+			if name, val, ok := splitHeader(line); ok &&
+				strings.EqualFold(name, caddy.DeploymentHeader) {
+				res.Served = val
+			}
+		}
+	}
+	return res, parsed
+}
+
+// parseStatusCode pulls the numeric code out of a status line like
+// "HTTP/1.1 502 Bad Gateway". Returns 0 if it can't.
+func parseStatusCode(statusLine string) int {
+	fields := strings.Fields(statusLine)
+	if len(fields) < 2 {
+		return 0
+	}
+	n, _ := strconv.Atoi(fields[1])
+	return n
+}
+
+// splitHeader splits "Name: value" into its parts.
+func splitHeader(line string) (name, value string, ok bool) {
+	i := strings.IndexByte(line, ':')
+	if i < 0 {
+		return "", "", false
+	}
+	return strings.TrimSpace(line[:i]), strings.TrimSpace(line[i+1:]), true
+}
+
+func isRedirect(status int) bool { return status >= 300 && status < 400 }
+
+func isGatewayError(status int) bool {
+	return status == 502 || status == 503 || status == 504
+}
+
+// primaryDomainLister is the store subset waitDataPlaneServing needs.
+type primaryDomainLister interface {
+	ListPrimaryDomainsForProject(ctx context.Context, projectID int64) ([]string, error)
+}
+
+// Tunable so tests can shrink the wait; production leaves the defaults.
+var (
+	dataPlaneVerifyTimeout = 30 * time.Second
+	dataPlaneVerifyPoll    = 2 * time.Second
+)
+
+// waitDataPlaneServing blocks until Caddy's running router actually serves the
+// just-cut-over deployment on the data plane — confirming the cutover landed
+// in the *compiled* router, not merely the admin config tree (which can lag
+// under reload pressure; that lag, against a since-deleted upstream, is the
+// post-cutover 502 incident this guards).
+//
+// Returns nil (nothing to probe) for non-container web types, internally
+// exposed services, and projects with no primary domains.
+//
+// Timeout policy is deliberately asymmetric:
+//   - Saw the router serving a DIFFERENT deployment, or a gateway error
+//     (502/503/504 — dialing a dead upstream)? That's real divergence:
+//     return an error so the caller reverts. This is the incident signature.
+//   - Only ever got probe-infra failures (Caddy unreachable / no header)?
+//     Log loudly but return nil — a broken probe must not fail every deploy,
+//     and the convergence reconciler still catches real post-deploy drift.
+func waitDataPlaneServing(
+	ctx context.Context,
+	p ReadinessProber,
+	st primaryDomainLister,
+	project store.Project,
+	dep store.Deployment,
+	cf *cobaltfile.Cobaltfile,
+	log *slog.Logger,
+	out io.Writer,
+) error {
+	web, ok := cf.Services["web"]
+	if !ok || web.ExposedInternally || web.Type != cobaltfile.TypeContainer {
+		return nil
+	}
+	domains, err := st.ListPrimaryDomainsForProject(ctx, project.ID)
+	if err != nil {
+		log.Warn("data-plane verify: list domains failed; skipping",
+			"project_id", project.ID, "error", err)
+		return nil
+	}
+	if len(domains) == 0 {
+		return nil
+	}
+	domain := domains[0]
+	want := strconv.Itoa(dep.Number)
+
+	fmt.Fprintf(out, "🔎 confirming the live router serves deployment #%d\n", dep.Number)
+
+	deadline := time.Now().Add(dataPlaneVerifyTimeout)
+	var sawDivergence bool
+	var lastDetail string
+	for {
+		if err := ctx.Err(); err != nil {
+			return err
+		}
+		res, err := probeDataPlane(ctx, p, domain)
+		switch {
+		case err != nil:
+			lastDetail = err.Error()
+		case res.Served == want:
+			fmt.Fprintf(out, "✅ live router serves deployment #%d\n", dep.Number)
+			return nil
+		case isGatewayError(res.Status):
+			sawDivergence = true
+			lastDetail = fmt.Sprintf("router returned %d (dialing a dead upstream)", res.Status)
+		case res.Served != "" && res.Served != want:
+			sawDivergence = true
+			lastDetail = fmt.Sprintf("router still serves deployment %s, want %s", res.Served, want)
+		default:
+			lastDetail = fmt.Sprintf("no deployment header yet (status %d)", res.Status)
+		}
+		if time.Now().After(deadline) {
+			break
+		}
+		select {
+		case <-ctx.Done():
+			return ctx.Err()
+		case <-time.After(dataPlaneVerifyPoll):
+		}
+	}
+
+	if sawDivergence {
+		return fmt.Errorf(
+			"live router never converged to deployment #%d within %s: %s",
+			dep.Number, dataPlaneVerifyTimeout, lastDetail)
+	}
+	log.Warn("data-plane verify: no positive confirmation, proceeding (probe inconclusive)",
+		"project_id", project.ID, "deployment", dep.Number, "detail", lastDetail)
+	fmt.Fprintf(out, "⚠️  could not confirm live router (probe inconclusive); proceeding — reconciler will self-heal if needed\n")
+	return nil
+}
+
+// isProbableHostname reports whether s is a plausible DNS hostname — letters,
+// digits, dot, hyphen only. Used to keep the probe's shell command injection-
+// free; anything outside this charset is refused rather than escaped.
+func isProbableHostname(s string) bool {
+	if s == "" || len(s) > 253 {
+		return false
+	}
+	for _, r := range s {
+		switch {
+		case r >= 'a' && r <= 'z',
+			r >= 'A' && r <= 'Z',
+			r >= '0' && r <= '9',
+			r == '.' || r == '-':
+		default:
+			return false
+		}
+	}
+	return true
+}
+
+// CaddyDataPlaneProber adapts a ReadinessProber into the deployment-identity
+// probe the Caddy reconciler consumes (worker.DataPlaneProber). It lives here
+// because the probe mechanics (exec-through-caddy) belong to deploy; the
+// reconciler depends on it through a structural interface, so worker never
+// imports deploy.
+type CaddyDataPlaneProber struct {
+	Prober ReadinessProber
+}
+
+// ServedDeployment reports the deployment number the running router serves for
+// domain (via X-Cobalt-Deployment), plus the HTTP status. served == "" means
+// no header (pre-header handler or non-project response). A non-nil error
+// means the probe could not run; callers treat that as "unknown", not drift.
+func (c CaddyDataPlaneProber) ServedDeployment(ctx context.Context, domain string) (served string, status int, err error) {
+	res, err := probeDataPlane(ctx, c.Prober, domain)
+	if err != nil {
+		return "", 0, err
+	}
+	return res.Served, res.Status, nil
+}

--- a/internal/server/deploy/dataplane_test.go
+++ b/internal/server/deploy/dataplane_test.go
@@ -1,0 +1,220 @@
+package deploy
+
+import (
+	"context"
+	"errors"
+	"io"
+	"log/slog"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/heyblueteam/cobalt/internal/server/cobaltfile"
+	"github.com/heyblueteam/cobalt/internal/server/store"
+)
+
+func TestParseHTTPHead(t *testing.T) {
+	t.Parallel()
+	tests := []struct {
+		name       string
+		raw        string
+		wantParsed bool
+		wantStatus int
+		wantServed string
+	}{
+		{
+			name:       "nc plaintext 200 with header",
+			raw:        "HTTP/1.1 200 OK\r\nServer: Caddy\r\nX-Cobalt-Deployment: 114\r\nContent-Length: 0\r\n\r\n",
+			wantParsed: true, wantStatus: 200, wantServed: "114",
+		},
+		{
+			name:       "gateway 502 carries no header (dead upstream)",
+			raw:        "HTTP/1.1 502 Bad Gateway\r\nServer: Caddy\r\n\r\n",
+			wantParsed: true, wantStatus: 502, wantServed: "",
+		},
+		{
+			// busybox `wget -S` indents each response-head line with spaces.
+			name:       "wget -S indented output",
+			raw:        "Connecting to localhost:443\n  HTTP/1.1 200 OK\n  Server: Caddy\n  X-Cobalt-Deployment: 207\n\n",
+			wantParsed: true, wantStatus: 200, wantServed: "207",
+		},
+		{
+			name:       "header name is case-insensitive",
+			raw:        "HTTP/1.1 200 OK\r\nx-cobalt-deployment: 9\r\n\r\n",
+			wantParsed: true, wantStatus: 200, wantServed: "9",
+		},
+		{
+			name:       "standalone redirect: 3xx, no header",
+			raw:        "HTTP/1.1 308 Permanent Redirect\r\nLocation: https://app.example.com/\r\n\r\n",
+			wantParsed: true, wantStatus: 308, wantServed: "",
+		},
+		{
+			name:       "header after blank line is ignored (body, not head)",
+			raw:        "HTTP/1.1 200 OK\r\n\r\nX-Cobalt-Deployment: 5\r\n",
+			wantParsed: true, wantStatus: 200, wantServed: "",
+		},
+		{
+			name:       "no HTTP response (connection refused)",
+			raw:        "nc: bad address 'localhost'\n",
+			wantParsed: false,
+		},
+		{
+			name:       "empty",
+			raw:        "",
+			wantParsed: false,
+		},
+	}
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+			res, parsed := parseHTTPHead(tc.raw)
+			if parsed != tc.wantParsed {
+				t.Fatalf("parsed: got %v, want %v", parsed, tc.wantParsed)
+			}
+			if !parsed {
+				return
+			}
+			if res.Status != tc.wantStatus {
+				t.Errorf("status: got %d, want %d", res.Status, tc.wantStatus)
+			}
+			if res.Served != tc.wantServed {
+				t.Errorf("served: got %q, want %q", res.Served, tc.wantServed)
+			}
+		})
+	}
+}
+
+func TestIsProbableHostname(t *testing.T) {
+	t.Parallel()
+	ok := []string{"blue.app", "wl.blue.app", "a-b.example.com", "localhost"}
+	bad := []string{"", "has space.com", "semi;colon", "back`tick", "quote'd", "pipe|d", "$(x)"}
+	for _, h := range ok {
+		if !isProbableHostname(h) {
+			t.Errorf("isProbableHostname(%q) = false, want true", h)
+		}
+	}
+	for _, h := range bad {
+		if isProbableHostname(h) {
+			t.Errorf("isProbableHostname(%q) = true, want false", h)
+		}
+	}
+}
+
+// fakeDataPlaneProber stands in for *docker.Client in waitDataPlaneServing tests. It
+// answers the :80 plaintext path (cmd[0]=="sh") with a canned HTTP response;
+// the :443 wget fallback always "fails to connect" so tests exercise the
+// plaintext branch deterministically.
+type fakeDataPlaneProber struct {
+	plaintextResp string // written to stdout for the nc path; "" + err => :80 closed
+	plaintextErr  error
+}
+
+func (f *fakeDataPlaneProber) FindContainerByLabel(context.Context, string) (string, error) {
+	return "cobalt-caddy", nil
+}
+
+func (f *fakeDataPlaneProber) Exec(_ context.Context, _ string, cmd []string, stdout, _ io.Writer) error {
+	if len(cmd) > 0 && cmd[0] == "sh" { // plaintext :80 path
+		if f.plaintextResp != "" {
+			_, _ = io.WriteString(stdout, f.plaintextResp)
+		}
+		return f.plaintextErr
+	}
+	return errors.New("wget: can't connect to remote host") // :443 closed
+}
+
+type fakeDomainLister struct {
+	domains []string
+	err     error
+}
+
+func (f fakeDomainLister) ListPrimaryDomainsForProject(context.Context, int64) ([]string, error) {
+	return f.domains, f.err
+}
+
+func resp(status, served string) string {
+	head := "HTTP/1.1 " + status + "\r\nServer: Caddy\r\n"
+	if served != "" {
+		head += "X-Cobalt-Deployment: " + served + "\r\n"
+	}
+	return head + "\r\n"
+}
+
+func TestWaitDataPlaneServing(t *testing.T) {
+	// Shrink the wait; these globals are only ever read by this function and
+	// only when an Orchestrator has a non-nil DataPlaneProber (never in other
+	// tests), so mutating them here is safe.
+	origTimeout, origPoll := dataPlaneVerifyTimeout, dataPlaneVerifyPoll
+	dataPlaneVerifyTimeout, dataPlaneVerifyPoll = 40*time.Millisecond, 5*time.Millisecond
+	t.Cleanup(func() { dataPlaneVerifyTimeout, dataPlaneVerifyPoll = origTimeout, origPoll })
+
+	container := &cobaltfile.Cobaltfile{Services: map[string]cobaltfile.Service{
+		"web": {Type: cobaltfile.TypeContainer, Port: 3000},
+	}}
+	static := &cobaltfile.Cobaltfile{Services: map[string]cobaltfile.Service{
+		"web": {Type: cobaltfile.TypeStatic},
+	}}
+	project := store.Project{ID: 1, Name: "api"}
+	dep := store.Deployment{Number: 5}
+	log := slog.New(slog.NewTextHandler(io.Discard, nil))
+
+	tests := []struct {
+		name      string
+		prober    *fakeDataPlaneProber
+		cf        *cobaltfile.Cobaltfile
+		domains   []string
+		wantErr   bool
+		errSubstr string
+	}{
+		{
+			name:   "router serves new deployment → pass",
+			prober: &fakeDataPlaneProber{plaintextResp: resp("200 OK", "5")},
+			cf:     container, domains: []string{"api.example.com"},
+		},
+		{
+			name:   "router 502s on dead upstream → hard fail (the incident)",
+			prober: &fakeDataPlaneProber{plaintextResp: resp("502 Bad Gateway", "")},
+			cf:     container, domains: []string{"api.example.com"},
+			wantErr: true, errSubstr: "never converged",
+		},
+		{
+			name:   "router still serves old deployment → hard fail",
+			prober: &fakeDataPlaneProber{plaintextResp: resp("200 OK", "3")},
+			cf:     container, domains: []string{"api.example.com"},
+			wantErr: true, errSubstr: "never converged",
+		},
+		{
+			name:   "probe infra broken (caddy unreachable) → soft pass",
+			prober: &fakeDataPlaneProber{plaintextErr: errors.New("nc failed")},
+			cf:     container, domains: []string{"api.example.com"},
+		},
+		{
+			name:   "static web type → skipped, no probe",
+			prober: &fakeDataPlaneProber{plaintextResp: resp("502 Bad Gateway", "")},
+			cf:     static, domains: []string{"api.example.com"},
+		},
+		{
+			name:   "no domains → skipped",
+			prober: &fakeDataPlaneProber{plaintextResp: resp("502 Bad Gateway", "")},
+			cf:     container, domains: nil,
+		},
+	}
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			st := fakeDomainLister{domains: tc.domains}
+			err := waitDataPlaneServing(context.Background(), tc.prober, st, project, dep, tc.cf, log, io.Discard)
+			if tc.wantErr {
+				if err == nil {
+					t.Fatalf("want error, got nil")
+				}
+				if tc.errSubstr != "" && !strings.Contains(err.Error(), tc.errSubstr) {
+					t.Errorf("error %q missing %q", err, tc.errSubstr)
+				}
+				return
+			}
+			if err != nil {
+				t.Fatalf("want nil, got %v", err)
+			}
+		})
+	}
+}

--- a/internal/server/deploy/orchestrator.go
+++ b/internal/server/deploy/orchestrator.go
@@ -34,6 +34,12 @@ type Orchestrator struct {
 	// get registered with the scheduler. nil in unit tests that don't
 	// exercise the cron path.
 	CronManager CronReconciler
+	// DataPlaneProber, when non-nil, gates each container cutover on a real
+	// request through Caddy's own listener confirming the running router
+	// serves the new deployment (not just the admin config tree, which can
+	// lag). Production wires the docker client; left nil in unit tests that
+	// don't exercise the data-plane gate, so the cutover path stays hermetic.
+	DataPlaneProber ReadinessProber
 }
 
 // CronReconciler is the cron-side surface the orchestrator calls
@@ -246,6 +252,19 @@ func (o *Orchestrator) cutover(
 		revertCaddySwap(context.Background(), log, o.Caddy, o.DB, *project, cf)
 		_ = stopServices(context.Background(), o.Docker, startedServices)
 		return fmt.Errorf("deploy: commit caddy: %w", err)
+	}
+
+	// Confirm the *running* router — not just the admin config tree — actually
+	// serves the new deployment before declaring success. Under reload pressure
+	// Caddy's admin API can report the new upstream while the compiled router
+	// still dials the old (now-deleted) container, 502ing every fresh request.
+	if o.DataPlaneProber != nil {
+		if err := waitDataPlaneServing(ctx, o.DataPlaneProber, o.DB, *project, dep, cf, log, out); err != nil {
+			fmt.Fprintf(out, "↩️  data-plane verify failed, reverting\n")
+			revertCaddySwap(context.Background(), log, o.Caddy, o.DB, *project, cf)
+			_ = stopServices(context.Background(), o.Docker, startedServices)
+			return fmt.Errorf("deploy: %w", err)
+		}
 	}
 	fmt.Fprintf(out, "✅ traffic swap verified\n")
 

--- a/internal/server/deploy/swap.go
+++ b/internal/server/deploy/swap.go
@@ -17,9 +17,9 @@ type SwapDocker interface{}
 // SwapCaddy is the Caddy subset swap-step helpers need.
 type SwapCaddy interface {
 	SetDomainsForProject(ctx context.Context, projectID int64, domains []string) error
-	VerifyServeService(ctx context.Context, projectID int64, container string, port int) error
+	VerifyServeService(ctx context.Context, projectID int64, container string, port, deploymentNumber int) error
 	ServeStaticSite(ctx context.Context, projectID int64, projectName string, deploymentNumber int) error
-	ServeService(ctx context.Context, projectID int64, container string, port int) error
+	ServeService(ctx context.Context, projectID int64, container string, port, deploymentNumber int) error
 }
 
 // SwapStore is the store subset swap-step helpers need.
@@ -73,7 +73,7 @@ func commitCaddySwap(
 	case cobaltfile.TypeContainer:
 		container := docker.ServiceName(project.Name, dep.Number, "web")
 		port := web.Port
-		if err := cy.VerifyServeService(ctx, project.ID, container, port); err != nil {
+		if err := cy.VerifyServeService(ctx, project.ID, container, port, dep.Number); err != nil {
 			return fmt.Errorf("deploy.commitCaddySwap: %w", err)
 		}
 	case cobaltfile.TypeStatic, cobaltfile.TypeGenerator:
@@ -117,7 +117,7 @@ func revertCaddySwap(
 	switch web.Type {
 	case cobaltfile.TypeContainer:
 		container := docker.ServiceName(project.Name, prev.Number, "web")
-		if err := cy.ServeService(ctx, project.ID, container, web.Port); err != nil {
+		if err := cy.ServeService(ctx, project.ID, container, web.Port, prev.Number); err != nil {
 			log.Error("deploy.revertCaddySwap: container revert failed",
 				"project_id", project.ID, "want_upstream", container, "error", err)
 		}

--- a/internal/server/deploy/swap_test.go
+++ b/internal/server/deploy/swap_test.go
@@ -29,14 +29,16 @@ type fakeSwapCaddy struct {
 }
 
 type verifyCall struct {
-	projectID int64
-	container string
-	port      int
+	projectID        int64
+	container        string
+	port             int
+	deploymentNumber int
 }
 type serveSvcCall struct {
-	projectID int64
-	container string
-	port      int
+	projectID        int64
+	container        string
+	port             int
+	deploymentNumber int
 }
 type staticCall struct {
 	projectID        int64
@@ -52,17 +54,17 @@ func (f *fakeSwapCaddy) SetDomainsForProject(_ context.Context, projectID int64,
 	return f.setDomainsErr
 }
 
-func (f *fakeSwapCaddy) VerifyServeService(_ context.Context, projectID int64, container string, port int) error {
+func (f *fakeSwapCaddy) VerifyServeService(_ context.Context, projectID int64, container string, port, deploymentNumber int) error {
 	f.mu.Lock()
 	defer f.mu.Unlock()
-	f.verifyCalls = append(f.verifyCalls, verifyCall{projectID, container, port})
+	f.verifyCalls = append(f.verifyCalls, verifyCall{projectID, container, port, deploymentNumber})
 	return f.verifyErr
 }
 
-func (f *fakeSwapCaddy) ServeService(_ context.Context, projectID int64, container string, port int) error {
+func (f *fakeSwapCaddy) ServeService(_ context.Context, projectID int64, container string, port, deploymentNumber int) error {
 	f.mu.Lock()
 	defer f.mu.Unlock()
-	f.serveSvcCalls = append(f.serveSvcCalls, serveSvcCall{projectID, container, port})
+	f.serveSvcCalls = append(f.serveSvcCalls, serveSvcCall{projectID, container, port, deploymentNumber})
 	return f.serveSvcErr
 }
 

--- a/internal/server/docker/names.go
+++ b/internal/server/docker/names.go
@@ -2,6 +2,7 @@ package docker
 
 import (
 	"fmt"
+	"strconv"
 	"strings"
 )
 
@@ -12,6 +13,33 @@ import (
 //	{projectName}-{deploymentNumber}-{serviceName}
 func ServiceName(projectName string, deploymentNumber int, serviceName string) string {
 	return fmt.Sprintf("%s-%d-%s", projectName, deploymentNumber, serviceName)
+}
+
+// WebGeneration parses the deployment number out of a project's `web` service
+// name — the inverse of ServiceName(projectName, n, "web"). It returns
+// ok=false for names that don't belong to this project or aren't the `web`
+// service (worker/cron services, other projects, malformed names).
+//
+// projectName is taken as known (not parsed back out) so a hyphenated project
+// name — or a hyphenated service name — doesn't make the split ambiguous.
+func WebGeneration(projectName, serviceName string) (int, bool) {
+	rest, ok := strings.CutPrefix(serviceName, projectName+"-")
+	if !ok {
+		return 0, false
+	}
+	// rest is "{number}-{serviceName}", e.g. "114-web"; split on the first '-'.
+	i := strings.IndexByte(rest, '-')
+	if i <= 0 {
+		return 0, false
+	}
+	if rest[i+1:] != "web" {
+		return 0, false
+	}
+	n, err := strconv.Atoi(rest[:i])
+	if err != nil {
+		return 0, false
+	}
+	return n, true
 }
 
 // NetworkName is the docker overlay network for a project's deployment.

--- a/internal/server/docker/names_test.go
+++ b/internal/server/docker/names_test.go
@@ -22,6 +22,37 @@ func TestNames(t *testing.T) {
 	}
 }
 
+func TestWebGeneration(t *testing.T) {
+	t.Parallel()
+	cases := []struct {
+		project, service string
+		wantN            int
+		wantOK           bool
+	}{
+		{"api", "api-7-web", 7, true},
+		{"api", "api-114-web", 114, true},
+		// hyphenated project name — projectName is known, so the split is safe.
+		{"my-app", "my-app-3-web", 3, true},
+		// non-web services are not web generations.
+		{"api", "api-7-worker", 0, false},
+		{"api", "api-7-cron-nightly", 0, false},
+		// other project / unrelated names.
+		{"api", "web-7-web", 0, false},
+		{"api", "api-web", 0, false},
+		{"api", "api-x-web", 0, false},
+		{"api", "", 0, false},
+		// round-trips with ServiceName.
+		{"api", ServiceName("api", 42, "web"), 42, true},
+	}
+	for _, c := range cases {
+		n, ok := WebGeneration(c.project, c.service)
+		if ok != c.wantOK || n != c.wantN {
+			t.Errorf("WebGeneration(%q, %q) = (%d, %v), want (%d, %v)",
+				c.project, c.service, n, ok, c.wantN, c.wantOK)
+		}
+	}
+}
+
 func TestSplitParams(t *testing.T) {
 	t.Parallel()
 	cases := []struct {

--- a/internal/server/server.go
+++ b/internal/server/server.go
@@ -171,14 +171,15 @@ func Run(ctx context.Context, cfg Config) error {
 	cronMgr := worker.NewCronManager(sched, dockerCli, db, log)
 
 	orchestrator := &deploy.Orchestrator{
-		DB:          db,
-		Docker:      dockerCli,
-		Caddy:       caddyCli,
-		Preparer:    preparer,
-		Builder:     builder,
-		DataDir:     cfg.DataDir,
-		Log:         log,
-		CronManager: cronMgr,
+		DB:              db,
+		Docker:          dockerCli,
+		Caddy:           caddyCli,
+		Preparer:        preparer,
+		Builder:         builder,
+		DataDir:         cfg.DataDir,
+		Log:             log,
+		CronManager:     cronMgr,
+		DataPlaneProber: dockerCli,
 	}
 
 	queue := deploy.NewQueue(db)
@@ -290,8 +291,9 @@ func registerScheduledJobs(
 			log.Warn("pending-apps cleanup failed", "error", err)
 		}
 	})
+	dataPlaneProber := deploy.CaddyDataPlaneProber{Prober: dockerCli}
 	_ = sched.Schedule("caddy-reconcile", "@every 30s", func(ctx context.Context) {
-		if _, err := worker.ReconcileCaddyState(ctx, log, db, caddyCli); err != nil {
+		if _, err := worker.ReconcileCaddyState(ctx, log, db, caddyCli, dataPlaneProber, dockerCli); err != nil {
 			log.Warn("caddy reconcile failed", "error", err)
 		}
 	})

--- a/internal/server/worker/caddy_dataplane_test.go
+++ b/internal/server/worker/caddy_dataplane_test.go
@@ -1,0 +1,170 @@
+package worker
+
+import (
+	"context"
+	"testing"
+
+	"github.com/heyblueteam/cobalt/internal/server/cobaltfile"
+	"github.com/heyblueteam/cobalt/internal/server/docker"
+	"github.com/heyblueteam/cobalt/internal/server/store"
+	"github.com/heyblueteam/cobalt/pkg/cobaltapi"
+)
+
+// fakeDataPlaneProber returns a canned ServedDeployment for every domain.
+type fakeDataPlaneProber struct {
+	served string
+	status int
+	err    error
+}
+
+func (f fakeDataPlaneProber) ServedDeployment(context.Context, string) (string, int, error) {
+	return f.served, f.status, f.err
+}
+
+// fakeReaper records RemoveService calls and serves a fixed service list.
+type fakeReaper struct {
+	services []docker.ServiceInfo
+	removed  []string
+	listErr  error
+}
+
+func (f *fakeReaper) ListServicesForProject(context.Context, int64) ([]docker.ServiceInfo, error) {
+	return f.services, f.listErr
+}
+
+func (f *fakeReaper) RemoveService(_ context.Context, name string) error {
+	f.removed = append(f.removed, name)
+	return nil
+}
+
+// inSyncFixture builds a store + caddy where the admin config tree is correct
+// (upstream == api-7-web): the case where only a data-plane probe can reveal a
+// lagging compiled router.
+func inSyncFixture(t *testing.T) (*fakeReconcileStore, *fakeReconcileCaddy) {
+	t.Helper()
+	cf := mustCobaltfileJSON(t, &cobaltfile.Cobaltfile{
+		Version: "1.0",
+		Services: map[string]cobaltfile.Service{
+			"web": {Type: cobaltfile.TypeContainer, Image: "default", Port: 3000},
+		},
+		Images: map[string]cobaltfile.Image{"default": {Dockerfile: "Dockerfile", Context: "."}},
+	})
+	st := &fakeReconcileStore{
+		projects: []store.Project{{ID: 1, Name: "api"}},
+		lastByID: map[int64]*store.Deployment{
+			1: {ID: 10, ProjectID: 1, Number: 7, Status: cobaltapi.StateSuccess, ResolvedCobaltfile: nullStr(cf)},
+		},
+		domains: map[int64][]string{1: {"api.example.com"}},
+	}
+	cy := newFakeReconcileCaddy()
+	cy.routeExists[1] = true
+	cy.upstream[1] = "api-7-web" // admin tree is correct
+	return st, cy
+}
+
+func TestReconcile_DataPlaneServesOldDeployment_ForcesRepair(t *testing.T) {
+	t.Parallel()
+	st, cy := inSyncFixture(t)
+	dp := fakeDataPlaneProber{served: "5", status: 200} // router still on #5
+
+	corrected, err := ReconcileCaddyState(context.Background(), quietLogger(), st, cy, dp, nil)
+	if err != nil {
+		t.Fatalf("Reconcile: %v", err)
+	}
+	if corrected != 1 {
+		t.Errorf("corrected: got %d, want 1", corrected)
+	}
+	if len(cy.serveCalls) != 1 || cy.serveCalls[0].Container != "api-7-web" {
+		t.Errorf("expected one ServeService repair to api-7-web, got %+v", cy.serveCalls)
+	}
+}
+
+func TestReconcile_DataPlaneGatewayError_ForcesRepair(t *testing.T) {
+	t.Parallel()
+	st, cy := inSyncFixture(t)
+	dp := fakeDataPlaneProber{served: "", status: 502} // dialing a dead upstream
+
+	corrected, err := ReconcileCaddyState(context.Background(), quietLogger(), st, cy, dp, nil)
+	if err != nil {
+		t.Fatalf("Reconcile: %v", err)
+	}
+	if corrected != 1 {
+		t.Errorf("corrected: got %d, want 1 (502 = divergence)", corrected)
+	}
+	if len(cy.serveCalls) != 1 {
+		t.Errorf("expected one ServeService repair, got %d", len(cy.serveCalls))
+	}
+}
+
+func TestReconcile_DataPlaneNoHeader_NoRepair(t *testing.T) {
+	t.Parallel()
+	st, cy := inSyncFixture(t)
+	dp := fakeDataPlaneProber{served: "", status: 200} // pre-header handler / unknown
+
+	corrected, err := ReconcileCaddyState(context.Background(), quietLogger(), st, cy, dp, nil)
+	if err != nil {
+		t.Fatalf("Reconcile: %v", err)
+	}
+	if corrected != 0 || len(cy.serveCalls) != 0 {
+		t.Errorf("served=\"\" must be treated as unknown, not drift: corrected=%d serveCalls=%d",
+			corrected, len(cy.serveCalls))
+	}
+}
+
+func TestReconcile_DataPlaneProbeInconclusive_NoRepair(t *testing.T) {
+	t.Parallel()
+	st, cy := inSyncFixture(t)
+	dp := fakeDataPlaneProber{err: context.DeadlineExceeded} // caddy unreachable
+
+	corrected, err := ReconcileCaddyState(context.Background(), quietLogger(), st, cy, dp, nil)
+	if err != nil {
+		t.Fatalf("Reconcile: %v", err)
+	}
+	if corrected != 0 || len(cy.serveCalls) != 0 {
+		t.Errorf("inconclusive probe must not force a repair: corrected=%d serveCalls=%d",
+			corrected, len(cy.serveCalls))
+	}
+}
+
+func TestReconcile_DataPlaneHealthy_ReapsSupersededWebOnly(t *testing.T) {
+	t.Parallel()
+	st, cy := inSyncFixture(t)
+	dp := fakeDataPlaneProber{served: "7", status: 200} // router confirmed on #7
+	reaper := &fakeReaper{services: []docker.ServiceInfo{
+		{Name: "api-7-web"},    // current — keep
+		{Name: "api-6-web"},    // superseded web — reap
+		{Name: "api-6-worker"}, // worker — not our concern here
+		{Name: "other-6-web"},  // different project — ignore
+	}}
+
+	corrected, err := ReconcileCaddyState(context.Background(), quietLogger(), st, cy, dp, reaper)
+	if err != nil {
+		t.Fatalf("Reconcile: %v", err)
+	}
+	if corrected != 0 || len(cy.serveCalls) != 0 {
+		t.Errorf("healthy data plane must not repair: corrected=%d serveCalls=%d", corrected, len(cy.serveCalls))
+	}
+	if len(reaper.removed) != 1 || reaper.removed[0] != "api-6-web" {
+		t.Errorf("expected to reap only api-6-web, got %v", reaper.removed)
+	}
+}
+
+func TestReconcile_NilProber_StillReapsButNeverDataPlaneRepairs(t *testing.T) {
+	t.Parallel()
+	st, cy := inSyncFixture(t)
+	reaper := &fakeReaper{services: []docker.ServiceInfo{
+		{Name: "api-7-web"},
+		{Name: "api-6-web"},
+	}}
+
+	corrected, err := ReconcileCaddyState(context.Background(), quietLogger(), st, cy, nil, reaper)
+	if err != nil {
+		t.Fatalf("Reconcile: %v", err)
+	}
+	if corrected != 0 || len(cy.serveCalls) != 0 {
+		t.Errorf("nil prober must not repair: corrected=%d serveCalls=%d", corrected, len(cy.serveCalls))
+	}
+	if len(reaper.removed) != 1 || reaper.removed[0] != "api-6-web" {
+		t.Errorf("expected to reap api-6-web even with nil prober, got %v", reaper.removed)
+	}
+}

--- a/internal/server/worker/caddy_reconcile.go
+++ b/internal/server/worker/caddy_reconcile.go
@@ -5,6 +5,7 @@ import (
 	"errors"
 	"fmt"
 	"log/slog"
+	"strconv"
 
 	"github.com/heyblueteam/cobalt/internal/server/caddy"
 	"github.com/heyblueteam/cobalt/internal/server/cobaltfile"
@@ -29,13 +30,36 @@ type CaddyReconcileStore interface {
 	ActiveDeploymentForProject(ctx context.Context, projectID int64) (*store.Deployment, error)
 }
 
+// DataPlaneProber reports which deployment Caddy's *running* router actually
+// serves for a domain — ground truth the admin API cannot give, because the
+// compiled router can lag the config tree under reload pressure (the silent
+// divergence behind the post-cutover 502 incident). A nil prober disables the
+// data-plane convergence check (unit tests that don't exercise it).
+type DataPlaneProber interface {
+	// ServedDeployment returns the deployment number the running router serves
+	// for domain (via the X-Cobalt-Deployment header) plus the HTTP status.
+	// served == "" means no header (pre-header handler / unknown). A non-nil
+	// error means the probe couldn't run; callers treat that as "unknown",
+	// never as drift.
+	ServedDeployment(ctx context.Context, domain string) (served string, status int, err error)
+}
+
+// ServiceReaper lists and removes a project's docker services. The reconciler
+// uses it to reap a superseded `*-web` generation kept alive for grace (see
+// deploy.cleanupOldServices) once the data plane confirms the current
+// deployment is serving. A nil reaper disables reaping.
+type ServiceReaper interface {
+	ListServicesForProject(ctx context.Context, projectID int64) ([]docker.ServiceInfo, error)
+	RemoveService(ctx context.Context, name string) error
+}
+
 // CaddyReconcileTarget is the Caddy subset the reconciler talks to.
 type CaddyReconcileTarget interface {
 	ProjectRouteExists(ctx context.Context, projectID int64) (bool, error)
 	AddProjectRoute(ctx context.Context, projectID int64, domains []string) error
 	CurrentUpstream(ctx context.Context, projectID int64) (string, error)
 	CurrentDomains(ctx context.Context, projectID int64) ([]string, error)
-	ServeService(ctx context.Context, projectID int64, container string, port int) error
+	ServeService(ctx context.Context, projectID int64, container string, port, deploymentNumber int) error
 	ServeStaticSite(ctx context.Context, projectID int64, projectName string, deploymentNumber int) error
 	SetDomainsForProject(ctx context.Context, projectID int64, domains []string) error
 }
@@ -62,6 +86,8 @@ func ReconcileCaddyState(
 	log *slog.Logger,
 	st CaddyReconcileStore,
 	cy CaddyReconcileTarget,
+	dp DataPlaneProber,
+	reaper ServiceReaper,
 ) (int, error) {
 	if log == nil {
 		log = slog.Default()
@@ -73,7 +99,7 @@ func ReconcileCaddyState(
 
 	r := reconcileResult{}
 	for _, p := range projects {
-		corrected, err := reconcileProject(ctx, log, st, cy, p)
+		corrected, err := reconcileProject(ctx, log, st, cy, dp, reaper, p)
 		if err != nil {
 			log.Warn("caddy reconcile: project failed",
 				"project_id", p.ID, "project", p.Name, "error", err)
@@ -98,6 +124,8 @@ func reconcileProject(
 	log *slog.Logger,
 	st CaddyReconcileStore,
 	cy CaddyReconcileTarget,
+	dp DataPlaneProber,
+	reaper ServiceReaper,
 	p store.Project,
 ) (bool, error) {
 	// Stand down while a deploy is in flight. A deploy owns its project's
@@ -183,16 +211,32 @@ func reconcileProject(
 		if err != nil {
 			return false, fmt.Errorf("read current upstream: %w", err)
 		}
-		if got == want {
-			return false, nil
+		if got != want {
+			// The admin config tree itself drifted — repair it.
+			log.Warn("caddy reconcile: upstream drifted (config tree)",
+				"project_id", p.ID, "project", p.Name,
+				"want", want, "got", got)
+			if err := cy.ServeService(ctx, p.ID, want, web.Port, live.Number); err != nil {
+				return false, fmt.Errorf("repair upstream: %w", err)
+			}
+			return true, nil
 		}
-		log.Warn("caddy reconcile: upstream drifted",
-			"project_id", p.ID, "project", p.Name,
-			"want", want, "got", got)
-		if err := cy.ServeService(ctx, p.ID, want, web.Port); err != nil {
-			return false, fmt.Errorf("repair upstream: %w", err)
+		// The config tree is correct — but the *compiled router* can lag the
+		// tree under reload pressure and keep dialing a since-deleted upstream
+		// (the silent post-cutover 502 divergence; the admin GET above can't
+		// see it). Probe the data plane and force-repair if the running router
+		// disagrees.
+		corrected, err := reconcileDataPlane(ctx, log, cy, dp, p, *live, web, domains[0])
+		if err != nil {
+			return false, err
 		}
-		return true, nil
+		if !corrected {
+			// Only reap a superseded web generation once the live router is
+			// confirmed (or unprobed-but-config-correct) on the new one — never
+			// while traffic might still be landing on the old build.
+			reapSupersededWeb(ctx, log, reaper, p, live.Number)
+		}
+		return corrected, nil
 
 	case cobaltfile.TypeStatic, cobaltfile.TypeGenerator:
 		// We don't have a cheap "what is the current root?" probe (it
@@ -201,6 +245,92 @@ func reconcileProject(
 		return false, nil
 	}
 	return false, nil
+}
+
+// reconcileDataPlane probes Caddy's running router for the project's primary
+// domain and, when it diverges from the desired deployment, force-repairs with
+// a single ServeService PATCH — which makes Caddy recompile the route. That's
+// cheaper and safer than delete+recreate: no window with no route (404), and
+// one reload instead of three.
+//
+// A nil prober, an inconclusive probe (Caddy unreachable), or a "no header"
+// response (a pre-header handler) are all treated as "unknown" — never as
+// drift — so a fleet-wide daemon upgrade can't stampede force-rebuilds.
+func reconcileDataPlane(
+	ctx context.Context,
+	log *slog.Logger,
+	cy CaddyReconcileTarget,
+	dp DataPlaneProber,
+	p store.Project,
+	live store.Deployment,
+	web cobaltfile.Service,
+	domain string,
+) (bool, error) {
+	if dp == nil {
+		return false, nil
+	}
+	want := strconv.Itoa(live.Number)
+	served, status, err := dp.ServedDeployment(ctx, domain)
+	if err != nil {
+		log.Debug("caddy reconcile: data-plane probe inconclusive",
+			"project_id", p.ID, "project", p.Name, "error", err)
+		return false, nil
+	}
+	// Divergence = the router serves a different deployment, or 502/503/504s
+	// because it's dialing a dead upstream. served=="" (no header) is NOT
+	// divergence — treat unknown handlers as fine and let their next deploy
+	// stamp the header.
+	if !isGatewayStatus(status) && (served == "" || served == want) {
+		return false, nil
+	}
+	log.Warn("caddy reconcile: upstream drifted (data plane)",
+		"project_id", p.ID, "project", p.Name,
+		"want", want, "served", served, "status", status)
+	container := docker.ServiceName(p.Name, live.Number, "web")
+	if err := cy.ServeService(ctx, p.ID, container, web.Port, live.Number); err != nil {
+		return false, fmt.Errorf("repair upstream (data plane): %w", err)
+	}
+	return true, nil
+}
+
+func isGatewayStatus(status int) bool {
+	return status == 502 || status == 503 || status == 504
+}
+
+// reapSupersededWeb removes any of the project's `*-web` services from an
+// older deployment than current. deploy.cleanupOldServices intentionally keeps
+// the most recent prior generation alive as a grace fallback (so a lagging
+// router serves the old build instead of 502ing); this reaps it once the live
+// deployment is confirmed serving. Best-effort and nil-safe.
+func reapSupersededWeb(
+	ctx context.Context,
+	log *slog.Logger,
+	reaper ServiceReaper,
+	p store.Project,
+	currentNumber int,
+) {
+	if reaper == nil {
+		return
+	}
+	services, err := reaper.ListServicesForProject(ctx, p.ID)
+	if err != nil {
+		log.Debug("caddy reconcile: list services for reap failed",
+			"project_id", p.ID, "error", err)
+		return
+	}
+	for _, s := range services {
+		n, ok := docker.WebGeneration(p.Name, s.Name)
+		if !ok || n >= currentNumber {
+			continue
+		}
+		if err := reaper.RemoveService(ctx, s.Name); err != nil {
+			log.Warn("caddy reconcile: reap superseded web service failed",
+				"name", s.Name, "project_id", p.ID, "error", err)
+			continue
+		}
+		log.Info("caddy reconcile: reaped superseded web service",
+			"name", s.Name, "project_id", p.ID, "current", currentNumber)
+	}
 }
 
 // reapplyHandler re-PATCHes the right handler kind onto a freshly
@@ -215,7 +345,7 @@ func reapplyHandler(
 	switch web.Type {
 	case cobaltfile.TypeContainer:
 		container := docker.ServiceName(p.Name, live.Number, "web")
-		if err := cy.ServeService(ctx, p.ID, container, web.Port); err != nil {
+		if err := cy.ServeService(ctx, p.ID, container, web.Port, live.Number); err != nil {
 			return false, fmt.Errorf("reapply container: %w", err)
 		}
 	case cobaltfile.TypeStatic, cobaltfile.TypeGenerator:

--- a/internal/server/worker/caddy_reconcile_test.go
+++ b/internal/server/worker/caddy_reconcile_test.go
@@ -69,9 +69,10 @@ type fakeReconcileCaddy struct {
 }
 
 type serveServiceCall struct {
-	ProjectID int64
-	Container string
-	Port      int
+	ProjectID        int64
+	Container        string
+	Port             int
+	DeploymentNumber int
 }
 type serveStaticCall struct {
 	ProjectID        int64
@@ -117,10 +118,10 @@ func (f *fakeReconcileCaddy) CurrentUpstream(_ context.Context, id int64) (strin
 	return f.upstream[id], nil
 }
 
-func (f *fakeReconcileCaddy) ServeService(_ context.Context, id int64, container string, port int) error {
+func (f *fakeReconcileCaddy) ServeService(_ context.Context, id int64, container string, port, deploymentNumber int) error {
 	f.mu.Lock()
 	defer f.mu.Unlock()
-	f.serveCalls = append(f.serveCalls, serveServiceCall{id, container, port})
+	f.serveCalls = append(f.serveCalls, serveServiceCall{id, container, port, deploymentNumber})
 	f.upstream[id] = container
 	return nil
 }
@@ -175,7 +176,7 @@ func TestReconcile_NoCorrectionWhenInSync(t *testing.T) {
 	cy.routeExists[1] = true
 	cy.upstream[1] = "api-7-web" // matches expected ServiceName
 
-	corrected, err := ReconcileCaddyState(context.Background(), quietLogger(), st, cy)
+	corrected, err := ReconcileCaddyState(context.Background(), quietLogger(), st, cy, nil, nil)
 	if err != nil {
 		t.Fatalf("Reconcile: %v", err)
 	}
@@ -210,7 +211,7 @@ func TestReconcile_PatchesUpstreamOnDrift(t *testing.T) {
 	cy.routeExists[1] = true
 	cy.upstream[1] = "api-5-web" // drifted to old deploy
 
-	corrected, err := ReconcileCaddyState(context.Background(), quietLogger(), st, cy)
+	corrected, err := ReconcileCaddyState(context.Background(), quietLogger(), st, cy, nil, nil)
 	if err != nil {
 		t.Fatalf("Reconcile: %v", err)
 	}
@@ -251,7 +252,7 @@ func TestReconcile_RecreatesMissingRoute(t *testing.T) {
 	// Route doesn't exist (Caddy was wiped).
 	cy.routeExists[1] = false
 
-	corrected, err := ReconcileCaddyState(context.Background(), quietLogger(), st, cy)
+	corrected, err := ReconcileCaddyState(context.Background(), quietLogger(), st, cy, nil, nil)
 	if err != nil {
 		t.Fatalf("Reconcile: %v", err)
 	}
@@ -288,7 +289,7 @@ func TestReconcile_StaticSiteRecreatesViaServeStaticSite(t *testing.T) {
 	cy := newFakeReconcileCaddy()
 	cy.routeExists[1] = false
 
-	corrected, _ := ReconcileCaddyState(context.Background(), quietLogger(), st, cy)
+	corrected, _ := ReconcileCaddyState(context.Background(), quietLogger(), st, cy, nil, nil)
 	if corrected != 1 {
 		t.Errorf("corrected: %d, want 1", corrected)
 	}
@@ -322,7 +323,7 @@ func TestReconcile_StaticSiteSkipsDriftCheck(t *testing.T) {
 	cy := newFakeReconcileCaddy()
 	cy.routeExists[1] = true
 
-	corrected, _ := ReconcileCaddyState(context.Background(), quietLogger(), st, cy)
+	corrected, _ := ReconcileCaddyState(context.Background(), quietLogger(), st, cy, nil, nil)
 	if corrected != 0 {
 		t.Errorf("static site existing route should NOT be corrected: %d", corrected)
 	}
@@ -335,7 +336,7 @@ func TestReconcile_NoLastSuccessSkipsProject(t *testing.T) {
 		lastByID: map[int64]*store.Deployment{},
 	}
 	cy := newFakeReconcileCaddy()
-	corrected, err := ReconcileCaddyState(context.Background(), quietLogger(), st, cy)
+	corrected, err := ReconcileCaddyState(context.Background(), quietLogger(), st, cy, nil, nil)
 	if err != nil {
 		t.Fatalf("Reconcile: %v", err)
 	}
@@ -354,7 +355,7 @@ func TestReconcile_MissingResolvedCobaltfileSkips(t *testing.T) {
 		},
 	}
 	cy := newFakeReconcileCaddy()
-	corrected, _ := ReconcileCaddyState(context.Background(), quietLogger(), st, cy)
+	corrected, _ := ReconcileCaddyState(context.Background(), quietLogger(), st, cy, nil, nil)
 	if corrected != 0 {
 		t.Errorf("corrected: %d, want 0 (no resolved cobaltfile)", corrected)
 	}
@@ -380,7 +381,7 @@ func TestReconcile_NoDomainsSkips(t *testing.T) {
 		// no domains
 	}
 	cy := newFakeReconcileCaddy()
-	corrected, _ := ReconcileCaddyState(context.Background(), quietLogger(), st, cy)
+	corrected, _ := ReconcileCaddyState(context.Background(), quietLogger(), st, cy, nil, nil)
 	if corrected != 0 {
 		t.Errorf("corrected: %d, want 0", corrected)
 	}
@@ -409,7 +410,7 @@ func TestReconcile_NoWebServiceSkipsCaddy(t *testing.T) {
 		domains: map[int64][]string{1: {"jobs.example.com"}},
 	}
 	cy := newFakeReconcileCaddy()
-	corrected, _ := ReconcileCaddyState(context.Background(), quietLogger(), st, cy)
+	corrected, _ := ReconcileCaddyState(context.Background(), quietLogger(), st, cy, nil, nil)
 	if corrected != 0 {
 		t.Errorf("cron-only project should not trigger Caddy correction: %d", corrected)
 	}
@@ -448,7 +449,7 @@ func TestReconcile_PerProjectFailureContinuesSweep(t *testing.T) {
 	cy.routeExists[1] = true
 	cy.upstream[1] = "api-5-web" // drifted
 
-	corrected, err := ReconcileCaddyState(context.Background(), quietLogger(), st, cy)
+	corrected, err := ReconcileCaddyState(context.Background(), quietLogger(), st, cy, nil, nil)
 	if err != nil {
 		t.Fatalf("Reconcile: %v", err)
 	}
@@ -460,7 +461,7 @@ func TestReconcile_PerProjectFailureContinuesSweep(t *testing.T) {
 func TestReconcile_ListProjectsErrorBubbles(t *testing.T) {
 	t.Parallel()
 	st := &fakeReconcileStore{listErr: errors.New("db down")}
-	if _, err := ReconcileCaddyState(context.Background(), quietLogger(), st, newFakeReconcileCaddy()); err == nil {
+	if _, err := ReconcileCaddyState(context.Background(), quietLogger(), st, newFakeReconcileCaddy(), nil, nil); err == nil {
 		t.Error("expected error from project list failure")
 	}
 }
@@ -487,7 +488,7 @@ func TestReconcile_CaddyRouteMissingButPriorDeploy_CallsAddProjectRouteFirst(t *
 	cy := newFakeReconcileCaddy()
 	cy.routeExists[1] = false
 
-	corrected, err := ReconcileCaddyState(context.Background(), quietLogger(), st, cy)
+	corrected, err := ReconcileCaddyState(context.Background(), quietLogger(), st, cy, nil, nil)
 	if err != nil {
 		t.Fatalf("Reconcile: %v", err)
 	}
@@ -528,7 +529,7 @@ func TestReconcile_DomainsDrifted_CallsSetDomainsEvenWhenUpstreamInSync(t *testi
 	cy.routeExists[1] = true
 	cy.upstream[1] = "api-7-web" // correct upstream
 
-	corrected, err := ReconcileCaddyState(context.Background(), quietLogger(), st, cy)
+	corrected, err := ReconcileCaddyState(context.Background(), quietLogger(), st, cy, nil, nil)
 	if err != nil {
 		t.Fatalf("Reconcile: %v", err)
 	}
@@ -581,7 +582,7 @@ func TestReconcile_SetDomainsFails_DoesNotHaltSweep(t *testing.T) {
 	cy.upstream[2] = "www-3-web"
 	cy.domainsErr = errors.New("caddy unreachable")
 
-	corrected, err := ReconcileCaddyState(context.Background(), quietLogger(), st, cy)
+	corrected, err := ReconcileCaddyState(context.Background(), quietLogger(), st, cy, nil, nil)
 	if err != nil {
 		t.Fatalf("Reconcile: error should be nil (per-project failure absorbed), got: %v", err)
 	}
@@ -626,7 +627,7 @@ func TestReconcile_ProjectRouteExistsError_DoesNotHaltSweep(t *testing.T) {
 	cy.upstream[2] = "www-3-web"
 	cy.routeExistsErr = errors.New("caddy admin API down")
 
-	_, err := ReconcileCaddyState(context.Background(), quietLogger(), st, cy)
+	_, err := ReconcileCaddyState(context.Background(), quietLogger(), st, cy, nil, nil)
 	if err != nil {
 		t.Fatalf("Reconcile: error should be nil (per-project failure absorbed), got: %v", err)
 	}
@@ -656,7 +657,7 @@ func TestReconcile_SkipsProjectWithActiveDeployment(t *testing.T) {
 	cy.routeExists[1] = true
 	cy.upstream[1] = "api-5-web" // drifted — would normally be "corrected" back to api-7-web
 
-	corrected, err := ReconcileCaddyState(context.Background(), quietLogger(), st, cy)
+	corrected, err := ReconcileCaddyState(context.Background(), quietLogger(), st, cy, nil, nil)
 	if err != nil {
 		t.Fatalf("Reconcile: %v", err)
 	}
@@ -694,7 +695,7 @@ func TestReconcile_DomainsInSync_SkipsSetDomains(t *testing.T) {
 	// set comparison ignores ordering).
 	cy.currentDomains[1] = []string{"www.api.example.com", "api.example.com"}
 
-	corrected, err := ReconcileCaddyState(context.Background(), quietLogger(), st, cy)
+	corrected, err := ReconcileCaddyState(context.Background(), quietLogger(), st, cy, nil, nil)
 	if err != nil {
 		t.Fatalf("Reconcile: %v", err)
 	}
@@ -727,7 +728,7 @@ func TestReconcile_DomainsDriftedSet_TriggersSetDomains(t *testing.T) {
 	cy.upstream[1] = "api-7-web"
 	cy.currentDomains[1] = []string{"api.example.com"} // missing new.example.com
 
-	if _, err := ReconcileCaddyState(context.Background(), quietLogger(), st, cy); err != nil {
+	if _, err := ReconcileCaddyState(context.Background(), quietLogger(), st, cy, nil, nil); err != nil {
 		t.Fatalf("Reconcile: %v", err)
 	}
 	if len(cy.domainCalls) != 1 {
@@ -741,7 +742,7 @@ func TestReconcile_ActiveDeploymentCheckError_DoesNotHaltSweep(t *testing.T) {
 		projects:  []store.Project{{ID: 1, Name: "api"}},
 		activeErr: errors.New("rqlite unreachable"),
 	}
-	if _, err := ReconcileCaddyState(context.Background(), quietLogger(), st, newFakeReconcileCaddy()); err != nil {
+	if _, err := ReconcileCaddyState(context.Background(), quietLogger(), st, newFakeReconcileCaddy(), nil, nil); err != nil {
 		t.Fatalf("Reconcile: per-project failure should be absorbed, got: %v", err)
 	}
 }


### PR DESCRIPTION
## The problem

Under a burst of deploys, `blue.app` served the loading-splash to a subset of users for ~80 minutes. Every cutover step succeeded, yet `cobalt_caddy` logged hundreds of `dial tcp: lookup <project>-<N>-web ... no such host` for `GET /assets/*.js` — the **running router kept dialing a container that had already been deleted**, so SPA chunk requests 502'd and the app never mounted. Already-loaded sessions were fine (they don't refetch chunks); only fresh loads hit the dead upstream.

Root cause: **Caddy's admin config tree can diverge from its compiled router under reload pressure.** A `@id` PATCH updates the admin tree synchronously, but the HTTP handlers only swap when the (8–12s, on a busy host) reload completes. During that window the admin API reports the *new* upstream while the running router still dials the *old* one — and the old service was deleted at cutover, so it's now `no such host`.

Every existing safeguard read the admin tree, so the divergence was invisible:
- `VerifyServeService` PATCHes then trusts an admin `GET .../upstreams/0/dial`.
- The convergence reconciler compares the same admin `GET` to the desired upstream.

Both saw "healthy" while the data plane 502'd. Zero `upstream drifted`, zero corrections.

> This is distinct from the deploy-verify race + admin-wedge fixed in #27 — same subsystem, different failure. This PR is **stacked on #27** (it builds on that reconciler/watchdog work; review/merge #27 first).

## What this does — make the *running router* observable, then act on it

**A1 — deployment-identity header.** `ServeService` stamps `X-Cobalt-Deployment: <n>` on proxied responses, in the same handler config as the upstream. A lagging compiled handler that still dials the old container also still emits the old number — that mismatch is the signal.

**A2 — data-plane probe.** A real request through Caddy's own listener from inside `cobalt-caddy`, reading the header back. Auto-detects topology (tunnel `:80` plaintext via a hand-built single-`Host` request; standalone `:443` via `wget --no-check-certificate`), so the daemon needn't know its own mode. Parses from stderr and tolerates busybox's nonzero exit on 4xx/5xx.

**A3 — gate the cutover.** After the swap, confirm the running router serves the new deployment before declaring success. **Asymmetric on purpose:** hard-fail and revert only on *real* divergence (router serving a different deployment, or a 502 dial-failure — the incident signature); soft-pass (log + proceed) on probe-infra ambiguity, so a broken probe can't fail every deploy. Opt-in via a nil-able `DataPlaneProber` field, so unit cutover tests stay hermetic.

**A4 — data-plane-aware self-heal.** When the admin tree looks correct (`got == want`), the reconciler now *also* probes the data plane and, on divergence, forces a recompile with a **single PATCH** — not a delete+recreate (which would open a no-route 404 window and triple the reload load). A missing header is treated as **unknown, never drift**, so a daemon upgrade can't stampede rebuilds across the fleet.

**B — grace-period cleanup.** `cleanupOldServices` keeps the most recent prior `*-web` generation alive *one cutover*, so a lagging router resolves to a working old build (**200**) instead of a `no such host` **502**. The reconciler reaps it once the data plane confirms the new generation; failing that, the next deploy reaps it — so at most one extra web generation ever lingers. Worker/cron services are reaped immediately as before.

## Scope

- **Not** included: full-config `POST /load` (higher blast radius — it replaces the *entire* Caddy config incl. redirect/daemon/admin routes; deferred). The drift-aware domain sync (write-on-drift) is already in #27.
- Probe mechanics, the cutover gate, and the reconciler prober/reaper are all dependency-injected and nil-safe.

## Test plan

- [x] `go build ./...`, `go vet ./...`, `gofmt` clean
- [x] `go test ./...` — all packages pass; `-race` clean on caddy/deploy/worker/docker
- [x] Header is stamped in the handler PATCH (`caddy`)
- [x] Probe parser: 200+header, 502/no-header, `wget -S` indentation, redirect, case-insensitivity, garbage; hostname injection guard
- [x] Cutover gate: serves-new → pass; serves-old / 502 → hard fail; probe-broken → soft pass; static / no-domains → skipped
- [x] Reconciler: serves-old / 502 → single-PATCH repair; no-header / inconclusive → no repair; healthy → reaps only the superseded `*-web` (not workers, not other projects); nil prober still reaps
- [x] `WebGeneration` name parser incl. hyphenated project names; grace retention keeps current + one prior web, reaps the rest

Ships via `cobalt server upgrade` (daemon rebuild), not a project deploy. No data migration.
