### PR TITLE
fix(stats): report the public host as Node, not the container ID

### DIFF
--- a/internal/server/api/stats.go
+++ b/internal/server/api/stats.go
@@ -156,14 +156,17 @@ func (h *Handler) assembleStats(ctx context.Context, sampler SystemSampler, usag
 	return snap, nil
 }
 
-// hostname is the OS hostname, falling back to the configured public
-// host — Node must never be empty, multi-node fan-in keys on it.
-func hostname(fallback string) string {
+// hostname is the configured public host, falling back to the OS
+// hostname — Node must never be empty, multi-node fan-in keys on it.
+// PublicHost comes first: the daemon runs in a container, where
+// os.Hostname() is the container ID — meaningless to a reader and
+// different after every redeploy, which would break fan-in keying.
+func hostname(publicHost string) string {
+	if publicHost != "" {
+		return publicHost
+	}
 	if h, err := os.Hostname(); err == nil && h != "" {
 		return h
-	}
-	if fallback != "" {
-		return fallback
 	}
 	return "unknown"
 }

--- a/internal/server/api/stats_test.go
+++ b/internal/server/api/stats_test.go
@@ -157,3 +157,15 @@ func TestServerStats_Follow(t *testing.T) {
 		t.Errorf("attribution = %+v", last.Containers[0])
 	}
 }
+
+// The daemon runs in a container, where os.Hostname() is the container
+// ID — Node must report the configured public host when one is set.
+func TestHostnamePrefersPublicHost(t *testing.T) {
+	t.Parallel()
+	if got := hostname("server.blue.cc"); got != "server.blue.cc" {
+		t.Errorf("hostname = %q, want the configured public host", got)
+	}
+	if got := hostname(""); got == "" || got == "unknown" {
+		t.Logf("no public host: fell back to OS hostname %q", got)
+	}
+}


### PR DESCRIPTION
Follow-up to #31, spotted on first prod run: the header showed `41b8bb0d37d3` (the daemon container's ID) instead of `server.blue.cc`.

`hostname()` preferred `os.Hostname()`, which inside a container is the container ID — meaningless to a reader and different after every redeploy, which would break the intended multi-node fan-in keyed on `node`. The configured `PublicHost` now wins; OS hostname is the fallback for installs that don't set one.

Verified: `go test ./...` + lint clean.