### PR TITLE
Per-service stopFirst: stop old generation before starting new

### DIFF
--- a/docs/plan.md
+++ b/docs/plan.md
@@ -44,7 +44,7 @@ Cross-cutting conventions to lock in before we have many callers depending on th
 
 Per-repo `cobalt.json` parser.
 
-- [x] Service definition: `type`, `image`, `port`, `command`, `build`, `publicPath`, `publishedPorts`, `volumes`, `schedule`, `exposedInternally`, `timeout`, `health`, `extraSwarmParams`, `extraRunParams`
+- [x] Service definition: `type`, `image`, `port`, `command`, `build`, `publicPath`, `publishedPorts`, `volumes`, `schedule`, `exposedInternally`, `timeout`, `health`, `extraSwarmParams`, `extraRunParams`, `stopFirst`
 - [x] Hook services validated: `hook:deploy:start:before`, `hook:deploy:start:after` must be type=command with non-empty command
 - [x] Cron service type with per-field cron schedule validation
 - [x] Static-site service type (publicPath + image-not-required logic)

--- a/internal/server/cobaltfile/cobaltfile.go
+++ b/internal/server/cobaltfile/cobaltfile.go
@@ -96,6 +96,16 @@ type Service struct {
 	// MinReplicas — so this is how you encode "api needs 4 to survive prod
 	// load" in the repo rather than only in operator memory.
 	MinReplicas int `json:"minReplicas,omitempty"`
+	// StopFirst stops the old deployment's instance of this service BEFORE
+	// starting the new one, instead of the default start-first blue-green.
+	// Required for services that publish host-mode ports (SMTP on 25, game
+	// servers, UDP): two generations can't bind the same host port, so
+	// start-first deadlocks until the health timeout. The cost is a brief
+	// downtime window every deploy — and if the new service fails its
+	// healthcheck, the service stays down until a retry or rollback.
+	// Container services only; rejected on a publicly-routed web service
+	// (that path has zero-downtime swap machinery stopFirst would defeat).
+	StopFirst bool `json:"stopFirst,omitempty"`
 }
 
 // Image describes how to build a docker image.

--- a/internal/server/cobaltfile/validate.go
+++ b/internal/server/cobaltfile/validate.go
@@ -80,6 +80,17 @@ func validateService(name string, s Service) error {
 	if s.MinReplicas > 0 && s.Type != TypeContainer {
 		return fmt.Errorf("cobaltfile: service %q minReplicas only valid for type=container (got %q)", name, s.Type)
 	}
+	if s.StopFirst {
+		if s.Type != TypeContainer {
+			return fmt.Errorf("cobaltfile: service %q stopFirst only valid for type=container (got %q)", name, s.Type)
+		}
+		// A publicly-routed web service already has zero-downtime cutover
+		// (Caddy swap + grace generation); stopFirst would defeat it and
+		// serve 502s during every deploy.
+		if name == "web" && !s.ExposedInternally {
+			return fmt.Errorf("cobaltfile: service %q is publicly routed; stopFirst would break zero-downtime cutover (allowed with exposedInternally: true)", name)
+		}
+	}
 	if s.Type == TypeCron {
 		if err := validateCronSchedule(s.Schedule); err != nil {
 			return fmt.Errorf("cobaltfile: service %q schedule: %w", name, err)

--- a/internal/server/cobaltfile/validate_test.go
+++ b/internal/server/cobaltfile/validate_test.go
@@ -294,3 +294,42 @@ func TestValidate_BuildOverrideSkipsImageCheck(t *testing.T) {
 		t.Errorf("build: override should skip image check: %v", err)
 	}
 }
+
+func TestValidate_StopFirstContainerOnly(t *testing.T) {
+	t.Parallel()
+	src := `{
+        "version": "1.0",
+        "services": {"worker": {
+            "type": "cron",
+            "schedule": "* * * * *",
+            "command": "echo hi",
+            "stopFirst": true
+        }}
+    }`
+	_, err := Parse([]byte(src))
+	mustContain(t, err, "stopFirst only valid for type=container")
+}
+
+func TestValidate_StopFirstRejectedOnPublicWeb(t *testing.T) {
+	t.Parallel()
+	src := `{
+        "version": "1.0",
+        "services": {"web": {"stopFirst": true}}
+    }`
+	_, err := Parse([]byte(src))
+	mustContain(t, err, "stopFirst would break zero-downtime cutover")
+}
+
+func TestValidate_StopFirstAllowedOnInternalServices(t *testing.T) {
+	t.Parallel()
+	src := `{
+        "version": "1.0",
+        "services": {
+            "web": {"exposedInternally": true, "stopFirst": true},
+            "smtp": {"type": "container", "stopFirst": true}
+        }
+    }`
+	if _, err := Parse([]byte(src)); err != nil {
+		t.Fatalf("Parse: %v", err)
+	}
+}

--- a/internal/server/deploy/orchestrator.go
+++ b/internal/server/deploy/orchestrator.go
@@ -222,6 +222,13 @@ func (o *Orchestrator) cutover(
 		log.Warn("set status swapping", "error", err)
 	}
 
+	// stopFirst services surrender their old generation before the new one
+	// starts — host-mode published ports can't be held by two generations at
+	// once. Anything stopped here is down until the new service is healthy.
+	if err := stopFirstPhase(ctx, o.Docker, *project, dep, built, out); err != nil {
+		return err
+	}
+
 	startedServices, err := startServicesPhase(ctx, o.Docker, *project, dep, built, envVars, deploymentNetwork, out)
 	if err != nil {
 		// Phase 1 failure: stop services we did start, no Caddy touch.

--- a/internal/server/deploy/services.go
+++ b/internal/server/deploy/services.go
@@ -21,6 +21,7 @@ type ServiceDocker interface {
 	WaitForServiceHealthy(ctx context.Context, name string, replicas int, timeout time.Duration) error
 	RemoveService(ctx context.Context, name string) error
 	ListServicesForDeployment(ctx context.Context, projectID int64, deploymentNumber int) ([]docker.ServiceInfo, error)
+	ListServicesForProject(ctx context.Context, projectID int64) ([]docker.ServiceInfo, error)
 }
 
 // startServicesPhase creates and starts every long-running service in the

--- a/internal/server/deploy/services_test.go
+++ b/internal/server/deploy/services_test.go
@@ -47,6 +47,10 @@ func (f *serviceDockerFake) ListServicesForDeployment(_ context.Context, _ int64
 	return f.services, f.listErr
 }
 
+func (f *serviceDockerFake) ListServicesForProject(_ context.Context, _ int64) ([]docker.ServiceInfo, error) {
+	return f.services, f.listErr
+}
+
 // findAttachment returns the NetworkAttachment matching name, or fails the
 // test if absent. Centralizes the "ordering is implementation detail, but
 // each network must be present exactly once" assertion the alias tests all

--- a/internal/server/deploy/stopfirst.go
+++ b/internal/server/deploy/stopfirst.go
@@ -1,0 +1,65 @@
+package deploy
+
+import (
+	"context"
+	"fmt"
+	"io"
+
+	"github.com/heyblueteam/cobalt/internal/server/docker"
+	"github.com/heyblueteam/cobalt/internal/server/store"
+)
+
+// stopFirstPhase removes the OLD generations of every stopFirst service
+// before the new generation is created. This is the escape hatch for
+// services that publish host-mode ports: two generations can't bind the
+// same host port, so the default start-first ordering deadlocks until the
+// health timeout. The price is a downtime window from here until the new
+// service passes its healthcheck — stopFirst services opted into that.
+//
+// Errors are fatal (unlike cleanupOldServices' best-effort): if the old
+// service can't be removed, the new one will deadlock on the port anyway,
+// and failing here surfaces the real cause instead of a 5-minute timeout.
+func stopFirstPhase(
+	ctx context.Context,
+	d ServiceDocker,
+	project store.Project,
+	dep store.Deployment,
+	built []BuiltService,
+	out io.Writer,
+) error {
+	var flagged []string
+	for _, b := range built {
+		if b.Service.StopFirst && runsAsService(b.Service) {
+			flagged = append(flagged, b.Name)
+		}
+	}
+	if len(flagged) == 0 {
+		return nil
+	}
+
+	services, err := d.ListServicesForProject(ctx, project.ID)
+	if err != nil {
+		return fmt.Errorf("deploy: stopFirst: list services: %w", err)
+	}
+
+	for _, name := range flagged {
+		for _, s := range services {
+			// Labels, not name parsing: ServiceName/DeploymentNumber come from
+			// the service's own cobalt labels, so a `smtp` flag can never match
+			// an unrelated `old-smtp` service.
+			if s.ServiceName != name || s.DeploymentNumber == dep.Number {
+				continue
+			}
+			fmt.Fprintf(out, "⏹  stopping %s before start (stopFirst — service is down until #%d is healthy)\n",
+				s.Name, dep.Number)
+			if err := d.RemoveService(ctx, s.Name); err != nil {
+				return fmt.Errorf("deploy: stopFirst: remove %q: %w", s.Name, err)
+			}
+		}
+	}
+	return nil
+}
+
+// Compile-time check that the real docker client satisfies the widened
+// ServiceDocker interface (ListServicesForProject is also used by cleanup).
+var _ ServiceDocker = (*docker.Client)(nil)

--- a/internal/server/deploy/stopfirst_test.go
+++ b/internal/server/deploy/stopfirst_test.go
@@ -1,0 +1,85 @@
+package deploy
+
+import (
+	"context"
+	"errors"
+	"io"
+	"testing"
+
+	"github.com/heyblueteam/cobalt/internal/server/cobaltfile"
+	"github.com/heyblueteam/cobalt/internal/server/docker"
+	"github.com/heyblueteam/cobalt/internal/server/store"
+)
+
+func stopFirstBuilt(name string, stopFirst bool) BuiltService {
+	return BuiltService{
+		Name: name,
+		Service: cobaltfile.Service{
+			Type:      cobaltfile.TypeContainer,
+			StopFirst: stopFirst,
+		},
+	}
+}
+
+func TestStopFirstPhase_RemovesOnlyOldGenerationsOfFlaggedService(t *testing.T) {
+	t.Parallel()
+	project := store.Project{ID: 1, Name: "haraka"}
+	dep := store.Deployment{Number: 10}
+	d := &serviceDockerFake{services: []docker.ServiceInfo{
+		{Name: "haraka-9-smtp", ProjectID: 1, DeploymentNumber: 9, ServiceName: "smtp"},
+		{Name: "haraka-8-smtp", ProjectID: 1, DeploymentNumber: 8, ServiceName: "smtp"},
+		{Name: "haraka-10-smtp", ProjectID: 1, DeploymentNumber: 10, ServiceName: "smtp"}, // current gen — keep
+		{Name: "haraka-9-acme", ProjectID: 1, DeploymentNumber: 9, ServiceName: "acme"},   // not flagged — keep
+		{Name: "haraka-9-old-smtp", ProjectID: 1, DeploymentNumber: 9, ServiceName: "old-smtp"}, // name collision — keep
+	}}
+	built := []BuiltService{
+		stopFirstBuilt("smtp", true),
+		stopFirstBuilt("acme", false),
+	}
+
+	if err := stopFirstPhase(context.Background(), d, project, dep, built, io.Discard); err != nil {
+		t.Fatalf("stopFirstPhase: %v", err)
+	}
+	want := map[string]bool{"haraka-9-smtp": true, "haraka-8-smtp": true}
+	if len(d.removed) != len(want) {
+		t.Fatalf("removed = %v, want exactly %v", d.removed, want)
+	}
+	for _, name := range d.removed {
+		if !want[name] {
+			t.Errorf("removed unexpected service %q", name)
+		}
+	}
+}
+
+func TestStopFirstPhase_NoFlaggedServices_TouchesNothing(t *testing.T) {
+	t.Parallel()
+	project := store.Project{ID: 1, Name: "api"}
+	dep := store.Deployment{Number: 2}
+	d := &serviceDockerFake{
+		services: []docker.ServiceInfo{{Name: "api-1-web", ProjectID: 1, DeploymentNumber: 1, ServiceName: "web"}},
+		listErr:  errors.New("must not even list"),
+	}
+	built := []BuiltService{stopFirstBuilt("web", false)}
+
+	if err := stopFirstPhase(context.Background(), d, project, dep, built, io.Discard); err != nil {
+		t.Fatalf("stopFirstPhase: %v", err)
+	}
+	if len(d.removed) != 0 {
+		t.Errorf("removed = %v, want none", d.removed)
+	}
+}
+
+func TestStopFirstPhase_RemoveFailureIsFatal(t *testing.T) {
+	t.Parallel()
+	project := store.Project{ID: 1, Name: "haraka"}
+	dep := store.Deployment{Number: 10}
+	d := &serviceDockerFake{
+		services:  []docker.ServiceInfo{{Name: "haraka-9-smtp", ProjectID: 1, DeploymentNumber: 9, ServiceName: "smtp"}},
+		removeErr: errors.New("boom"),
+	}
+	built := []BuiltService{stopFirstBuilt("smtp", true)}
+
+	if err := stopFirstPhase(context.Background(), d, project, dep, built, io.Discard); err == nil {
+		t.Fatal("want error when old service can't be removed (new one would deadlock on the port)")
+	}
+}


### PR DESCRIPTION
Implements `stopFirst: true` on cobalt.json container services — stop-then-start instead of the default start-first blue-green.

## Why
Host-mode published ports make blue-green physically impossible: the old generation holds the port until `cleanupOldServices`, which only runs **after** the new generation passes health — so the new task can never schedule and `waitHealthyAll` times out at 5m (`healthy=0 running=0`). This is exactly haraka deploy #10's failure, and it will hit any host-port service (SMTP, game servers, UDP).

## What
- `Service.StopFirst` (`stopFirst` in cobalt.json) — doc comment spells out the trade-off: brief downtime every deploy, and if the new service fails health you're down until retry/rollback. Opt-in only; default ordering bit-for-bit unchanged.
- `stopFirstPhase` in the cutover, immediately before `startServicesPhase`: removes old generations of flagged services, matched via cobalt **service labels** (`ServiceName`/`DeploymentNumber`), never name parsing — a `smtp` flag can't catch an unrelated `old-smtp`.
- Failures are **fatal** (unlike best-effort cleanup): if the old service can't be removed, the new one deadlocks on the port anyway; failing loud with the real cause beats a 5-minute timeout.
- Validation: rejected on non-container services and on publicly-routed `web` (it would silently defeat the Caddy zero-downtime swap + grace generation); allowed with `exposedInternally: true`.
- Deploy log makes the downtime window explicit: `⏹ stopping haraka-9-smtp before start (stopFirst — service is down until #10 is healthy)`.

## Tests
- Phase: removes only old generations of flagged services (current gen, unflagged services, and the `old-smtp` name-collision case all untouched); no-op skips listing entirely; remove failure is fatal.
- Validation: container-only, public-web rejection, internal-web + container allowed.
- `go test ./...` — all 20 packages green.

## Follow-up after merge
Redeploy the cobalt daemon, add `"stopFirst": true` to haraka's `smtp` service, redeploy haraka — unblocks heyblueteam/haraka#2 (RCPT gate for blue#465's custom names).

Plan: `blue/plans/cobalt-stop-first.md`.