### PR TITLE
Fix stopFirst matching: listServices never fills the label-derived fields

### DIFF
--- a/internal/server/deploy/stopfirst.go
+++ b/internal/server/deploy/stopfirst.go
@@ -44,10 +44,13 @@ func stopFirstPhase(
 
 	for _, name := range flagged {
 		for _, s := range services {
-			// Labels, not name parsing: ServiceName/DeploymentNumber come from
-			// the service's own cobalt labels, so a `smtp` flag can never match
-			// an unrelated `old-smtp` service.
-			if s.ServiceName != name || s.DeploymentNumber == dep.Number {
+			// `docker service ls` gives us names only (listServices fills just
+			// Name/Replicas — the label-derived ServiceInfo fields are NOT
+			// populated on this path), so match by exact name parse. Generation
+			// treats project and service as known, so a `smtp` flag can never
+			// match an unrelated `old-smtp` service.
+			gen, ok := docker.Generation(project.Name, name, s.Name)
+			if !ok || gen == dep.Number {
 				continue
 			}
 			fmt.Fprintf(out, "⏹  stopping %s before start (stopFirst — service is down until #%d is healthy)\n",

--- a/internal/server/deploy/stopfirst_test.go
+++ b/internal/server/deploy/stopfirst_test.go
@@ -25,12 +25,17 @@ func TestStopFirstPhase_RemovesOnlyOldGenerationsOfFlaggedService(t *testing.T) 
 	t.Parallel()
 	project := store.Project{ID: 1, Name: "haraka"}
 	dep := store.Deployment{Number: 10}
+	// Names only: the real listServices populates just Name/Replicas from
+	// `docker service ls` — the label-derived ServiceInfo fields stay zero.
+	// Constructing fixtures the same way keeps this test honest about what
+	// the phase can actually see (the v1.2.0 bug was matching on fields the
+	// producer never fills).
 	d := &serviceDockerFake{services: []docker.ServiceInfo{
-		{Name: "haraka-9-smtp", ProjectID: 1, DeploymentNumber: 9, ServiceName: "smtp"},
-		{Name: "haraka-8-smtp", ProjectID: 1, DeploymentNumber: 8, ServiceName: "smtp"},
-		{Name: "haraka-10-smtp", ProjectID: 1, DeploymentNumber: 10, ServiceName: "smtp"}, // current gen — keep
-		{Name: "haraka-9-acme", ProjectID: 1, DeploymentNumber: 9, ServiceName: "acme"},   // not flagged — keep
-		{Name: "haraka-9-old-smtp", ProjectID: 1, DeploymentNumber: 9, ServiceName: "old-smtp"}, // name collision — keep
+		{Name: "haraka-9-smtp"},
+		{Name: "haraka-8-smtp"},
+		{Name: "haraka-10-smtp"},    // current gen — keep
+		{Name: "haraka-9-acme"},     // not flagged — keep
+		{Name: "haraka-9-old-smtp"}, // name collision — keep
 	}}
 	built := []BuiltService{
 		stopFirstBuilt("smtp", true),
@@ -56,7 +61,7 @@ func TestStopFirstPhase_NoFlaggedServices_TouchesNothing(t *testing.T) {
 	project := store.Project{ID: 1, Name: "api"}
 	dep := store.Deployment{Number: 2}
 	d := &serviceDockerFake{
-		services: []docker.ServiceInfo{{Name: "api-1-web", ProjectID: 1, DeploymentNumber: 1, ServiceName: "web"}},
+		services: []docker.ServiceInfo{{Name: "api-1-web"}},
 		listErr:  errors.New("must not even list"),
 	}
 	built := []BuiltService{stopFirstBuilt("web", false)}
@@ -74,7 +79,7 @@ func TestStopFirstPhase_RemoveFailureIsFatal(t *testing.T) {
 	project := store.Project{ID: 1, Name: "haraka"}
 	dep := store.Deployment{Number: 10}
 	d := &serviceDockerFake{
-		services:  []docker.ServiceInfo{{Name: "haraka-9-smtp", ProjectID: 1, DeploymentNumber: 9, ServiceName: "smtp"}},
+		services:  []docker.ServiceInfo{{Name: "haraka-9-smtp"}},
 		removeErr: errors.New("boom"),
 	}
 	built := []BuiltService{stopFirstBuilt("smtp", true)}

--- a/internal/server/docker/names.go
+++ b/internal/server/docker/names.go
@@ -23,16 +23,29 @@ func ServiceName(projectName string, deploymentNumber int, serviceName string) s
 // projectName is taken as known (not parsed back out) so a hyphenated project
 // name — or a hyphenated service name — doesn't make the split ambiguous.
 func WebGeneration(projectName, serviceName string) (int, bool) {
-	rest, ok := strings.CutPrefix(serviceName, projectName+"-")
+	return Generation(projectName, "web", serviceName)
+}
+
+// Generation parses the deployment number out of a full swarm service name —
+// the inverse of ServiceName(projectName, n, svcName) for one known project
+// and logical service. ok=false for other projects, other services, and
+// malformed names.
+//
+// Both projectName and svcName are taken as known (not parsed back out), so
+// hyphens in either never make the split ambiguous: "haraka-9-old-smtp" is
+// NOT a generation of svc "smtp" because the middle segment "9-old" isn't a
+// number.
+func Generation(projectName, svcName, fullName string) (int, bool) {
+	rest, ok := strings.CutPrefix(fullName, projectName+"-")
 	if !ok {
 		return 0, false
 	}
-	// rest is "{number}-{serviceName}", e.g. "114-web"; split on the first '-'.
+	// rest is "{number}-{svcName}", e.g. "114-web"; split on the first '-'.
 	i := strings.IndexByte(rest, '-')
 	if i <= 0 {
 		return 0, false
 	}
-	if rest[i+1:] != "web" {
+	if rest[i+1:] != svcName {
 		return 0, false
 	}
 	n, err := strconv.Atoi(rest[:i])


### PR DESCRIPTION
v1.2.0's `stopFirstPhase` matched old generations via `ServiceInfo.ServiceName`/`DeploymentNumber` — but `listServices` only parses `Name` and `Replicas` out of `docker service ls`; those fields are never populated on this path. The phase compared against empty strings, silently stopped nothing, and haraka deploy #11 hit the identical port-25 deadlock as #10 (no `⏹ stopping` line in the deploy log was the tell).

Fix: exact name parsing via a new `docker.Generation(project, svc, fullName)` — a generalization of the existing `WebGeneration` parser (which now delegates to it). Project and service names are treated as known, so hyphenated names stay unambiguous: `haraka-9-old-smtp` is not a generation of `smtp` because `9-old` isn't a number.

The unit tests passed in #33 because the fake populated fields the real client never does — fixtures now construct `ServiceInfo` exactly the way `listServices` does (names only), so this class of gap can't reopen silently.

`go test ./...` — all packages green.

After merge: tag v1.2.1, upgrade daemon, redeploy haraka.