### PR TITLE
fix(worker): never reap web service on inconclusive data-plane probe

### DIFF
--- a/internal/server/worker/caddy_dataplane_test.go
+++ b/internal/server/worker/caddy_dataplane_test.go
@@ -3,6 +3,7 @@ package worker
 import (
 	"context"
 	"testing"
+	"time"
 
 	"github.com/heyblueteam/cobalt/internal/server/cobaltfile"
 	"github.com/heyblueteam/cobalt/internal/server/docker"
@@ -39,8 +40,18 @@ func (f *fakeReaper) RemoveService(_ context.Context, name string) error {
 
 // inSyncFixture builds a store + caddy where the admin config tree is correct
 // (upstream == api-7-web): the case where only a data-plane probe can reveal a
-// lagging compiled router.
+// lagging compiled router. The live deployment's cutover (FinishedAt) is set
+// well past reapMinAge by default, so tests exercising confirmation/repair
+// behavior aren't incidentally blocked by the grace-floor check — tests that
+// specifically want to exercise the floor build their own fixture.
 func inSyncFixture(t *testing.T) (*fakeReconcileStore, *fakeReconcileCaddy) {
+	t.Helper()
+	return inSyncFixtureFinishedAgo(t, reapMinAge*10)
+}
+
+// inSyncFixtureFinishedAgo is inSyncFixture parameterized on how long ago the
+// live deployment's cutover completed, for tests exercising reapMinAge.
+func inSyncFixtureFinishedAgo(t *testing.T, ago time.Duration) (*fakeReconcileStore, *fakeReconcileCaddy) {
 	t.Helper()
 	cf := mustCobaltfileJSON(t, &cobaltfile.Cobaltfile{
 		Version: "1.0",
@@ -49,10 +60,14 @@ func inSyncFixture(t *testing.T) (*fakeReconcileStore, *fakeReconcileCaddy) {
 		},
 		Images: map[string]cobaltfile.Image{"default": {Dockerfile: "Dockerfile", Context: "."}},
 	})
+	finishedAt := time.Now().Add(-ago).Unix()
 	st := &fakeReconcileStore{
 		projects: []store.Project{{ID: 1, Name: "api"}},
 		lastByID: map[int64]*store.Deployment{
-			1: {ID: 10, ProjectID: 1, Number: 7, Status: cobaltapi.StateSuccess, ResolvedCobaltfile: nullStr(cf)},
+			1: {
+				ID: 10, ProjectID: 1, Number: 7, Status: cobaltapi.StateSuccess,
+				ResolvedCobaltfile: nullStr(cf), FinishedAt: &finishedAt,
+			},
 		},
 		domains: map[int64][]string{1: {"api.example.com"}},
 	}
@@ -149,7 +164,12 @@ func TestReconcile_DataPlaneHealthy_ReapsSupersededWebOnly(t *testing.T) {
 	}
 }
 
-func TestReconcile_NilProber_StillReapsButNeverDataPlaneRepairs(t *testing.T) {
+// TestReconcile_NilProber_NeverReapsOrRepairs replaces what was previously
+// TestReconcile_NilProber_StillReapsButNeverDataPlaneRepairs, which asserted
+// the 2026-07-14 incident's actual bug as intended behavior: a disabled
+// prober (dp == nil) is "unknown," not confirmation, and must never license a
+// reap — only a genuinely-confirmed data-plane probe may.
+func TestReconcile_NilProber_NeverReapsOrRepairs(t *testing.T) {
 	t.Parallel()
 	st, cy := inSyncFixture(t)
 	reaper := &fakeReaper{services: []docker.ServiceInfo{
@@ -164,7 +184,148 @@ func TestReconcile_NilProber_StillReapsButNeverDataPlaneRepairs(t *testing.T) {
 	if corrected != 0 || len(cy.serveCalls) != 0 {
 		t.Errorf("nil prober must not repair: corrected=%d serveCalls=%d", corrected, len(cy.serveCalls))
 	}
+	if len(reaper.removed) != 0 {
+		t.Errorf("nil prober is unknown, not confirmed — must not reap: got %v", reaper.removed)
+	}
+}
+
+// TestReconcile_ProbeInconclusive_NeverReaps covers the exact incident shape:
+// a probe error (Caddy unreachable / timeout) must not license a reap, same
+// as a nil prober.
+func TestReconcile_ProbeInconclusive_NeverReaps(t *testing.T) {
+	t.Parallel()
+	st, cy := inSyncFixture(t)
+	dp := fakeDataPlaneProber{err: context.DeadlineExceeded}
+	reaper := &fakeReaper{services: []docker.ServiceInfo{
+		{Name: "api-7-web"},
+		{Name: "api-6-web"},
+	}}
+
+	corrected, err := ReconcileCaddyState(context.Background(), quietLogger(), st, cy, dp, reaper)
+	if err != nil {
+		t.Fatalf("Reconcile: %v", err)
+	}
+	if corrected != 0 || len(cy.serveCalls) != 0 {
+		t.Errorf("inconclusive probe must not repair: corrected=%d serveCalls=%d", corrected, len(cy.serveCalls))
+	}
+	if len(reaper.removed) != 0 {
+		t.Errorf("inconclusive probe is unknown, not confirmed — must not reap: got %v", reaper.removed)
+	}
+}
+
+// TestReconcile_NoHeader_NeverReaps covers served=="" (a pre-header handler):
+// treated as unknown, so it must not repair (already covered above) and must
+// also not reap.
+func TestReconcile_NoHeader_NeverReaps(t *testing.T) {
+	t.Parallel()
+	st, cy := inSyncFixture(t)
+	dp := fakeDataPlaneProber{served: "", status: 200}
+	reaper := &fakeReaper{services: []docker.ServiceInfo{
+		{Name: "api-7-web"},
+		{Name: "api-6-web"},
+	}}
+
+	corrected, err := ReconcileCaddyState(context.Background(), quietLogger(), st, cy, dp, reaper)
+	if err != nil {
+		t.Fatalf("Reconcile: %v", err)
+	}
+	if corrected != 0 || len(cy.serveCalls) != 0 {
+		t.Errorf("no-header must not repair: corrected=%d serveCalls=%d", corrected, len(cy.serveCalls))
+	}
+	if len(reaper.removed) != 0 {
+		t.Errorf("no-header is unknown, not confirmed — must not reap: got %v", reaper.removed)
+	}
+}
+
+// TestReconcile_ConfirmedButWithinGraceFloor_DoesNotReapYet is the direct
+// regression test for the 2026-07-14 incident: even with a genuinely
+// confirmed data-plane probe, a generation reaped within reapMinAge of its
+// own cutover is exactly the window where a Cloudflare-pooled connection can
+// still be pinned to the old Docker DNS name.
+func TestReconcile_ConfirmedButWithinGraceFloor_DoesNotReapYet(t *testing.T) {
+	t.Parallel()
+	st, cy := inSyncFixtureFinishedAgo(t, 10*time.Second) // well under reapMinAge
+	dp := fakeDataPlaneProber{served: "7", status: 200}   // genuinely confirmed
+	reaper := &fakeReaper{services: []docker.ServiceInfo{
+		{Name: "api-7-web"},
+		{Name: "api-6-web"},
+	}}
+
+	corrected, err := ReconcileCaddyState(context.Background(), quietLogger(), st, cy, dp, reaper)
+	if err != nil {
+		t.Fatalf("Reconcile: %v", err)
+	}
+	if corrected != 0 || len(cy.serveCalls) != 0 {
+		t.Errorf("confirmed healthy data plane must not repair: corrected=%d serveCalls=%d", corrected, len(cy.serveCalls))
+	}
+	if len(reaper.removed) != 0 {
+		t.Errorf("confirmed but within reapMinAge of cutover — must not reap yet: got %v", reaper.removed)
+	}
+}
+
+// TestReconcile_ConfirmedAndPastGraceFloor_Reaps confirms reaping still
+// happens once both conditions hold: genuine confirmation AND enough time
+// elapsed since cutover.
+func TestReconcile_ConfirmedAndPastGraceFloor_Reaps(t *testing.T) {
+	t.Parallel()
+	st, cy := inSyncFixtureFinishedAgo(t, reapMinAge+time.Minute)
+	dp := fakeDataPlaneProber{served: "7", status: 200}
+	reaper := &fakeReaper{services: []docker.ServiceInfo{
+		{Name: "api-7-web"},
+		{Name: "api-6-web"},
+	}}
+
+	corrected, err := ReconcileCaddyState(context.Background(), quietLogger(), st, cy, dp, reaper)
+	if err != nil {
+		t.Fatalf("Reconcile: %v", err)
+	}
+	if corrected != 0 || len(cy.serveCalls) != 0 {
+		t.Errorf("confirmed healthy data plane must not repair: corrected=%d serveCalls=%d", corrected, len(cy.serveCalls))
+	}
 	if len(reaper.removed) != 1 || reaper.removed[0] != "api-6-web" {
-		t.Errorf("expected to reap api-6-web even with nil prober, got %v", reaper.removed)
+		t.Errorf("expected to reap api-6-web once confirmed and past grace floor, got %v", reaper.removed)
+	}
+}
+
+// TestReconcile_NoFinishedAt_NeverReaps guards the defensive nil-check: a
+// deployment row missing a cutover timestamp must not be reaped from, rather
+// than guessing at its age.
+func TestReconcile_NoFinishedAt_NeverReaps(t *testing.T) {
+	t.Parallel()
+	cf := mustCobaltfileJSON(t, &cobaltfile.Cobaltfile{
+		Version: "1.0",
+		Services: map[string]cobaltfile.Service{
+			"web": {Type: cobaltfile.TypeContainer, Image: "default", Port: 3000},
+		},
+		Images: map[string]cobaltfile.Image{"default": {Dockerfile: "Dockerfile", Context: "."}},
+	})
+	st := &fakeReconcileStore{
+		projects: []store.Project{{ID: 1, Name: "api"}},
+		lastByID: map[int64]*store.Deployment{
+			1: {
+				ID: 10, ProjectID: 1, Number: 7, Status: cobaltapi.StateSuccess,
+				ResolvedCobaltfile: nullStr(cf), FinishedAt: nil,
+			},
+		},
+		domains: map[int64][]string{1: {"api.example.com"}},
+	}
+	cy := newFakeReconcileCaddy()
+	cy.routeExists[1] = true
+	cy.upstream[1] = "api-7-web"
+	dp := fakeDataPlaneProber{served: "7", status: 200}
+	reaper := &fakeReaper{services: []docker.ServiceInfo{
+		{Name: "api-7-web"},
+		{Name: "api-6-web"},
+	}}
+
+	corrected, err := ReconcileCaddyState(context.Background(), quietLogger(), st, cy, dp, reaper)
+	if err != nil {
+		t.Fatalf("Reconcile: %v", err)
+	}
+	if corrected != 0 || len(cy.serveCalls) != 0 {
+		t.Errorf("confirmed healthy data plane must not repair: corrected=%d serveCalls=%d", corrected, len(cy.serveCalls))
+	}
+	if len(reaper.removed) != 0 {
+		t.Errorf("missing FinishedAt must not reap: got %v", reaper.removed)
 	}
 }

--- a/internal/server/worker/caddy_reconcile.go
+++ b/internal/server/worker/caddy_reconcile.go
@@ -6,12 +6,27 @@ import (
 	"fmt"
 	"log/slog"
 	"strconv"
+	"time"
 
 	"github.com/heyblueteam/cobalt/internal/server/caddy"
 	"github.com/heyblueteam/cobalt/internal/server/cobaltfile"
 	"github.com/heyblueteam/cobalt/internal/server/docker"
 	"github.com/heyblueteam/cobalt/internal/server/store"
 )
+
+// reapMinAge is the minimum time since a deployment's cutover before its
+// superseded web generation may be reaped, regardless of data-plane probe
+// outcome. This is the backstop for the 2026-07-14 incident: a Cloudflare
+// edge machine can hold a pooled keep-alive connection to Caddy that
+// resolved (and cached, for the connection's lifetime) the old generation's
+// Docker DNS name. Reaping that name out from under a still-live pooled
+// connection leaves it dialing a deleted host indefinitely — bounded only by
+// however long Cloudflare takes to cycle that specific connection, which can
+// be well over 20 minutes. This floor doesn't eliminate that risk (only a
+// stable service name/VIP would), but it keeps the reap from firing within
+// the same tick as cutover, when the odds of a live pooled connection still
+// pointing at the old generation are highest.
+const reapMinAge = 5 * time.Minute
 
 // CaddyReconcileStore is the store subset the Caddy reconciler needs.
 type CaddyReconcileStore interface {
@@ -226,17 +241,23 @@ func reconcileProject(
 		// (the silent post-cutover 502 divergence; the admin GET above can't
 		// see it). Probe the data plane and force-repair if the running router
 		// disagrees.
-		corrected, err := reconcileDataPlane(ctx, log, cy, dp, p, *live, web, domains[0])
+		outcome, err := reconcileDataPlane(ctx, log, cy, dp, p, *live, web, domains[0])
 		if err != nil {
 			return false, err
 		}
-		if !corrected {
+		switch outcome {
+		case dataPlaneRepaired:
+			return true, nil
+		case dataPlaneConfirmed:
 			// Only reap a superseded web generation once the live router is
-			// confirmed (or unprobed-but-config-correct) on the new one — never
-			// while traffic might still be landing on the old build.
-			reapSupersededWeb(ctx, log, reaper, p, live.Number)
+			// GENUINELY confirmed on the new one — never on an unprobed,
+			// disabled, or inconclusive result. See reapMinAge's doc comment
+			// for why confirmation alone still isn't sufficient on its own.
+			reapSupersededWeb(ctx, log, reaper, p, *live)
+			return false, nil
+		default: // dataPlaneUnknown
+			return false, nil
 		}
-		return corrected, nil
 
 	case cobaltfile.TypeStatic, cobaltfile.TypeGenerator:
 		// We don't have a cheap "what is the current root?" probe (it
@@ -247,6 +268,27 @@ func reconcileProject(
 	return false, nil
 }
 
+// dataPlaneOutcome is the result of probing Caddy's running router, kept as
+// an explicit tri-state so callers can never conflate "we don't actually
+// know" with "we confirmed it's fine" — the two were collapsed into a single
+// bool before the 2026-07-14 incident, and the reconciler treated an
+// inconclusive probe as license to reap the superseded web service.
+type dataPlaneOutcome int
+
+const (
+	// dataPlaneUnknown means the probe gave no usable signal: disabled
+	// (nil prober), errored (Caddy unreachable), or returned no
+	// X-Cobalt-Deployment header (a pre-header handler). Never treat this
+	// as confirmation of anything.
+	dataPlaneUnknown dataPlaneOutcome = iota
+	// dataPlaneConfirmed means the router positively reported serving the
+	// desired deployment number, with no gateway error.
+	dataPlaneConfirmed
+	// dataPlaneRepaired means the router had diverged and this call issued
+	// a force-repair PATCH.
+	dataPlaneRepaired
+)
+
 // reconcileDataPlane probes Caddy's running router for the project's primary
 // domain and, when it diverges from the desired deployment, force-repairs with
 // a single ServeService PATCH — which makes Caddy recompile the route. That's
@@ -254,8 +296,10 @@ func reconcileProject(
 // one reload instead of three.
 //
 // A nil prober, an inconclusive probe (Caddy unreachable), or a "no header"
-// response (a pre-header handler) are all treated as "unknown" — never as
-// drift — so a fleet-wide daemon upgrade can't stampede force-rebuilds.
+// response (a pre-header handler) are all treated as dataPlaneUnknown — never
+// as drift, and never as confirmation — so a fleet-wide daemon upgrade can't
+// stampede force-rebuilds, and an unprobed project's superseded web service is
+// never reaped on the strength of "we didn't see anything wrong."
 func reconcileDataPlane(
 	ctx context.Context,
 	log *slog.Logger,
@@ -265,32 +309,34 @@ func reconcileDataPlane(
 	live store.Deployment,
 	web cobaltfile.Service,
 	domain string,
-) (bool, error) {
+) (dataPlaneOutcome, error) {
 	if dp == nil {
-		return false, nil
+		return dataPlaneUnknown, nil
 	}
 	want := strconv.Itoa(live.Number)
 	served, status, err := dp.ServedDeployment(ctx, domain)
 	if err != nil {
 		log.Debug("caddy reconcile: data-plane probe inconclusive",
 			"project_id", p.ID, "project", p.Name, "error", err)
-		return false, nil
+		return dataPlaneUnknown, nil
 	}
-	// Divergence = the router serves a different deployment, or 502/503/504s
-	// because it's dialing a dead upstream. served=="" (no header) is NOT
-	// divergence — treat unknown handlers as fine and let their next deploy
-	// stamp the header.
-	if !isGatewayStatus(status) && (served == "" || served == want) {
-		return false, nil
+	// served=="" (no header) is NOT divergence — treat unknown handlers as
+	// fine and let their next deploy stamp the header — but it's also not a
+	// positive confirmation, so it must not license a reap either.
+	if !isGatewayStatus(status) && served == "" {
+		return dataPlaneUnknown, nil
+	}
+	if !isGatewayStatus(status) && served == want {
+		return dataPlaneConfirmed, nil
 	}
 	log.Warn("caddy reconcile: upstream drifted (data plane)",
 		"project_id", p.ID, "project", p.Name,
 		"want", want, "served", served, "status", status)
 	container := docker.ServiceName(p.Name, live.Number, "web")
 	if err := cy.ServeService(ctx, p.ID, container, web.Port, live.Number); err != nil {
-		return false, fmt.Errorf("repair upstream (data plane): %w", err)
+		return dataPlaneUnknown, fmt.Errorf("repair upstream (data plane): %w", err)
 	}
-	return true, nil
+	return dataPlaneRepaired, nil
 }
 
 func isGatewayStatus(status int) bool {
@@ -301,15 +347,31 @@ func isGatewayStatus(status int) bool {
 // older deployment than current. deploy.cleanupOldServices intentionally keeps
 // the most recent prior generation alive as a grace fallback (so a lagging
 // router serves the old build instead of 502ing); this reaps it once the live
-// deployment is confirmed serving. Best-effort and nil-safe.
+// deployment is confirmed serving AND at least reapMinAge has elapsed since
+// cutover (see its doc comment — confirmation alone doesn't rule out a
+// pooled client connection still pinned to the old service's DNS name).
+// Best-effort and nil-safe.
 func reapSupersededWeb(
 	ctx context.Context,
 	log *slog.Logger,
 	reaper ServiceReaper,
 	p store.Project,
-	currentNumber int,
+	live store.Deployment,
 ) {
 	if reaper == nil {
+		return
+	}
+	if live.FinishedAt == nil {
+		// A successful deployment should always have this set; if it
+		// somehow doesn't, don't guess at how long ago cutover happened —
+		// skip reaping this tick rather than risk reaping too early.
+		log.Debug("caddy reconcile: skipping reap, no cutover timestamp",
+			"project_id", p.ID, "current", live.Number)
+		return
+	}
+	if age := time.Since(time.Unix(*live.FinishedAt, 0)); age < reapMinAge {
+		log.Debug("caddy reconcile: skipping reap, within grace floor",
+			"project_id", p.ID, "current", live.Number, "age", age)
 		return
 	}
 	services, err := reaper.ListServicesForProject(ctx, p.ID)
@@ -320,7 +382,7 @@ func reapSupersededWeb(
 	}
 	for _, s := range services {
 		n, ok := docker.WebGeneration(p.Name, s.Name)
-		if !ok || n >= currentNumber {
+		if !ok || n >= live.Number {
 			continue
 		}
 		if err := reaper.RemoveService(ctx, s.Name); err != nil {
@@ -329,7 +391,7 @@ func reapSupersededWeb(
 			continue
 		}
 		log.Info("caddy reconcile: reaped superseded web service",
-			"name", s.Name, "project_id", p.ID, "current", currentNumber)
+			"name", s.Name, "project_id", p.ID, "current", live.Number)
 	}
 }
 


### PR DESCRIPTION
## Summary

Fixes the reconciler bug behind the 2026-07-14 production incident: an already-open Cloudflare-to-origin keep-alive connection stayed pinned to a deleted Docker service name for 20+ minutes, causing intermittent 502/521s and failed dynamic chunk loads for a subset of users hitting that one edge machine.

**Root cause:** `reconcileDataPlane` collapsed three distinct outcomes — prober disabled, probe errored/inconclusive, and genuinely confirmed — into a single `(false, nil)` return. The caller (`reconcileProject`) treated any `!corrected` as license to call `reapSupersededWeb`, which removes the prior deployment's Docker Swarm service (and its DNS name) with no drain wait or minimum-age check. On the incident deploy, both the deploy's own cutover probe and the reconciler's first follow-up tick were inconclusive, and the old service was reaped anyway — out from under a still-live pooled connection.

**Fix:**
- Made the probe outcome an explicit tri-state (`dataPlaneUnknown` / `dataPlaneConfirmed` / `dataPlaneRepaired`) so "we don't know" can never be read as "confirmed."
- Only `reapSupersededWeb` on genuine `dataPlaneConfirmed`.
- Added `reapMinAge` (5 min): a hard floor on top of confirmation — a generation is never reaped before that much time has passed since its own cutover (`Deployment.FinishedAt`), regardless of probe outcome. This is the backstop for a misconfigured/permanently-inconclusive prober, and narrows the window where a pooled connection could still be pinned to the old name.

This does not eliminate the underlying class of bug (a Docker DNS name disappearing out from under an already-open Caddy→upstream connection tied to a per-deployment-number service name) — that's a larger architectural follow-up (stable service naming/VIP). This PR fixes the actual triggering defect: reaping on zero real confirmation.

Full incident writeup and follow-up tracking: `plans/cobalt-reap-connection-poisoning.md` and a new `docs/gotchas.md` entry in the `blue` monorepo.

## Test plan

- [x] `go build ./...`
- [x] `go vet ./...`
- [x] `go test ./...` (full suite, all packages pass)
- [x] Existing reconciler tests updated: `TestReconcile_NilProber_StillReapsButNeverDataPlaneRepairs` renamed to `TestReconcile_NilProber_NeverReapsOrRepairs` and fixed to assert no reap (it previously asserted the bug as intended behavior)
- [x] New coverage added: probe-error-never-reaps, no-header-never-reaps, confirmed-but-within-grace-floor-does-not-reap-yet, confirmed-and-past-grace-floor-reaps, missing-FinishedAt-never-reaps