### PR TITLE
🐛 fix(caddy): restart cobalt_caddy stop-first so it doesn't deadlock on host ports

### DIFF
--- a/cmd/cobalt/assets/init-docker-compose.yml
+++ b/cmd/cobalt/assets/init-docker-compose.yml
@@ -70,6 +70,16 @@ services:
     command: caddy run --config /etc/caddy/Caddyfile --adapter caddyfile
     deploy:
       replicas: 1
+      # The host-mode ports above mean two generations can't run at once —
+      # they'd fight over 80/443. Swarm's default start-first ordering would
+      # leave a restart's new task Pending forever ("host-mode port already in
+      # use") while the old one keeps running, so a restart silently no-ops.
+      # stop-first is mandatory here: it accepts a brief (~1-2s) all-sites blip
+      # in exchange for the restart actually cycling.
+      update_config:
+        order: stop-first
+      rollback_config:
+        order: stop-first
       restart_policy:
         condition: any
       placement:

--- a/internal/server/docker/service.go
+++ b/internal/server/docker/service.go
@@ -162,11 +162,19 @@ func (c *Client) ScaleService(ctx context.Context, name string, replicas int) er
 }
 
 // RestartService forces a rolling restart of an existing swarm service in
-// place — same config, fresh tasks — via `docker service update --force`.
-// The Caddy watchdog uses it to recover a wedged admin endpoint without a
-// human SSHing in to `docker restart`.
+// place — same config, fresh tasks. The Caddy watchdog uses it to recover a
+// wedged admin endpoint without a human SSHing in to `docker restart`.
+//
+// The restart is forced stop-first (old task removed before the new one
+// starts). Its only caller is the Caddy ingress service, which publishes
+// host-mode ports 80/443: two generations can't bind the same host port, so
+// the Swarm default start-first ordering leaves the new task Pending forever
+// ("no suitable node (host-mode port already in use)") while the wedged old
+// task keeps running — the restart silently no-ops. Passing the order here
+// also heals a service whose stored spec is start-first. The cost is a brief
+// (~1-2s) window with no Caddy bound, which the watchdog already accounts for.
 func (c *Client) RestartService(ctx context.Context, name string) error {
-	return c.run(ctx, "service", "update", "--force", name)
+	return c.run(ctx, "service", "update", "--force", "--update-order", "stop-first", name)
 }
 
 // ServiceInfo summarizes a swarm service's identity.

--- a/internal/server/docker/service_test.go
+++ b/internal/server/docker/service_test.go
@@ -416,6 +416,21 @@ func TestScaleService(t *testing.T) {
 	}
 }
 
+func TestRestartService_ForcesStopFirst(t *testing.T) {
+	t.Parallel()
+	r := newFakeRunner()
+	c := NewWithRunner(r)
+	if err := c.RestartService(context.Background(), "cobalt_caddy"); err != nil {
+		t.Fatalf("RestartService: %v", err)
+	}
+	args := r.lastCall().Args
+	// stop-first is load-bearing: the caddy ingress publishes host-mode ports,
+	// so start-first (Swarm's default) deadlocks the restart on the bound port.
+	if !argSequence(args, "service", "update", "--force", "--update-order", "stop-first", "cobalt_caddy") {
+		t.Errorf("restart args = %v, want `service update --force --update-order stop-first cobalt_caddy`", args)
+	}
+}
+
 func TestListServicesForProject_Parses(t *testing.T) {
 	t.Parallel()
 	r := newFakeRunner()


### PR DESCRIPTION
## Problem

`cobalt_caddy` publishes **host-mode ports 80/443** with `replicas: 1`, so two generations can't run simultaneously. But its update order is **start-first** (Swarm's default when unset), so `docker service update --force cobalt_caddy` — exactly what `RestartService` issues — leaves the new task **Pending forever** (`"no suitable node (host-mode port already in use)"`) while the wedged old task keeps serving. **The restart silently no-ops.**

This breaks cobalt's own recovery path: the **CaddyWatchdog** restarts `cobalt_caddy` via `RestartService` when Caddy's admin socket wedges — so on a start-first service, **the watchdog can never actually recover a wedged Caddy**, despite its comment assuming a working "~1-2s interruption" restart.

It also bit a manual restart during a 2026-07-15 production incident (remediating a Cloudflare edge→origin connection poisoned by a service reap): the `--force` restart deadlocked and recovery required a hand `docker rm -f` of the old container so the queued task could bind the port.

## Fix

Make the caddy restart **stop-first** in both places the order is decided:

- **`internal/server/docker/service.go`** — `RestartService` passes `--update-order stop-first` alongside `--force`. Stops the old task before starting the new one (the only order that works for a host-port service), and heals a service whose stored spec is start-first. It's watchdog-only and only ever restarts the caddy ingress, so forcing stop-first is safe.
- **`cmd/cobalt/assets/init-docker-compose.yml`** — pin the `caddy` service's `deploy.update_config.order` and `rollback_config.order` to `stop-first` (with a comment) so new installs get the correct spec.
- **Test** asserting `RestartService` issues `service update --force --update-order stop-first <name>`.

**Trade-off:** a brief (~1-2s) window with no Caddy bound on each caddy restart — unavoidable for a single-replica host-port ingress, and already the watchdog's stated cost. start-first simply doesn't restart at all.

## Existing hosts

The compose change only affects `cobalt init` for new hosts. A host already running a start-first `cobalt_caddy` is healed by the `RestartService` fix on the next watchdog-triggered restart, or update its `/opt/cobalt/docker-compose.yml` and re-`docker stack deploy` to make it explicit now.

## Verification

- `go build ./...`, `go vet`, `gofmt` clean
- `go test ./internal/server/docker/ ./internal/server/worker/` green (incl. new `TestRestartService_ForcesStopFirst`)
- compose YAML validated (`caddy.deploy.update_config.order == stop-first`)

Companion to the reap-connection-poisoning fix — full context in the blue repo's `plans/cobalt-reap-connection-poisoning.md` (Fix B section).