### PR TITLE
🐛 fix(release): strip macOS quarantine on cask install so Gatekeeper stops blocking cobalt

### DIFF
--- a/.goreleaser.yml
+++ b/.goreleaser.yml
@@ -35,6 +35,16 @@ homebrew_casks:
       verified: "github.com/heyblueteam/cobalt"
     binaries:
       - "cobalt"
+    # The macOS binary is unsigned/unnotarized, so Homebrew installs it with a
+    # com.apple.quarantine marker and Gatekeeper blocks the first run ("cobalt
+    # Not Opened / could not verify … free of malware"). Strip the marker on
+    # install so `brew install`/`brew upgrade` just works. The real fix is
+    # Developer-ID signing + notarization (needs an Apple Developer account);
+    # this is the free stopgap until then.
+    hooks:
+      post:
+        install: |
+          system_command "/usr/bin/xattr", args: ["-dr", "com.apple.quarantine", "#{staged_path}/cobalt"]
 
 checksum:
   name_template: "checksums.txt"


### PR DESCRIPTION
## Problem

The macOS build is **unsigned and unnotarized** (`.goreleaser.yml` has no `signs:`/`notarize:` block), so Homebrew installs the binary with a `com.apple.quarantine` marker and Gatekeeper blocks the first run:

> "cobalt" Not Opened — Apple could not verify "cobalt" is free of malware…

Every `cobalt` invocation then silently dies (killed before it runs) until the user manually runs `xattr -d com.apple.quarantine <binary>`. Hit live during the v1.4.0 upgrade — every command produced no output until the marker was cleared by hand.

## Fix (stopgap)

Add a cask **postflight** that strips the quarantine marker on install, so `brew install` / `brew upgrade` just work:

```ruby
postflight do
  system_command "/usr/bin/xattr", args: ["-dr", "com.apple.quarantine", "#{staged_path}/cobalt"]
end
```

Verified against a local `goreleaser release --snapshot` build — the generated `dist/homebrew/Casks/cobalt.rb` now emits the `postflight` block, and `goreleaser check` passes.

## Scope / limitations

- Covers the **Homebrew** install path (the cask runs the postflight). A binary downloaded directly from the GitHub release still shows the Gatekeeper dialog.
- This is a **stopgap**, not real trust. The proper fix is Developer-ID **signing + notarization** in the release pipeline — deferred until an Apple Developer account is available. (Notably relevant ahead of the public MAD spin-out.)