### PR TITLE
fix(caddy): atomic read-modify-write route apply + retry hardening

### DIFF
--- a/internal/server/caddy/client.go
+++ b/internal/server/caddy/client.go
@@ -116,16 +116,27 @@ func (c *Client) do(ctx context.Context, method, path string, body, out any) err
 	return c.doLocked(ctx, method, path, body, out)
 }
 
-// retryableMethods are the HTTP methods our admin client retries on
-// transient failure. Caddy's admin API is idempotent on @id-keyed
-// PATCH/PUT/DELETE — running the same call twice produces the same
-// state. POSTs that target a numeric route position (e.g.
-// `/config/.../routes/0`) ARE NOT idempotent; we don't retry those.
-var retryableMethods = map[string]bool{
-	http.MethodGet:    true,
-	http.MethodPatch:  true,
-	http.MethodPut:    true,
-	http.MethodDelete: true,
+// isRetryable reports whether a failed admin call is safe to re-send.
+// Retrying is only safe when a call that timed out AFTER Caddy applied it
+// converges to the same state on replay:
+//
+//   - GET is read-only.
+//   - PATCH and DELETE are only issued against @id-keyed paths in this
+//     package; replaying them converges.
+//   - PUT is idempotent ONLY when @id-keyed. Against a positional route
+//     index (e.g. `/config/.../routes/0`) it is an INSERT — Caddy prepends
+//     rather than replaces — so re-sending a timed-out-but-applied call
+//     would duplicate the route. Those surface their error instead.
+//   - POST (`/load`) stays outside the retried set; the read-modify-write
+//     apply wrapping it lets the failure bubble to its caller.
+func isRetryable(method, path string) bool {
+	switch method {
+	case http.MethodGet, http.MethodPatch, http.MethodDelete:
+		return true
+	case http.MethodPut:
+		return strings.HasPrefix(path, "/id/")
+	}
+	return false
 }
 
 // retryBackoff is the per-attempt sleep schedule for retried admin
@@ -137,7 +148,7 @@ var retryBackoff = []time.Duration{0, 2 * time.Second, 8 * time.Second}
 // during a Caddy reload) but not permanent errors (4xx responses, JSON
 // marshal failures, context cancellation).
 func (c *Client) doLocked(ctx context.Context, method, path string, body, out any) error {
-	if !retryableMethods[method] {
+	if !isRetryable(method, path) {
 		return c.doOnce(ctx, method, path, body, out)
 	}
 	var lastErr error

--- a/internal/server/caddy/client_test.go
+++ b/internal/server/caddy/client_test.go
@@ -9,17 +9,20 @@ import (
 	"net/http/httptest"
 	"strings"
 	"sync"
+	"sync/atomic"
 	"testing"
 )
 
-// fakeCaddy is an httptest.Server that records every admin request and
-// answers @id GETs from an in-memory map. Enough fidelity for our wire-format
-// tests; not a real Caddy.
+// fakeCaddy is an httptest.Server that records every admin request, answers
+// @id GETs from an in-memory map, and holds a full-config document for the
+// GET /config/ + POST /load pair the read-modify-write route apply uses.
+// Enough fidelity for our wire-format tests; not a real Caddy.
 type fakeCaddy struct {
 	t      *testing.T
 	mu     sync.Mutex
 	calls  []recordedCall
 	byID   map[string]json.RawMessage
+	config json.RawMessage
 	server *httptest.Server
 }
 
@@ -29,12 +32,49 @@ type recordedCall struct {
 	Body   json.RawMessage
 }
 
+// fakeBootstrapConfig is the full-config document a pristine cobalt Caddy
+// holds: admin + logging blocks, and the cobalt server with only the daemon
+// host route installed by the bootstrap config.
+const fakeBootstrapConfig = `{"admin":{"listen":"unix//cobalt/caddy-socket/caddy.sock"},"apps":{"http":{"servers":{"cobalt":{"listen":[":80"],"routes":[{"@id":"cobalt-daemon-host","handle":[],"match":[{"host":["cobalt.example"]}],"terminal":true}]}}}},"logging":{}}`
+
 func newFakeCaddy(t *testing.T) *fakeCaddy {
 	t.Helper()
-	f := &fakeCaddy{t: t, byID: map[string]json.RawMessage{}}
+	f := &fakeCaddy{
+		t:      t,
+		byID:   map[string]json.RawMessage{},
+		config: json.RawMessage(fakeBootstrapConfig),
+	}
+	f.indexIDs(f.config)
 	f.server = httptest.NewServer(http.HandlerFunc(f.handle))
 	t.Cleanup(f.server.Close)
 	return f
+}
+
+// indexIDs walks a config document and registers every object carrying an
+// @id into byID, mirroring how real Caddy rebuilds its id index on load.
+func (f *fakeCaddy) indexIDs(doc json.RawMessage) {
+	var root any
+	if err := json.Unmarshal(doc, &root); err != nil {
+		return
+	}
+	var walk func(v any)
+	walk = func(v any) {
+		switch t := v.(type) {
+		case map[string]any:
+			if id, ok := t["@id"].(string); ok && id != "" {
+				raw, _ := json.Marshal(t)
+				f.byID[id] = raw
+			}
+			for _, child := range t {
+				walk(child)
+			}
+		case []any:
+			for _, child := range t {
+				walk(child)
+			}
+		}
+	}
+	walk(root)
 }
 
 func (f *fakeCaddy) handle(w http.ResponseWriter, r *http.Request) {
@@ -93,6 +133,19 @@ func (f *fakeCaddy) handle(w http.ResponseWriter, r *http.Request) {
 			w.WriteHeader(http.StatusOK)
 			return
 		}
+	}
+
+	// Full-config read + atomic swap — the read-modify-write route apply.
+	if r.Method == http.MethodGet && r.URL.Path == "/config/" {
+		w.Write(f.config)
+		return
+	}
+	if r.Method == http.MethodPost && r.URL.Path == "/load" {
+		f.config = body
+		f.byID = map[string]json.RawMessage{}
+		f.indexIDs(body)
+		w.WriteHeader(http.StatusOK)
+		return
 	}
 
 	// PUT to /config/.../routes/0 — register the route under its @id.
@@ -173,10 +226,10 @@ func TestAddProjectRoute_BodyShape(t *testing.T) {
 		t.Fatalf("AddProjectRoute: %v", err)
 	}
 	call := f.lastCall(t)
-	if call.Method != http.MethodPut {
-		t.Errorf("method: got %s, want PUT", call.Method)
+	if call.Method != http.MethodPost {
+		t.Errorf("method: got %s, want POST", call.Method)
 	}
-	if call.Path != "/config/apps/http/servers/cobalt/routes/0" {
+	if call.Path != "/load" {
 		t.Errorf("path: got %s", call.Path)
 	}
 	bodyStr := string(call.Body)
@@ -188,6 +241,8 @@ func TestAddProjectRoute_BodyShape(t *testing.T) {
 		`"terminal":true`,
 		`"reverse_proxy"`,
 		c.PlaceholderUpstream,
+		// The rest of the live config rides along untouched in the load.
+		`"@id":"cobalt-daemon-host"`,
 	} {
 		if !strings.Contains(bodyStr, want) {
 			t.Errorf("body missing %q\nfull: %s", want, bodyStr)
@@ -402,5 +457,59 @@ func TestStaticSiteDeploymentPath(t *testing.T) {
 	want := "/cobalt/srv/myblog/deployments/5"
 	if got != want {
 		t.Errorf("got %q, want %q", got, want)
+	}
+}
+
+func TestRetryClassification(t *testing.T) {
+	t.Parallel()
+	cases := []struct {
+		method, path string
+		want         bool
+	}{
+		{http.MethodGet, "/config/", true},
+		{http.MethodGet, "/id/cobalt-project-handler-2/upstreams/0/dial", true},
+		{http.MethodPatch, "/id/cobalt-project-handler-2", true},
+		{http.MethodDelete, "/id/cobalt-redirect-5", true},
+		// An @id-keyed PUT converges on replay; safe to retry.
+		{http.MethodPut, "/id/cobalt-project-2", true},
+		// A positional route PUT is an insert: re-sending a call that timed
+		// out after Caddy applied it would duplicate the route.
+		{http.MethodPut, "/config/apps/http/servers/cobalt/routes/0", false},
+		// The full-config load: POST stays outside the retried set.
+		{http.MethodPost, "/load", false},
+	}
+	for _, tc := range cases {
+		if got := isRetryable(tc.method, tc.path); got != tc.want {
+			t.Errorf("isRetryable(%s %s): got %v, want %v", tc.method, tc.path, got, tc.want)
+		}
+	}
+}
+
+func TestPositionalPutNotRetriedOnTransportError(t *testing.T) {
+	t.Parallel()
+	var attempts atomic.Int32
+	// Hijack + close: the client sees a transport-layer error (the
+	// transient shape the retry loop normally re-sends).
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		attempts.Add(1)
+		hj, ok := w.(http.Hijacker)
+		if !ok {
+			t.Error("response writer is not a hijacker")
+			return
+		}
+		if conn, _, err := hj.Hijack(); err == nil {
+			conn.Close()
+		}
+	}))
+	defer srv.Close()
+
+	c := NewHTTPClient(srv.URL, srv.Client())
+	err := c.do(context.Background(), http.MethodPut,
+		"/config/apps/http/servers/cobalt/routes/0", map[string]any{"@id": "x"}, nil)
+	if err == nil {
+		t.Fatal("expected a transport error")
+	}
+	if got := attempts.Load(); got != 1 {
+		t.Errorf("positional PUT attempted %d times, want exactly 1", got)
 	}
 }

--- a/internal/server/caddy/load.go
+++ b/internal/server/caddy/load.go
@@ -1,0 +1,115 @@
+package caddy
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"net/http"
+)
+
+// applyCobaltRoutes performs a read-modify-write of the `cobalt` HTTP
+// server's routes slice: GET the full live config from /config/, hand the
+// slice to mutate, and POST the merged document back via /load — Caddy's
+// atomic full-config swap (no-op when unchanged, rolled back on a failed
+// apply). Unlike the positional `PUT .../routes/0` this replaces, the load
+// can't half-apply and re-running it converges instead of duplicating.
+//
+// Only the objects on the path down to the routes slice are decoded; every
+// sibling — the admin and logging blocks, other apps, and any route mutate
+// leaves in place (the `cobalt-redirect-*` routes owned by the API domain
+// handlers, the daemon host route) — is carried as raw bytes and survives
+// the round-trip byte-for-byte. This is deliberately NOT a from-scratch
+// serialization of desired state: blocks cobalt doesn't own are never
+// rebuilt, so they can never be clobbered.
+//
+// adminMu is held across the whole read-modify-write so no other cobalt
+// writer can interleave between the GET and the /load.
+func (c *Client) applyCobaltRoutes(ctx context.Context, mutate func(routes []json.RawMessage) ([]json.RawMessage, error)) error {
+	c.adminMu.Lock()
+	defer c.adminMu.Unlock()
+
+	var full map[string]json.RawMessage
+	if err := c.doLocked(ctx, http.MethodGet, "/config/", nil, &full); err != nil {
+		return fmt.Errorf("caddy: read full config: %w", err)
+	}
+	apps, err := rawObject(full, "apps")
+	if err != nil {
+		return err
+	}
+	httpApp, err := rawObject(apps, "http")
+	if err != nil {
+		return err
+	}
+	servers, err := rawObject(httpApp, "servers")
+	if err != nil {
+		return err
+	}
+	cobaltSrv, err := rawObject(servers, "cobalt")
+	if err != nil {
+		return err
+	}
+	var routes []json.RawMessage
+	if raw, ok := cobaltSrv["routes"]; ok {
+		if err := json.Unmarshal(raw, &routes); err != nil {
+			return fmt.Errorf("caddy: decode cobalt routes: %w", err)
+		}
+	}
+
+	mutated, err := mutate(routes)
+	if err != nil {
+		return err
+	}
+
+	// Re-encode only the objects we opened on the way down; their sibling
+	// keys are still raw bytes and marshal back unchanged.
+	for _, step := range []struct {
+		parent map[string]json.RawMessage
+		key    string
+		child  any
+	}{
+		{cobaltSrv, "routes", mutated},
+		{servers, "cobalt", cobaltSrv},
+		{httpApp, "servers", servers},
+		{apps, "http", httpApp},
+		{full, "apps", apps},
+	} {
+		raw, err := json.Marshal(step.child)
+		if err != nil {
+			return fmt.Errorf("caddy: re-encode %q: %w", step.key, err)
+		}
+		step.parent[step.key] = raw
+	}
+
+	if err := c.doLocked(ctx, http.MethodPost, "/load", full, nil); err != nil {
+		return fmt.Errorf("caddy: load full config: %w", err)
+	}
+	return nil
+}
+
+// rawObject decodes obj[key] as a JSON object whose values stay raw. A
+// missing key or non-object value is an error: the bootstrap config
+// (WriteInitConfig) always writes the blocks on the path to the cobalt
+// server, so their absence means this Caddy isn't running a cobalt config —
+// failing loudly beats inventing structure over live state we don't own.
+func rawObject(obj map[string]json.RawMessage, key string) (map[string]json.RawMessage, error) {
+	raw, ok := obj[key]
+	if !ok {
+		return nil, fmt.Errorf("caddy: full config has no %q block", key)
+	}
+	var child map[string]json.RawMessage
+	if err := json.Unmarshal(raw, &child); err != nil {
+		return nil, fmt.Errorf("caddy: decode %q block: %w", key, err)
+	}
+	return child, nil
+}
+
+// routeID returns the @id of a raw route object, or "" when it has none.
+func routeID(raw json.RawMessage) string {
+	var doc struct {
+		ID string `json:"@id"`
+	}
+	if err := json.Unmarshal(raw, &doc); err != nil {
+		return ""
+	}
+	return doc.ID
+}

--- a/internal/server/caddy/load_test.go
+++ b/internal/server/caddy/load_test.go
@@ -1,0 +1,211 @@
+package caddy
+
+import (
+	"context"
+	"encoding/json"
+	"io"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"sync"
+	"testing"
+)
+
+// Blocks of a live Caddy config the read-modify-write apply must never
+// rebuild. Each carries deliberately NON-alphabetical interior key order:
+// if the apply ever decoded one into a Go map and re-marshaled it, the keys
+// would come back sorted and the byte-for-byte assertions below would fail.
+const (
+	rtAdminBlock    = `{"listen":"unix//cobalt/caddy-socket/caddy.sock","origins":["cobalt-caddy"],"enforce_origin":false}`
+	rtLoggingBlock  = `{"logs":{"default":{"encoder":{"wrap":{"format":"json"},"format":"filter"}}}}`
+	rtTLSApp        = `{"automation":{"policies":[{"subjects":["blue.app","www.example.com"]}]}}`
+	rtRedirectRoute = `{"@id":"cobalt-redirect-5","match":[{"host":["www.example.com"]}],"handle":[{"handler":"subroute","routes":[{"handle":[{"handler":"static_response","status_code":301,"headers":{"Location":["https://example.com{http.request.uri}"]}}]}]}],"terminal":true}`
+	rtProjectRoute  = `{"@id":"cobalt-project-2","match":[{"@id":"cobalt-project-hosts-2","host":["blue.app"]}],"handle":[{"handler":"subroute","routes":[{"handle":[{"@id":"cobalt-project-handler-2","handler":"reverse_proxy","upstreams":[{"dial":"next-114-web:80"}]}]}]}],"terminal":true}`
+	rtDaemonRoute   = `{"@id":"cobalt-daemon-host","match":[{"host":["cobalt.blue.cc"]}],"handle":[{"handler":"subroute","routes":[{"handle":[{"@id":"cobalt-daemon-handler","handler":"reverse_proxy","upstreams":[{"dial":"cobalt:80"}]}]}]}],"terminal":true}`
+)
+
+// rtLiveConfig assembles the live document. The levels the apply traverses
+// (top level, apps, http, servers, cobalt) are written in Go's map-marshal
+// (alphabetical) key order, so an untouched round trip must reproduce the
+// document byte-for-byte.
+const rtLiveConfig = `{"admin":` + rtAdminBlock +
+	`,"apps":{"http":{"servers":{"cobalt":{"listen":[":80"],"logs":{},"protocols":["h1","h2"],"routes":[` +
+	rtRedirectRoute + `,` + rtProjectRoute + `,` + rtDaemonRoute +
+	`]}}},"tls":` + rtTLSApp + `},"logging":` + rtLoggingBlock + `}`
+
+// loadCapturingCaddy fakes only the two endpoints the read-modify-write
+// apply touches: GET /config/ serves a fixed document, POST /load captures
+// what the client sends back.
+type loadCapturingCaddy struct {
+	mu     sync.Mutex
+	loads  [][]byte
+	server *httptest.Server
+}
+
+func newLoadCapturingCaddy(t *testing.T, config string) *loadCapturingCaddy {
+	t.Helper()
+	f := &loadCapturingCaddy{}
+	f.server = httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		switch {
+		case r.Method == http.MethodGet && r.URL.Path == "/config/":
+			w.Write([]byte(config))
+		case r.Method == http.MethodPost && r.URL.Path == "/load":
+			body, _ := io.ReadAll(r.Body)
+			f.mu.Lock()
+			f.loads = append(f.loads, body)
+			f.mu.Unlock()
+			w.WriteHeader(http.StatusOK)
+		default:
+			t.Errorf("unexpected admin call: %s %s", r.Method, r.URL.Path)
+			http.NotFound(w, r)
+		}
+	}))
+	t.Cleanup(f.server.Close)
+	return f
+}
+
+func (f *loadCapturingCaddy) lastLoad(t *testing.T) string {
+	t.Helper()
+	f.mu.Lock()
+	defer f.mu.Unlock()
+	if len(f.loads) == 0 {
+		t.Fatal("no /load call captured")
+	}
+	return string(f.loads[len(f.loads)-1])
+}
+
+func (f *loadCapturingCaddy) loadCount() int {
+	f.mu.Lock()
+	defer f.mu.Unlock()
+	return len(f.loads)
+}
+
+func TestApplyCobaltRoutes_NoOpRoundTrip(t *testing.T) {
+	t.Parallel()
+	f := newLoadCapturingCaddy(t, rtLiveConfig)
+	c := NewHTTPClient(f.server.URL, f.server.Client())
+
+	err := c.applyCobaltRoutes(context.Background(), func(routes []json.RawMessage) ([]json.RawMessage, error) {
+		return routes, nil
+	})
+	if err != nil {
+		t.Fatalf("applyCobaltRoutes: %v", err)
+	}
+	posted := f.lastLoad(t)
+
+	// Pinpoint first: every block cobalt doesn't own must survive the
+	// modify step byte-for-byte.
+	for name, block := range map[string]string{
+		"admin":          rtAdminBlock,
+		"logging":        rtLoggingBlock,
+		"tls app":        rtTLSApp,
+		"redirect route": rtRedirectRoute,
+		"daemon route":   rtDaemonRoute,
+		"project route":  rtProjectRoute,
+	} {
+		if !strings.Contains(posted, block) {
+			t.Errorf("%s block not preserved byte-for-byte\nwant substring: %s\nposted: %s", name, block, posted)
+		}
+	}
+	// And the untouched round trip reproduces the whole document exactly.
+	if posted != rtLiveConfig {
+		t.Errorf("no-op round trip altered the config\n got: %s\nwant: %s", posted, rtLiveConfig)
+	}
+}
+
+func TestAddProjectRoute_TouchesOnlyOwnedRoutes(t *testing.T) {
+	t.Parallel()
+	f := newLoadCapturingCaddy(t, rtLiveConfig)
+	c := NewHTTPClient(f.server.URL, f.server.Client())
+
+	if err := c.AddProjectRoute(context.Background(), 7, []string{"seven.example"}); err != nil {
+		t.Fatalf("AddProjectRoute: %v", err)
+	}
+	posted := f.lastLoad(t)
+
+	// The pre-existing routes and non-route blocks pass through untouched,
+	// keeping their relative order.
+	idxRedirect := strings.Index(posted, rtRedirectRoute)
+	idxProject := strings.Index(posted, rtProjectRoute)
+	idxDaemon := strings.Index(posted, rtDaemonRoute)
+	if idxRedirect < 0 || idxProject < 0 || idxDaemon < 0 {
+		t.Fatalf("an existing route was altered (redirect=%d project=%d daemon=%d)\nposted: %s",
+			idxRedirect, idxProject, idxDaemon, posted)
+	}
+	if !(idxRedirect < idxProject && idxProject < idxDaemon) {
+		t.Errorf("existing route order changed (redirect=%d project=%d daemon=%d)",
+			idxRedirect, idxProject, idxDaemon)
+	}
+	for name, block := range map[string]string{
+		"admin":   rtAdminBlock,
+		"logging": rtLoggingBlock,
+		"tls app": rtTLSApp,
+	} {
+		if !strings.Contains(posted, block) {
+			t.Errorf("%s block not preserved byte-for-byte: %s", name, posted)
+		}
+	}
+	// The new route is prepended ahead of every existing route.
+	idxNew := strings.Index(posted, `"@id":"cobalt-project-7"`)
+	if idxNew < 0 {
+		t.Fatalf("new project route missing: %s", posted)
+	}
+	if idxNew > idxRedirect {
+		t.Errorf("new route not prepended (new=%d redirect=%d)", idxNew, idxRedirect)
+	}
+	if !strings.Contains(posted, `"seven.example"`) {
+		t.Errorf("new route missing its domain: %s", posted)
+	}
+}
+
+func TestAddProjectRoute_ReplacesExistingRoute(t *testing.T) {
+	t.Parallel()
+	f := newLoadCapturingCaddy(t, rtLiveConfig)
+	c := NewHTTPClient(f.server.URL, f.server.Client())
+
+	// Project 2 already has a route in the live config; re-adding must
+	// replace it, never leave two routes claiming the same @id.
+	if err := c.AddProjectRoute(context.Background(), 2, []string{"replacement.example"}); err != nil {
+		t.Fatalf("AddProjectRoute: %v", err)
+	}
+	posted := f.lastLoad(t)
+
+	if n := strings.Count(posted, `"@id":"cobalt-project-2",`); n != 1 {
+		t.Errorf("want exactly 1 route with the project @id, got %d\nposted: %s", n, posted)
+	}
+	if strings.Contains(posted, rtProjectRoute) {
+		t.Errorf("stale project route survived the replace: %s", posted)
+	}
+	if !strings.Contains(posted, `"replacement.example"`) {
+		t.Errorf("replacement route missing its domain: %s", posted)
+	}
+	for name, block := range map[string]string{
+		"redirect route": rtRedirectRoute,
+		"daemon route":   rtDaemonRoute,
+	} {
+		if !strings.Contains(posted, block) {
+			t.Errorf("%s not preserved byte-for-byte: %s", name, posted)
+		}
+	}
+}
+
+func TestApplyCobaltRoutes_UnrecognizedConfigFailsLoud(t *testing.T) {
+	t.Parallel()
+	// A Caddy without the cobalt server block isn't running our bootstrap
+	// config; the apply must refuse to invent structure (and must not POST).
+	f := newLoadCapturingCaddy(t, `{"admin":{},"apps":{"http":{"servers":{}}}}`)
+	c := NewHTTPClient(f.server.URL, f.server.Client())
+
+	err := c.applyCobaltRoutes(context.Background(), func(routes []json.RawMessage) ([]json.RawMessage, error) {
+		return routes, nil
+	})
+	if err == nil {
+		t.Fatal("expected an error for a config without the cobalt server")
+	}
+	if !strings.Contains(err.Error(), `"cobalt"`) {
+		t.Errorf("error should name the missing block: %v", err)
+	}
+	if n := f.loadCount(); n != 0 {
+		t.Errorf("apply must not POST /load on an unrecognized config, got %d loads", n)
+	}
+}

--- a/internal/server/caddy/routes.go
+++ b/internal/server/caddy/routes.go
@@ -2,6 +2,7 @@ package caddy
 
 import (
 	"context"
+	"encoding/json"
 	"fmt"
 	"net/http"
 )
@@ -34,8 +35,12 @@ func (c *Client) SetDomainsForProject(ctx context.Context, projectID int64, doma
 // domain matchers and the placeholder upstream. The deploy flow later calls
 // ServeService to swap in the real container.
 //
-// Caddy's admin API treats /config/.../routes/0 as "prepend to the routes
-// slice" — this is how every disco-style daemon adds new routes today.
+// Applied as a read-modify-write of the full config (applyCobaltRoutes)
+// rather than Caddy's positional `PUT .../routes/0`. The positional PUT is
+// a *prepend*, not a replace: re-running it — or re-sending a call that
+// timed out after Caddy had already applied it — inserts a duplicate route.
+// The atomic /load path drops any existing route carrying this project's
+// @id before inserting the new one, so the call is idempotent.
 func (c *Client) AddProjectRoute(ctx context.Context, projectID int64, domains []string) error {
 	body := map[string]any{
 		"@id": ProjectRouteID(projectID),
@@ -72,7 +77,25 @@ func (c *Client) AddProjectRoute(ctx context.Context, projectID int64, domains [
 		},
 		"terminal": true,
 	}
-	return c.do(ctx, http.MethodPut, "/config/apps/http/servers/cobalt/routes/0", body, nil)
+	raw, err := json.Marshal(body)
+	if err != nil {
+		return fmt.Errorf("caddy: marshal project route: %w", err)
+	}
+	id := ProjectRouteID(projectID)
+	return c.applyCobaltRoutes(ctx, func(routes []json.RawMessage) ([]json.RawMessage, error) {
+		// Prepend, matching the old routes/0 semantics (project routes sit
+		// ahead of the daemon-host route). Every route is host-matched and
+		// terminal, so relative order across distinct hosts doesn't change
+		// matching.
+		out := make([]json.RawMessage, 0, len(routes)+1)
+		out = append(out, raw)
+		for _, r := range routes {
+			if routeID(r) != id {
+				out = append(out, r)
+			}
+		}
+		return out, nil
+	})
 }
 
 // RemoveProjectRoute deletes the entire project route by its @id.

--- a/internal/server/server.go
+++ b/internal/server/server.go
@@ -293,8 +293,17 @@ func registerScheduledJobs(
 	})
 	dataPlaneProber := deploy.CaddyDataPlaneProber{Prober: dockerCli}
 	_ = sched.Schedule("caddy-reconcile", "@every 30s", func(ctx context.Context) {
-		if _, err := worker.ReconcileCaddyState(ctx, log, db, caddyCli, dataPlaneProber, dockerCli); err != nil {
+		corrections, err := worker.ReconcileCaddyState(ctx, log, db, caddyCli, dataPlaneProber, dockerCli)
+		if err != nil {
 			log.Warn("caddy reconcile failed", "error", err)
+			return
+		}
+		if corrections > 0 {
+			// A steady-state pass corrects nothing, so any nonzero count
+			// means Caddy's live state had drifted from the deployed truth.
+			// Keep this WARN stable and greppable — the 2026-06-02 upstream
+			// divergence ran 82 minutes with zero cobalt-side signal.
+			log.Warn("caddy reconcile corrected drift", "corrections", corrections)
 		}
 	})
 	caddyWatchdog := worker.NewCaddyWatchdog(caddyCli, dockerCli, worker.DefaultCaddyServiceName, log)


### PR DESCRIPTION
## Context

Closes out sections 4C2 and 4C3 of the Caddy upstream hardening plan (`blue/plans/cobalt-caddy-upstream-hardening.md`); A, B, and C1 shipped earlier.

Two related hazards in the admin apply path:

1. **Positional route PUT is an insert, not a replace.** `AddProjectRoute` wrote `PUT /config/.../routes/0`, which *prepends* to the routes slice. Re-running it — or the retry layer re-sending a call that timed out after Caddy had already applied it (`MethodPut` was blanket-retried in `retryableMethods`) — inserts a duplicate route.
2. **A "compute desired config from scratch" fix would be worse.** The single `cobalt` server block also holds routes cobalt's project reconciler does *not* own: the `cobalt-redirect-*` routes (reconciled out of band by the API domain handlers), the daemon host route, and the admin/logging blocks. A from-scratch `POST /load` derivation that missed any of them would clobber live state on every apply. That audit (plan §4C, audit note 2) is why the chosen strategy is **read-modify-write**: GET the full live config, edit only the cobalt-owned route, and POST the whole merged document back.

## Changes

- **`caddy/load.go` (new)** — `applyCobaltRoutes`: GET `/config/`, hand the `cobalt` server's routes slice to a mutate callback, `POST /load` the merged document (atomic swap; Caddy no-ops when unchanged and rolls back a failed apply). Only the objects on the path down to the routes slice are decoded — every sibling block and every route the mutation leaves alone is carried as `json.RawMessage` and survives byte-for-byte. Refuses (fails loud, no POST) if the live config has no cobalt server block. Held under `adminMu` across the whole read-modify-write.
- **`caddy/routes.go`** — `AddProjectRoute` now goes through `applyCobaltRoutes`: it drops any existing route with the project's `@id` before prepending the new one, so it is idempotent and can never duplicate. This is the single route-slice writer used by both the deploy apply (`SetDomainsForProject` → new-project case) and the reconciler's route-missing recreate — one way to mutate the routes slice. `@id`-keyed PATCH/DELETE/GET helpers are unchanged.
- **`caddy/client.go`** — retry classification is now method **+ path**: PUT is retried only against `/id/`-keyed paths; a positional route PUT surfaces its error instead of being replayed (the timed-out-but-applied replay is exactly the duplicate-route case). GET/PATCH/DELETE retry as before; POST (`/load`) stays non-retried per existing semantics. This also covers the redirect path's positional PUT, which keeps its current mechanism.
- **`server.go`** — the caddy-reconcile scheduler no longer discards the corrections count: `corrections > 0` logs a stable, greppable `WARN caddy reconcile corrected drift corrections=N` (the 2026-06-02 incident produced zero cobalt-side signal for 82 minutes); reconcile failure keeps its existing WARN. No metrics, no new dependencies.

## Verification

All run from the worktree root:

- `go build ./...` — pass
- `go vet ./...` — pass
- `go vet -tags integration ./...` — pass (build-tagged integration tests still compile)
- `go test ./...` — all 20 packages pass
- `go test -race ./internal/server/caddy/ ./internal/server/worker/ ./internal/server/deploy/ ./internal/server/` — pass

New tests (all in `internal/server/caddy`):

- `TestApplyCobaltRoutes_NoOpRoundTrip` — GET → identity-mutate → POST `/load` reproduces the document **byte-for-byte**; the admin block, logging block, tls app, redirect route, and daemon route are written with deliberately non-alphabetical key order, so any accidental decode/re-encode of a non-owned block would reorder keys and fail.
- `TestAddProjectRoute_TouchesOnlyOwnedRoutes` — adding a route leaves every pre-existing route and non-route block byte-identical and in order; the new route is prepended.
- `TestAddProjectRoute_ReplacesExistingRoute` — re-adding a project's route replaces it (exactly one route with that `@id`), never duplicates.
- `TestApplyCobaltRoutes_UnrecognizedConfigFailsLoud` — no cobalt server block → error, and no `/load` is posted.
- `TestRetryClassification` — `@id`-keyed PUT retryable; positional-index PUT not; GET retryable; POST `/load` not.
- `TestPositionalPutNotRetriedOnTransportError` — a positional PUT hitting a transport-level failure is attempted exactly once.

## Deploy notes

- At runtime, the only wire-level change on the happy path is how a project route is **created**: one `GET /config/` + one `POST /load` instead of one positional PUT. Route creation happens on first deploy of a project or when the reconciler recreates a missing route — both rare. Cutovers, domain updates, and removals keep their existing single `@id`-keyed PATCH/DELETE calls.
- `/load` is atomic: it cannot half-apply, and Caddy rolls back to the previous config if the new one fails to provision. If the daemon dies between the GET and the POST, nothing was applied and the 30s caddy-reconcile pass recreates the missing/drifted route on its next cycle — the apply path is self-healing by construction.
- Positional PUTs (project-route path removed; redirect path retained) are no longer silently retried; a transient admin failure there now surfaces to the caller, and the out-of-band redirect sync re-converges on its next pass.

Part of the plans gap-closing sweep.