### PR TITLE
fix(deploy): self-heal missing Caddy route during swap-commit

### DIFF
--- a/internal/server/deploy/swap.go
+++ b/internal/server/deploy/swap.go
@@ -5,6 +5,7 @@ import (
 	"fmt"
 	"log/slog"
 
+	"github.com/heyblueteam/cobalt/internal/server/caddy"
 	"github.com/heyblueteam/cobalt/internal/server/cobaltfile"
 	"github.com/heyblueteam/cobalt/internal/server/docker"
 	"github.com/heyblueteam/cobalt/internal/server/store"
@@ -20,6 +21,7 @@ type SwapCaddy interface {
 	VerifyServeService(ctx context.Context, projectID int64, container string, port, deploymentNumber int) error
 	ServeStaticSite(ctx context.Context, projectID int64, projectName string, deploymentNumber int) error
 	ServeService(ctx context.Context, projectID int64, container string, port, deploymentNumber int) error
+	AddProjectRoute(ctx context.Context, projectID int64, domains []string) error
 }
 
 // SwapStore is the store subset swap-step helpers need.
@@ -48,6 +50,21 @@ type SwapStore interface {
 //     file_server. (Static-site verification is best-effort: we just
 //     verify the route exists; we don't deeply check the file_server
 //     config.)
+//
+// Route recovery: SetDomainsForProject above confirms/creates the route
+// once, up front — but Caddy can lose the entire route (and every @id
+// inside it, including the handler the switch below PATCHes) *after* that
+// check and *before* the PATCH: the admin-API watchdog self-heals an
+// unresponsive Caddy by restarting it, which boots from an empty bootstrap
+// config until the next caddy-reconcile tick repopulates routes, and the
+// reconciler explicitly stands down for a project with an in-flight deploy
+// (this one) — so nothing else will recreate it. Root-caused from the
+// 2026-07-20 blue.app incident: deploy 388's handler PATCH landed 4.3s after
+// Caddy rebooted, seconds before the next reconcile tick, which skipped
+// project 1 anyway because this deploy was "active". If the handler PATCH
+// 404s with "unknown object ID", that's indistinguishable from "the route
+// vanished out from under us" — recreate it once via the same idempotent
+// AddProjectRoute the reconciler uses, then retry exactly once.
 func commitCaddySwap(
 	ctx context.Context,
 	cy SwapCaddy,
@@ -73,17 +90,42 @@ func commitCaddySwap(
 	case cobaltfile.TypeContainer:
 		container := docker.ServiceName(project.Name, dep.Number, "web")
 		port := web.Port
-		if err := cy.VerifyServeService(ctx, project.ID, container, port, dep.Number); err != nil {
+		err := cy.VerifyServeService(ctx, project.ID, container, port, dep.Number)
+		if caddy.IsNotFound(err) {
+			err = recreateRouteThenRetry(ctx, cy, project.ID, domains, func() error {
+				return cy.VerifyServeService(ctx, project.ID, container, port, dep.Number)
+			})
+		}
+		if err != nil {
 			return fmt.Errorf("deploy.commitCaddySwap: %w", err)
 		}
 	case cobaltfile.TypeStatic, cobaltfile.TypeGenerator:
-		if err := cy.ServeStaticSite(ctx, project.ID, project.Name, dep.Number); err != nil {
+		err := cy.ServeStaticSite(ctx, project.ID, project.Name, dep.Number)
+		if caddy.IsNotFound(err) {
+			err = recreateRouteThenRetry(ctx, cy, project.ID, domains, func() error {
+				return cy.ServeStaticSite(ctx, project.ID, project.Name, dep.Number)
+			})
+		}
+		if err != nil {
 			return fmt.Errorf("deploy.commitCaddySwap: serve static: %w", err)
 		}
 	default:
 		return fmt.Errorf("deploy.commitCaddySwap: unsupported web type %q", web.Type)
 	}
 	return nil
+}
+
+// recreateRouteThenRetry recreates a project's Caddy route (AddProjectRoute
+// is idempotent — safe even if the route turns out to still exist, e.g. a
+// 404 from something other than route-loss) and runs op again. Used when a
+// handler PATCH 404s with "unknown object ID", which happens when Caddy's
+// admin-API watchdog restarts Caddy between commitCaddySwap's earlier route
+// check and this PATCH — see commitCaddySwap's doc comment.
+func recreateRouteThenRetry(ctx context.Context, cy SwapCaddy, projectID int64, domains []string, op func() error) error {
+	if err := cy.AddProjectRoute(ctx, projectID, domains); err != nil {
+		return fmt.Errorf("recreate route after missing handler: %w", err)
+	}
+	return op()
 }
 
 // revertCaddySwap is the Phase 2 failure path. It looks up the last

--- a/internal/server/deploy/swap_test.go
+++ b/internal/server/deploy/swap_test.go
@@ -9,9 +9,14 @@ import (
 	"sync"
 	"testing"
 
+	"github.com/heyblueteam/cobalt/internal/server/caddy"
 	"github.com/heyblueteam/cobalt/internal/server/cobaltfile"
 	"github.com/heyblueteam/cobalt/internal/server/store"
 )
+
+// notFoundErr mirrors what caddy.Client returns for a 404 — the exact shape
+// commitCaddySwap's caddy.IsNotFound check keys on.
+var notFoundErr = &caddy.HTTPError{Status: 404, Body: "unknown object ID 'cobalt-project-handler-7'"}
 
 // fakeSwapCaddy records every call so swap tests can assert exact
 // dispatch (container path vs static-site path vs no-op).
@@ -22,10 +27,19 @@ type fakeSwapCaddy struct {
 	verifyCalls     []verifyCall
 	serveSvcCalls   []serveSvcCall
 	staticCalls     []staticCall
+	addRouteCalls   []addRouteCall
 	setDomainsErr   error
-	verifyErr       error
 	serveSvcErr     error
-	staticErr       error
+	addRouteErr     error
+
+	// verifyErrs/staticErrs are consumed one per call, in order — lets a
+	// test script "404 on the first attempt, succeed on the retry" (the
+	// missing-route self-heal path). A single static error can still be
+	// set via verifyErr/staticErr, returned once the slice is exhausted.
+	verifyErrs []error
+	verifyErr  error
+	staticErrs []error
+	staticErr  error
 }
 
 type verifyCall struct {
@@ -45,6 +59,10 @@ type staticCall struct {
 	projectName      string
 	deploymentNumber int
 }
+type addRouteCall struct {
+	projectID int64
+	domains   []string
+}
 
 func (f *fakeSwapCaddy) SetDomainsForProject(_ context.Context, projectID int64, domains []string) error {
 	f.mu.Lock()
@@ -58,6 +76,9 @@ func (f *fakeSwapCaddy) VerifyServeService(_ context.Context, projectID int64, c
 	f.mu.Lock()
 	defer f.mu.Unlock()
 	f.verifyCalls = append(f.verifyCalls, verifyCall{projectID, container, port, deploymentNumber})
+	if n := len(f.verifyCalls) - 1; n < len(f.verifyErrs) {
+		return f.verifyErrs[n]
+	}
 	return f.verifyErr
 }
 
@@ -72,7 +93,17 @@ func (f *fakeSwapCaddy) ServeStaticSite(_ context.Context, projectID int64, proj
 	f.mu.Lock()
 	defer f.mu.Unlock()
 	f.staticCalls = append(f.staticCalls, staticCall{projectID, projectName, deploymentNumber})
+	if n := len(f.staticCalls) - 1; n < len(f.staticErrs) {
+		return f.staticErrs[n]
+	}
 	return f.staticErr
+}
+
+func (f *fakeSwapCaddy) AddProjectRoute(_ context.Context, projectID int64, domains []string) error {
+	f.mu.Lock()
+	defer f.mu.Unlock()
+	f.addRouteCalls = append(f.addRouteCalls, addRouteCall{projectID, domains})
+	return f.addRouteErr
 }
 
 type fakeSwapStore struct {
@@ -239,6 +270,97 @@ func TestCommitCaddySwap_VerifyErrorPropagates(t *testing.T) {
 	err := commitCaddySwap(context.Background(), cy, st, project, dep, cf)
 	if err == nil || !strings.Contains(err.Error(), "upstream not reflected") {
 		t.Errorf("expected verify error, got %v", err)
+	}
+}
+
+func TestCommitCaddySwap_ContainerRouteRecreatedOnMissingHandler(t *testing.T) {
+	t.Parallel()
+	// Reproduces the 2026-07-20 incident: Caddy's admin-API watchdog
+	// restarts Caddy between SetDomainsForProject's route check and this
+	// PATCH, so the handler @id the PATCH targets no longer exists. The
+	// swap must self-heal — recreate the route, retry once, succeed —
+	// rather than fail and revert the deploy.
+	cy := &fakeSwapCaddy{verifyErrs: []error{notFoundErr, nil}}
+	st := &fakeSwapStore{primaryDomains: []string{"api.example.com", "alt.example.com"}}
+	project, dep := newSwapFixtures()
+	cf := &cobaltfile.Cobaltfile{Services: map[string]cobaltfile.Service{
+		"web": {Type: cobaltfile.TypeContainer, Port: 3000},
+	}}
+	if err := commitCaddySwap(context.Background(), cy, st, project, dep, cf); err != nil {
+		t.Fatalf("commitCaddySwap: %v", err)
+	}
+	if len(cy.addRouteCalls) != 1 {
+		t.Fatalf("AddProjectRoute calls: %d, want 1", len(cy.addRouteCalls))
+	}
+	if got := cy.addRouteCalls[0]; got.projectID != 7 || len(got.domains) != 2 {
+		t.Errorf("AddProjectRoute args: %+v", got)
+	}
+	if len(cy.verifyCalls) != 2 {
+		t.Fatalf("VerifyServeService calls: %d, want 2 (original + retry)", len(cy.verifyCalls))
+	}
+}
+
+func TestCommitCaddySwap_StaticRouteRecreatedOnMissingHandler(t *testing.T) {
+	t.Parallel()
+	cy := &fakeSwapCaddy{staticErrs: []error{notFoundErr, nil}}
+	st := &fakeSwapStore{primaryDomains: []string{"site.example.com"}}
+	project, dep := newSwapFixtures()
+	cf := &cobaltfile.Cobaltfile{Services: map[string]cobaltfile.Service{
+		"web": {Type: cobaltfile.TypeStatic, PublicPath: "dist"},
+	}}
+	if err := commitCaddySwap(context.Background(), cy, st, project, dep, cf); err != nil {
+		t.Fatalf("commitCaddySwap: %v", err)
+	}
+	if len(cy.addRouteCalls) != 1 {
+		t.Fatalf("AddProjectRoute calls: %d, want 1", len(cy.addRouteCalls))
+	}
+	if len(cy.staticCalls) != 2 {
+		t.Fatalf("ServeStaticSite calls: %d, want 2 (original + retry)", len(cy.staticCalls))
+	}
+}
+
+func TestCommitCaddySwap_RouteRecreateFailurePropagates(t *testing.T) {
+	t.Parallel()
+	cy := &fakeSwapCaddy{
+		verifyErrs:  []error{notFoundErr},
+		addRouteErr: errors.New("caddy still unreachable"),
+	}
+	st := &fakeSwapStore{primaryDomains: []string{"x.example.com"}}
+	project, dep := newSwapFixtures()
+	cf := &cobaltfile.Cobaltfile{Services: map[string]cobaltfile.Service{
+		"web": {Type: cobaltfile.TypeContainer, Port: 3000},
+	}}
+	err := commitCaddySwap(context.Background(), cy, st, project, dep, cf)
+	if err == nil || !strings.Contains(err.Error(), "caddy still unreachable") {
+		t.Errorf("expected recreate-route error to propagate, got %v", err)
+	}
+	// Must not retry the PATCH if recreating the route itself failed —
+	// there's nothing to point it at.
+	if len(cy.verifyCalls) != 1 {
+		t.Errorf("VerifyServeService calls: %d, want 1 (no retry after failed recreate)", len(cy.verifyCalls))
+	}
+}
+
+func TestCommitCaddySwap_PersistentMissingHandlerFailsAfterOneRetry(t *testing.T) {
+	t.Parallel()
+	// The retry is a single attempt, not a loop — a Caddy that's still
+	// missing the route after recreation (or wedged some other way) must
+	// still fail the deploy rather than retry forever.
+	cy := &fakeSwapCaddy{verifyErrs: []error{notFoundErr, notFoundErr}}
+	st := &fakeSwapStore{primaryDomains: []string{"x.example.com"}}
+	project, dep := newSwapFixtures()
+	cf := &cobaltfile.Cobaltfile{Services: map[string]cobaltfile.Service{
+		"web": {Type: cobaltfile.TypeContainer, Port: 3000},
+	}}
+	err := commitCaddySwap(context.Background(), cy, st, project, dep, cf)
+	if err == nil || !strings.Contains(err.Error(), "unknown object ID") {
+		t.Errorf("expected persistent not-found error to propagate, got %v", err)
+	}
+	if len(cy.verifyCalls) != 2 {
+		t.Errorf("VerifyServeService calls: %d, want exactly 2", len(cy.verifyCalls))
+	}
+	if len(cy.addRouteCalls) != 1 {
+		t.Errorf("AddProjectRoute calls: %d, want exactly 1 (one recreate attempt, not a loop)", len(cy.addRouteCalls))
 	}
 }
 


### PR DESCRIPTION
## Context

Root-caused from the 2026-07-20 blue.app outage (see `blue` repo incident writeup — happy to paste the full timeline if useful). blue.app returned Cloudflare 525 for several minutes, and an unrelated `api` deploy (#388) failed with:

```
caddy: status 404: {"error":"unknown object ID 'cobalt-project-handler-1'"}
```

## Root cause

`commitCaddySwap` checks/creates the project's Caddy route **once**, up front, via `SetDomainsForProject` — then unconditionally PATCHes the handler `@id` moments later in `VerifyServeService` (container) or `ServeStaticSite` (static/generator). If Caddy loses that route in between, the PATCH 404s with "unknown object ID", the deploy reverts, and fails — even though nothing about the deployment itself is broken.

The concrete trigger: cobalt's own `caddy-watchdog` self-heals an unresponsive Caddy by restarting the service. A fresh Caddy boots from the empty bootstrap Caddyfile with **zero site routes** until the next `caddy-reconcile` tick repopulates them. The reconciler, in turn, explicitly stands down for any project with an in-flight deploy — "a deploy owns its Caddy state end-to-end" — which is the right call normally, but wrong in this specific case: the deploy's own PATCH now has nothing to patch.

Exact timeline from the incident (Loki, millisecond precision):

- `07:36:56.015` — watchdog: 3 consecutive admin-probe failures → restarts `cobalt_caddy`
- `07:37:12.974` — fresh Caddy admin endpoint comes up (empty config)
- `07:37:17.277` — deployment #388's handler PATCH → **404** (4.3s after Caddy came back, before this project's own reconcile check ever runs)
- `07:37:17.278` — the very next reconcile tick fires — but skips project 1 (`api`) and project 2 (`next`), both mid-deploy at that instant; it repairs 5 *other* projects that weren't

Same restart is why blue.app itself 525'd: `next`'s deploy had already swapped successfully before the restart, so it didn't retry, but the route stayed gone until that project's deploy finished and reconcile caught up — several minutes later.

The watchdog restart itself was triggered by unrelated host resource pressure (a pre-existing over-enqueue bug in a downstream product flooding the DB — not a cobalt issue), but the *window* it creates is a real cobalt gap independent of what caused it: any Caddy restart while a deploy is mid-swap can hit this.

## Fix

On "unknown object ID" from the handler PATCH, treat it as route-loss and self-heal: recreate the route via the same idempotent `AddProjectRoute` the reconciler already uses, then retry the PATCH exactly once (not a loop). Applies symmetrically to both the container (`VerifyServeService`) and static/generator (`ServeStaticSite`) paths.

`AddProjectRoute` is idempotent (per #38), so this is safe even if the 404 turns out to be something other than genuine route-loss.

## Tests

New tests in `internal/server/deploy/swap_test.go`:

- `TestCommitCaddySwap_ContainerRouteRecreatedOnMissingHandler` — 404 on first PATCH → route recreated → retry succeeds
- `TestCommitCaddySwap_StaticRouteRecreatedOnMissingHandler` — same for the static/generator path
- `TestCommitCaddySwap_RouteRecreateFailurePropagates` — if the recreate itself fails, that error propagates and the PATCH is *not* retried
- `TestCommitCaddySwap_PersistentMissingHandlerFailsAfterOneRetry` — confirms this is one retry, not a loop; a still-missing route after recreation still fails the deploy
- Existing `TestCommitCaddySwap_VerifyErrorPropagates` / `_StaticErrorPropagates` confirm non-404 errors are untouched (no spurious retry)

```
go build ./...          # pass
go vet ./...             # pass
go test ./...             # all packages pass
go test -race ./internal/server/deploy/... ./internal/server/caddy/... ./internal/server/worker/... ./internal/server/...   # pass
```

## Deploy notes

Happy path is unchanged — this only adds a fallback branch that fires on a 404 that today just fails the deploy outright. No new dependencies, no config changes.