### PR TITLE
🐛 fix: send project SNI in Caddy probe

### DIFF
--- a/internal/server/deploy/dataplane.go
+++ b/internal/server/deploy/dataplane.go
@@ -3,9 +3,12 @@ package deploy
 import (
 	"bytes"
 	"context"
+	"crypto/tls"
 	"fmt"
 	"io"
 	"log/slog"
+	"net"
+	"net/http"
 	"strconv"
 	"strings"
 	"time"
@@ -34,12 +37,17 @@ type dataPlaneResult struct {
 // dataPlaneProbeTimeout bounds a single scheme's probe (plaintext or TLS).
 const dataPlaneProbeTimeout = 5 * time.Second
 
-// probeDataPlane issues a real HTTP request through Caddy's own listener from
-// inside the cobalt-caddy container, with Host set to the project's domain,
-// and reports the X-Cobalt-Deployment header the running router emits plus the
-// HTTP status. This is the only ground truth for "which deployment does the
-// compiled router actually serve" — every admin-API read reflects the config
-// tree, which can diverge from the running router.
+// caddyHTTPSAddress is Caddy's service address on the cobalt stack network.
+// Dialing it directly keeps the probe off the public DNS/Cloudflare path while
+// the request URL supplies the project domain for both HTTP Host and TLS SNI.
+const caddyHTTPSAddress = "caddy:443"
+
+// probeDataPlane issues a real HTTP request through Caddy's own listener, with
+// Host set to the project's domain, and reports the X-Cobalt-Deployment header
+// the running router emits plus the HTTP status. This is the only ground truth
+// for "which deployment does the compiled router actually serve" — every
+// admin-API read reflects the config tree, which can diverge from the running
+// router.
 //
 // It auto-detects cobalt's two topologies so the daemon needn't know its own
 // mode:
@@ -57,6 +65,10 @@ const dataPlaneProbeTimeout = 5 * time.Second
 // Returns an error only when neither scheme yields an HTTP response (Caddy
 // unreachable). Any HTTP answer — even a 502 — is a successful probe.
 func probeDataPlane(ctx context.Context, p ReadinessProber, domain string) (dataPlaneResult, error) {
+	return probeDataPlaneAt(ctx, p, domain, caddyHTTPSAddress)
+}
+
+func probeDataPlaneAt(ctx context.Context, p ReadinessProber, domain, httpsAddress string) (dataPlaneResult, error) {
 	if !isProbableHostname(domain) {
 		return dataPlaneResult{}, fmt.Errorf("data-plane probe: refusing to probe implausible host %q", domain)
 	}
@@ -68,7 +80,7 @@ func probeDataPlane(ctx context.Context, p ReadinessProber, domain string) (data
 		return res, nil
 	}
 	// 2) https :443 — the standalone topology.
-	if res, ok := probeHTTPS(ctx, p, container, domain); ok {
+	if res, ok := probeHTTPS(ctx, domain, httpsAddress); ok {
 		return res, nil
 	}
 	return dataPlaneResult{}, fmt.Errorf(
@@ -91,8 +103,8 @@ func probePlaintext(ctx context.Context, p ReadinessProber, container, domain st
 		domain,
 	)
 	var stdout bytes.Buffer
-	// nc exits non-zero on connection refused; we decide on parsed output, not
-	// exit code (mirrors the busybox-exit-code caveat on the wget path).
+	// nc exits non-zero on connection refused; decide on parsed output rather
+	// than its exit code.
 	_ = p.Exec(probeCtx, container, []string{"sh", "-c", script}, &stdout, io.Discard)
 
 	res, parsed := parseHTTPHead(stdout.String())
@@ -108,29 +120,52 @@ func probePlaintext(ctx context.Context, p ReadinessProber, container, domain st
 	return res, true
 }
 
-// probeHTTPS probes Caddy's :443 listener with busybox wget over TLS. wget -S
-// writes the response head to stderr; we parse there. Note busybox wget exits
-// non-zero on any 4xx/5xx even when a header is present, so we never gate on
-// the exit code — only on whether a status line was parsed.
-func probeHTTPS(ctx context.Context, p ReadinessProber, container, domain string) (dataPlaneResult, bool) {
+// probeHTTPS probes Caddy's :443 listener directly from the daemon. The
+// transport dials Caddy's private service address while retaining the project
+// domain as the request host and TLS SNI. Using https://localhost here would
+// make Caddy reject the handshake before it could return an HTTP response.
+func probeHTTPS(ctx context.Context, domain, address string) (dataPlaneResult, bool) {
 	probeCtx, cancel := context.WithTimeout(ctx, dataPlaneProbeTimeout)
 	defer cancel()
-	cmd := []string{
-		"wget", "-S", "-O", "/dev/null", "-T", "4",
-		"--no-check-certificate",
-		"--header", "Host: " + domain,
-		"https://localhost/",
+
+	dialer := &net.Dialer{}
+	transport := &http.Transport{
+		DialContext: func(ctx context.Context, network, _ string) (net.Conn, error) {
+			return dialer.DialContext(ctx, network, address)
+		},
+		TLSClientConfig: &tls.Config{
+			ServerName:         domain,
+			InsecureSkipVerify: true, //nolint:gosec // Same trust model as the former wget --no-check-certificate probe.
+		},
+		DisableKeepAlives: true,
 	}
-	var stderr bytes.Buffer
-	_ = p.Exec(probeCtx, container, cmd, io.Discard, &stderr)
-	return parseHTTPHead(stderr.String())
+	defer transport.CloseIdleConnections()
+	client := &http.Client{
+		Transport: transport,
+		CheckRedirect: func(_ *http.Request, _ []*http.Request) error {
+			return http.ErrUseLastResponse
+		},
+	}
+	req, err := http.NewRequestWithContext(probeCtx, http.MethodGet, "https://"+domain+"/", nil)
+	if err != nil {
+		return dataPlaneResult{}, false
+	}
+	req.Host = domain
+	req.Close = true
+	resp, err := client.Do(req)
+	if err != nil {
+		return dataPlaneResult{}, false
+	}
+	defer resp.Body.Close()
+	return dataPlaneResult{
+		Served: resp.Header.Get(caddy.DeploymentHeader),
+		Status: resp.StatusCode,
+	}, true
 }
 
-// parseHTTPHead scans raw response text (an nc body or busybox `wget -S`
-// stderr) for the first HTTP status line and the X-Cobalt-Deployment header,
-// stopping at the first blank line (end of headers). Each line is left-trimmed
-// so it copes with wget's leading-space indentation. parsed is false when no
-// HTTP status line is present.
+// parseHTTPHead scans a raw plaintext response for the first HTTP status line
+// and the X-Cobalt-Deployment header, stopping at the first blank line (end of
+// headers). parsed is false when no HTTP status line is present.
 func parseHTTPHead(raw string) (res dataPlaneResult, parsed bool) {
 	for _, rawLine := range strings.Split(raw, "\n") {
 		line := strings.TrimSpace(rawLine)

--- a/internal/server/deploy/dataplane_test.go
+++ b/internal/server/deploy/dataplane_test.go
@@ -5,6 +5,8 @@ import (
 	"errors"
 	"io"
 	"log/slog"
+	"net/http"
+	"net/http/httptest"
 	"strings"
 	"testing"
 	"time"
@@ -33,8 +35,7 @@ func TestParseHTTPHead(t *testing.T) {
 			wantParsed: true, wantStatus: 502, wantServed: "",
 		},
 		{
-			// busybox `wget -S` indents each response-head line with spaces.
-			name:       "wget -S indented output",
+			name:       "indented response lines",
 			raw:        "Connecting to localhost:443\n  HTTP/1.1 200 OK\n  Server: Caddy\n  X-Cobalt-Deployment: 207\n\n",
 			wantParsed: true, wantStatus: 200, wantServed: "207",
 		},
@@ -100,10 +101,8 @@ func TestIsProbableHostname(t *testing.T) {
 	}
 }
 
-// fakeDataPlaneProber stands in for *docker.Client in waitDataPlaneServing tests. It
-// answers the :80 plaintext path (cmd[0]=="sh") with a canned HTTP response;
-// the :443 wget fallback always "fails to connect" so tests exercise the
-// plaintext branch deterministically.
+// fakeDataPlaneProber stands in for *docker.Client in waitDataPlaneServing
+// tests. It answers the :80 plaintext path with a canned HTTP response.
 type fakeDataPlaneProber struct {
 	plaintextResp string // written to stdout for the nc path; "" + err => :80 closed
 	plaintextErr  error
@@ -120,7 +119,7 @@ func (f *fakeDataPlaneProber) Exec(_ context.Context, _ string, cmd []string, st
 		}
 		return f.plaintextErr
 	}
-	return errors.New("wget: can't connect to remote host") // :443 closed
+	return errors.New("unexpected exec command")
 }
 
 type fakeDomainLister struct {
@@ -184,8 +183,8 @@ func TestWaitDataPlaneServing(t *testing.T) {
 			wantErr: true, errSubstr: "never converged",
 		},
 		{
-			name:   "probe infra broken (caddy unreachable) → soft pass",
-			prober: &fakeDataPlaneProber{plaintextErr: errors.New("nc failed")},
+			name:   "probe inconclusive (no deployment header) → soft pass",
+			prober: &fakeDataPlaneProber{plaintextResp: resp("200 OK", "")},
 			cf:     container, domains: []string{"api.example.com"},
 		},
 		{
@@ -216,5 +215,39 @@ func TestWaitDataPlaneServing(t *testing.T) {
 				t.Fatalf("want nil, got %v", err)
 			}
 		})
+	}
+}
+
+func TestProbeDataPlaneHTTPSFallbackUsesProjectDomainForHostAndSNI(t *testing.T) {
+	t.Parallel()
+	type observation struct {
+		host string
+		sni  string
+	}
+	observed := make(chan observation, 1)
+	server := httptest.NewTLSServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		observed <- observation{host: r.Host, sni: r.TLS.ServerName}
+		w.Header().Set("X-Cobalt-Deployment", "403")
+		w.WriteHeader(http.StatusNoContent)
+	}))
+	defer server.Close()
+
+	address := strings.TrimPrefix(server.URL, "https://")
+	prober := &fakeDataPlaneProber{
+		plaintextResp: resp("308 Permanent Redirect", ""),
+	}
+	result, err := probeDataPlaneAt(context.Background(), prober, "api.blue.app", address)
+	if err != nil {
+		t.Fatalf("probeDataPlaneAt: %v", err)
+	}
+	if result.Status != http.StatusNoContent || result.Served != "403" {
+		t.Fatalf("result = %+v, want status 204 served 403", result)
+	}
+	got := <-observed
+	if got.host != "api.blue.app" {
+		t.Errorf("Host = %q, want api.blue.app", got.host)
+	}
+	if got.sni != "api.blue.app" {
+		t.Errorf("SNI = %q, want api.blue.app", got.sni)
 	}
 }


### PR DESCRIPTION
## Summary

- replace the BusyBox `wget https://localhost` fallback with an in-process Go HTTPS probe
- dial Caddy over its private service address while sending the project domain as both TLS SNI and HTTP Host
- preserve the existing timeout, redirect, and certificate-verification behavior
- stop creating unreaped `ssl_client` helper processes in the Caddy container

## Root cause

The standalone probe reached port 80, received Caddy's HTTPS redirect, then connected to `https://localhost/`. Overriding the HTTP Host header did not change TLS SNI, so Caddy rejected SNI `localhost` before returning an HTTP response. Reconciliation therefore classified every probe as inconclusive and could never enter the confirmed-only superseded-service reaper.

## Proof

- the regression test drives the real port-80 redirect branch into the TLS fallback and asserts the project domain is received as both Host and SNI
- the existing reconciler tests prove a matching deployment header past the grace floor reaps older web generations
- direct probes over the production Cobalt-to-Caddy network returned the current deployment header for each affected project when the project domain was used as SNI

## Verification

- `make test`
- `go test -race ./internal/server/deploy ./internal/server/worker -count=1`
- `go test ./internal/server/deploy -run TestProbeDataPlaneHTTPSFallbackUsesProjectDomainForHostAndSNI -count=100`
- `go vet ./...`
- `golangci-lint run ./internal/server/deploy/...`