### PR TITLE
fix(caddy): run caddy with init:true so it reaps probe ssl_client zombies

### DIFF
--- a/cmd/cobalt/assets/init-docker-compose.yml
+++ b/cmd/cobalt/assets/init-docker-compose.yml
@@ -50,6 +50,10 @@ services:
 
   caddy:
     image: caddy:2.7.6
+    # tini as PID 1 reaps the ssl_client helpers busybox wget forks during the
+    # data-plane probe (dataplane.go); caddy itself never wait()s them, so
+    # without this they pile up as defunct zombies (~24k/day in prod).
+    init: true
     volumes:
       - caddy-data:/data
       - caddy-config:/config

--- a/deploy/compose/docker-compose.yml
+++ b/deploy/compose/docker-compose.yml
@@ -75,6 +75,10 @@ services:
   # Admin API runs over a unix socket shared with the cobalt container.
   caddy-ssl:
     image: caddy:${CADDY_VERSION:-2.7.6}
+    # tini as PID 1 reaps the ssl_client helpers busybox wget forks during the
+    # data-plane probe (dataplane.go); caddy itself never wait()s them, so
+    # without this they pile up as defunct zombies (~24k/day in prod).
+    init: true
     volumes:
       - caddy-data:/data
       - caddy-config:/config


### PR DESCRIPTION
## Problem

`cobalt_caddy` accumulates **defunct `ssl_client` zombies** — ~24k/day in prod (24,076 observed under the caddy process).

**Root cause:** the data-plane probe (`internal/server/deploy/dataplane.go` → `probeHTTPS`) execs busybox `wget -S --no-check-certificate` (HTTPS) into the caddy container to read `X-Cobalt-Deployment`. busybox `wget` over TLS forks an `ssl_client` helper; when `wget` exits, `ssl_client` reparents to the container's **PID 1 = caddy**, which isn't an init and never `wait()`s it → zombie. One probe per project per 30s reconcile ≈ one every ~2s ≈ the observed leak rate.

(The recent SNI/self-heal probe fixes — #39/#40 — made the probe *correct*; they didn't touch this side effect.)

## Fix

`init: true` on the caddy service in both stack files (`cmd/cobalt/assets/init-docker-compose.yml`, `deploy/compose/docker-compose.yml`). `docker stack deploy` honors it (maps to swarm `ContainerSpec.Init`) → tini becomes PID 1, caddy a child, and reparented `ssl_client` helpers get reaped instantly. Fixes any zombie in the container, not just this probe.

## Notes

- **Not urgent** — `pid_max` is 4M, so the current zombies are harmless; this stops unbounded growth and cleans up caddy's process table.
- **Applies on the next caddy (re)deploy** — recreating `cobalt_caddy` is a brief ingress blip, so do it deliberately. Existing zombies clear when the container is recreated.

https://claude.ai/code/session_01BY3aNz6fXhiAA5wbebpijv