### PR TITLE
Add stable public web services

### DIFF
--- a/internal/server/api/projects.go
+++ b/internal/server/api/projects.go
@@ -200,6 +200,19 @@ func (h *Handler) DeleteProject(w http.ResponseWriter, r *http.Request) {
 		writeError(w, http.StatusInternalServerError, "internal error")
 		return
 	}
+	if h.Caddy != nil {
+		if err := h.Caddy.RemoveProjectRoute(r.Context(), p.ID); err != nil {
+			h.Log.Warn("api: delete project: remove caddy route", "project_id", p.ID, "error", err)
+		}
+	}
+	// Stable public web has no deployment number, so generation cleanup cannot
+	// discover it after this project's rows are gone. A missing service is a
+	// no-op, and the captured project ID remains valid after the DB delete.
+	if h.Docker != nil {
+		if err := h.Docker.RemoveService(r.Context(), docker.StablePublicWebServiceName(p.ID)); err != nil {
+			h.Log.Warn("api: delete project: remove stable public web", "project_id", p.ID, "error", err)
+		}
+	}
 	h.cleanupProjectArtifacts(r.Context(), *p)
 	w.WriteHeader(http.StatusNoContent)
 }

--- a/internal/server/cobaltfile/cobaltfile.go
+++ b/internal/server/cobaltfile/cobaltfile.go
@@ -46,10 +46,11 @@ const (
 
 // Cobaltfile is the parsed contents of cobalt.json.
 type Cobaltfile struct {
-	Version  string             `json:"version"`
-	Name     string             `json:"name,omitempty"`
-	Services map[string]Service `json:"services,omitempty"`
-	Images   map[string]Image   `json:"images,omitempty"`
+	Version         string             `json:"version"`
+	Name            string             `json:"name,omitempty"`
+	Services        map[string]Service `json:"services,omitempty"`
+	Images          map[string]Image   `json:"images,omitempty"`
+	StablePublicWeb bool               `json:"stablePublicWeb,omitempty"`
 }
 
 // ServiceType is one of a fixed set of service kinds.
@@ -118,6 +119,28 @@ type Image struct {
 type Volume struct {
 	Name            string `json:"name"`
 	DestinationPath string `json:"destinationPath"`
+}
+
+// UsesStablePublicWeb reports whether the project can use Cobalt's durable
+// public-web service. The stable service only joins cobalt-main, so projects
+// needing a deployment-scoped network stay on the existing generation route.
+// Keep this deliberately conservative until service dependencies are modeled
+// explicitly in cobalt.json.
+func (cf *Cobaltfile) UsesStablePublicWeb() bool {
+	if !cf.StablePublicWeb {
+		return false
+	}
+	web, ok := cf.Services["web"]
+	if !ok || web.Type != TypeContainer || web.ExposedInternally || web.StopFirst ||
+		len(web.PublishedPorts) != 0 || len(web.Volumes) != 0 || web.ExtraSwarmParams != "" {
+		return false
+	}
+	for name, service := range cf.Services {
+		if name != "web" && service.Type == TypeContainer {
+			return false
+		}
+	}
+	return true
 }
 
 // PublishedPort exposes a container port on the host network.

--- a/internal/server/cobaltfile/cobaltfile_test.go
+++ b/internal/server/cobaltfile/cobaltfile_test.go
@@ -25,6 +25,29 @@ func TestParse_Empty(t *testing.T) {
 	}
 }
 
+func TestUsesStablePublicWeb(t *testing.T) {
+	t.Parallel()
+	cases := []struct {
+		name string
+		cf   Cobaltfile
+		want bool
+	}{
+		{"eligible", Cobaltfile{StablePublicWeb: true, Services: map[string]Service{"web": {Type: TypeContainer}}}, true},
+		{"not opted in", Cobaltfile{Services: map[string]Service{"web": {Type: TypeContainer}}}, false},
+		{"published port", Cobaltfile{StablePublicWeb: true, Services: map[string]Service{"web": {Type: TypeContainer, PublishedPorts: []PublishedPort{{PublishedAs: 80, FromContainerPort: 8000}}}}}, false},
+		{"volume", Cobaltfile{StablePublicWeb: true, Services: map[string]Service{"web": {Type: TypeContainer, Volumes: []Volume{{Name: "data", DestinationPath: "/data"}}}}}, false},
+		{"extra swarm params", Cobaltfile{StablePublicWeb: true, Services: map[string]Service{"web": {Type: TypeContainer, ExtraSwarmParams: "--limit-cpu 1"}}}, false},
+		{"worker", Cobaltfile{StablePublicWeb: true, Services: map[string]Service{"web": {Type: TypeContainer}, "worker": {Type: TypeContainer}}}, false},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			if got := tc.cf.UsesStablePublicWeb(); got != tc.want {
+				t.Errorf("UsesStablePublicWeb() = %v, want %v", got, tc.want)
+			}
+		})
+	}
+}
+
 func TestParse_ContainerWithExtraSwarmParams(t *testing.T) {
 	t.Parallel()
 	src := `{

--- a/internal/server/deploy/cleanup.go
+++ b/internal/server/deploy/cleanup.go
@@ -37,6 +37,7 @@ func cleanupOldServices(
 	d CleanupDocker,
 	project store.Project,
 	dep store.Deployment,
+	stableWeb bool,
 	out io.Writer,
 ) {
 	services, err := d.ListServicesForProject(ctx, project.ID)
@@ -49,6 +50,13 @@ func cleanupOldServices(
 
 	var stale []string
 	for _, s := range services {
+		if s.Name == docker.StablePublicWebServiceName(project.ID) {
+			if stableWeb {
+				continue // durable Caddy upstream, managed separately from generations
+			}
+			stale = append(stale, s.Name) // explicit stable-mode revert
+			continue
+		}
 		if strings.HasPrefix(s.Name, currentPrefix) {
 			continue // current deployment — keep
 		}

--- a/internal/server/deploy/cleanup_test.go
+++ b/internal/server/deploy/cleanup_test.go
@@ -42,7 +42,7 @@ func TestCleanupOldServices_KeepsCurrentAndGraceWeb(t *testing.T) {
 		"api-5-web",    // older web — reap
 	)}
 	cleanupOldServices(context.Background(), quietLog(), d,
-		store.Project{ID: 1, Name: "api"}, store.Deployment{Number: 7}, io.Discard)
+		store.Project{ID: 1, Name: "api"}, store.Deployment{Number: 7}, false, io.Discard)
 
 	got := append([]string(nil), d.removed...)
 	sort.Strings(got)
@@ -61,7 +61,7 @@ func TestCleanupOldServices_FirstDeploy_NothingToReap(t *testing.T) {
 	t.Parallel()
 	d := &fakeCleanupDocker{services: svcs("api-1-web", "api-1-worker")}
 	cleanupOldServices(context.Background(), quietLog(), d,
-		store.Project{ID: 1, Name: "api"}, store.Deployment{Number: 1}, io.Discard)
+		store.Project{ID: 1, Name: "api"}, store.Deployment{Number: 1}, false, io.Discard)
 	if len(d.removed) != 0 {
 		t.Errorf("first deploy should reap nothing, removed %v", d.removed)
 	}
@@ -73,10 +73,25 @@ func TestCleanupOldServices_HyphenatedProjectName(t *testing.T) {
 		"my-app-7-web", "my-app-6-web", "my-app-5-web",
 	)}
 	cleanupOldServices(context.Background(), quietLog(), d,
-		store.Project{ID: 1, Name: "my-app"}, store.Deployment{Number: 7}, io.Discard)
+		store.Project{ID: 1, Name: "my-app"}, store.Deployment{Number: 7}, false, io.Discard)
 	// Keep current (7) + grace (6); reap only 5.
 	if len(d.removed) != 1 || d.removed[0] != "my-app-5-web" {
 		t.Errorf("removed %v, want [my-app-5-web]", d.removed)
+	}
+}
+
+func TestCleanupOldServices_KeepsStablePublicWebOnlyWhileEnabled(t *testing.T) {
+	t.Parallel()
+	d := &fakeCleanupDocker{services: svcs("cobalt-web-1", "api-7-web")}
+	project := store.Project{ID: 1, Name: "api"}
+	cleanupOldServices(context.Background(), quietLog(), d, project, store.Deployment{Number: 7}, true, io.Discard)
+	if len(d.removed) != 0 {
+		t.Errorf("stable mode removed %v", d.removed)
+	}
+
+	cleanupOldServices(context.Background(), quietLog(), d, project, store.Deployment{Number: 7}, false, io.Discard)
+	if len(d.removed) != 1 || d.removed[0] != "cobalt-web-1" {
+		t.Errorf("direct-mode revert removed %v, want [cobalt-web-1]", d.removed)
 	}
 }
 

--- a/internal/server/deploy/orchestrator.go
+++ b/internal/server/deploy/orchestrator.go
@@ -229,13 +229,14 @@ func (o *Orchestrator) cutover(
 		return err
 	}
 
-	startedServices, err := startServicesPhase(ctx, o.Docker, *project, dep, built, envVars, deploymentNetwork, out)
+	stableWeb := cf.UsesStablePublicWeb()
+	startedServices, err := startServicesPhase(ctx, o.Docker, *project, dep, built, envVars, deploymentNetwork, stableWeb, out)
 	if err != nil {
 		// Phase 1 failure: stop services we did start, no Caddy touch.
 		_ = stopServices(context.Background(), o.Docker, startedServices)
 		return err
 	}
-	if err := waitHealthyAll(ctx, o.Docker, *project, dep, built, out); err != nil {
+	if err := waitHealthyAll(ctx, o.Docker, *project, dep, built, stableWeb, out); err != nil {
 		_ = stopServices(context.Background(), o.Docker, startedServices)
 		return err
 	}
@@ -284,7 +285,7 @@ func (o *Orchestrator) cutover(
 	}
 
 	// POST-SUCCESS — clean up old services. Best effort.
-	cleanupOldServices(context.Background(), log, o.Docker, *project, dep, out)
+	cleanupOldServices(context.Background(), log, o.Docker, *project, dep, stableWeb, out)
 
 	// Cron reconciliation: register / update / remove project crons
 	// declared in the just-cut-over cobaltfile. Best effort; failure

--- a/internal/server/deploy/readiness.go
+++ b/internal/server/deploy/readiness.go
@@ -81,6 +81,9 @@ func waitHTTPReady(
 		port = cobaltfile.DefaultPort
 	}
 	serviceName := docker.ServiceName(project.Name, dep.Number, "web")
+	if cf.UsesStablePublicWeb() {
+		serviceName = docker.StablePublicWebServiceName(project.ID)
+	}
 
 	fmt.Fprintf(out, "🩺 probing %s:%d for readiness\n", serviceName, port)
 

--- a/internal/server/deploy/services.go
+++ b/internal/server/deploy/services.go
@@ -18,6 +18,7 @@ const HealthcheckTimeout = 5 * time.Minute
 // ServiceDocker is the docker subset the service phase uses.
 type ServiceDocker interface {
 	CreateService(ctx context.Context, opts docker.ServiceCreateOpts) error
+	ReconcileStableService(ctx context.Context, opts docker.ServiceCreateOpts) error
 	WaitForServiceHealthy(ctx context.Context, name string, replicas int, timeout time.Duration) error
 	RemoveService(ctx context.Context, name string) error
 	ListServicesForDeployment(ctx context.Context, projectID int64, deploymentNumber int) ([]docker.ServiceInfo, error)
@@ -39,11 +40,23 @@ func startServicesPhase(
 	built []BuiltService,
 	envVars map[string]string,
 	deploymentNetwork string,
+	stableWeb bool,
 	out io.Writer,
 ) ([]string, error) {
 	var started []string
 	for _, b := range built {
 		if !runsAsService(b.Service) {
+			continue
+		}
+		if stableWeb && b.Name == "web" {
+			fmt.Fprintf(out, "🚀 updating stable public web service\n")
+			opts := stablePublicWebServiceOpts(project, dep, b, envVars)
+			if err := d.ReconcileStableService(ctx, opts); err != nil {
+				return started, fmt.Errorf("deploy: reconcile stable public web: %w", err)
+			}
+			// A stable service may already serve the last successful deployment.
+			// Never add it to rollback cleanup, which would turn a failed update
+			// into an outage by deleting that known-good service.
 			continue
 		}
 		fmt.Fprintf(out, "🚀 starting service %s\n", b.Name)
@@ -64,11 +77,21 @@ func waitHealthyAll(
 	project store.Project,
 	dep store.Deployment,
 	built []BuiltService,
+	stableWeb bool,
 	out io.Writer,
 ) error {
 	first := true
 	for _, b := range built {
 		if !runsAsService(b.Service) {
+			continue
+		}
+		if stableWeb && b.Name == "web" {
+			name := docker.StablePublicWebServiceName(project.ID)
+			t0 := time.Now()
+			if err := d.WaitForServiceHealthy(ctx, name, replicaCount(b.Service), HealthcheckTimeout); err != nil {
+				return fmt.Errorf("deploy: wait healthy stable public web: %w", err)
+			}
+			fmt.Fprintf(out, "✅ stable public web healthy (%s)\n", time.Since(t0).Round(time.Second))
 			continue
 		}
 		if first {
@@ -177,6 +200,23 @@ func serviceCreateOpts(
 			DestinationPath: v.DestinationPath,
 		})
 	}
+	return opts
+}
+
+// stablePublicWebServiceOpts creates the one long-lived public web service.
+// It intentionally attaches only to cobalt-main: a deployment-specific
+// network would be deleted with the generation and would reintroduce the DNS
+// failure this service exists to prevent.
+func stablePublicWebServiceOpts(
+	project store.Project,
+	dep store.Deployment,
+	b BuiltService,
+	envVars map[string]string,
+) docker.ServiceCreateOpts {
+	opts := serviceCreateOpts(project, dep, b, envVars, "")
+	stableName := docker.StablePublicWebServiceName(project.ID)
+	opts.Name = stableName
+	opts.Networks = []docker.NetworkAttachment{{Name: MainNetworkName, Alias: stableName}}
 	return opts
 }
 

--- a/internal/server/deploy/services.go
+++ b/internal/server/deploy/services.go
@@ -20,6 +20,7 @@ type ServiceDocker interface {
 	CreateService(ctx context.Context, opts docker.ServiceCreateOpts) error
 	ReconcileStableService(ctx context.Context, opts docker.ServiceCreateOpts) error
 	WaitForServiceHealthy(ctx context.Context, name string, replicas int, timeout time.Duration) error
+	WaitForServiceDeploymentHealthy(ctx context.Context, name string, deploymentNumber, replicas int, timeout time.Duration) error
 	RemoveService(ctx context.Context, name string) error
 	ListServicesForDeployment(ctx context.Context, projectID int64, deploymentNumber int) ([]docker.ServiceInfo, error)
 	ListServicesForProject(ctx context.Context, projectID int64) ([]docker.ServiceInfo, error)
@@ -88,7 +89,7 @@ func waitHealthyAll(
 		if stableWeb && b.Name == "web" {
 			name := docker.StablePublicWebServiceName(project.ID)
 			t0 := time.Now()
-			if err := d.WaitForServiceHealthy(ctx, name, replicaCount(b.Service), HealthcheckTimeout); err != nil {
+			if err := d.WaitForServiceDeploymentHealthy(ctx, name, dep.Number, replicaCount(b.Service), HealthcheckTimeout); err != nil {
 				return fmt.Errorf("deploy: wait healthy stable public web: %w", err)
 			}
 			fmt.Fprintf(out, "✅ stable public web healthy (%s)\n", time.Since(t0).Round(time.Second))

--- a/internal/server/deploy/services_test.go
+++ b/internal/server/deploy/services_test.go
@@ -63,6 +63,11 @@ func (f *serviceDockerFake) WaitForServiceHealthy(_ context.Context, name string
 	return f.healthCheckErr
 }
 
+func (f *serviceDockerFake) WaitForServiceDeploymentHealthy(_ context.Context, name string, _ int, replicas int, timeout time.Duration) error {
+	f.healthChecks = append(f.healthChecks, healthCheckCall{name: name, replicas: replicas, timeout: timeout})
+	return f.healthCheckErr
+}
+
 func (f *serviceDockerFake) RemoveService(_ context.Context, name string) error {
 	f.removed = append(f.removed, name)
 	return f.removeErr

--- a/internal/server/deploy/services_test.go
+++ b/internal/server/deploy/services_test.go
@@ -13,6 +13,7 @@ import (
 
 type serviceDockerFake struct {
 	created        []docker.ServiceCreateOpts
+	stableCreated  []docker.ServiceCreateOpts
 	healthChecks   []healthCheckCall
 	removed        []string
 	services       []docker.ServiceInfo
@@ -31,6 +32,30 @@ type healthCheckCall struct {
 func (f *serviceDockerFake) CreateService(_ context.Context, opts docker.ServiceCreateOpts) error {
 	f.created = append(f.created, opts)
 	return f.createErr
+}
+
+func (f *serviceDockerFake) ReconcileStableService(_ context.Context, opts docker.ServiceCreateOpts) error {
+	f.stableCreated = append(f.stableCreated, opts)
+	return f.createErr
+}
+
+func TestStartServicesPhase_UsesStablePublicWeb(t *testing.T) {
+	t.Parallel()
+	d := &serviceDockerFake{}
+	project := store.Project{ID: 7, Name: "api"}
+	dep := store.Deployment{Number: 3}
+	built := []BuiltService{{Name: "web", Service: cobaltfile.Service{Type: cobaltfile.TypeContainer}, ImageTag: "api:3"}}
+	started, err := startServicesPhase(context.Background(), d, project, dep, built, nil, "cobalt-project-api-3", true, io.Discard)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(started) != 0 || len(d.created) != 0 || len(d.stableCreated) != 1 {
+		t.Fatalf("started=%v created=%v stable=%v", started, d.created, d.stableCreated)
+	}
+	got := d.stableCreated[0]
+	if got.Name != "cobalt-web-7" || len(got.Networks) != 1 || got.Networks[0].Name != MainNetworkName {
+		t.Errorf("stable opts = %+v", got)
+	}
 }
 
 func (f *serviceDockerFake) WaitForServiceHealthy(_ context.Context, name string, replicas int, timeout time.Duration) error {
@@ -233,7 +258,7 @@ func TestWaitHealthyAll_UsesMinReplicas(t *testing.T) {
 		},
 	}
 
-	if err := waitHealthyAll(context.Background(), d, project, dep, built, io.Discard); err != nil {
+	if err := waitHealthyAll(context.Background(), d, project, dep, built, false, io.Discard); err != nil {
 		t.Fatalf("waitHealthyAll: %v", err)
 	}
 	if len(d.healthChecks) != 1 {

--- a/internal/server/deploy/swap.go
+++ b/internal/server/deploy/swap.go
@@ -89,6 +89,9 @@ func commitCaddySwap(
 	switch web.Type {
 	case cobaltfile.TypeContainer:
 		container := docker.ServiceName(project.Name, dep.Number, "web")
+		if cf.UsesStablePublicWeb() {
+			container = docker.StablePublicWebServiceName(project.ID)
+		}
 		port := web.Port
 		err := cy.VerifyServeService(ctx, project.ID, container, port, dep.Number)
 		if caddy.IsNotFound(err) {
@@ -159,6 +162,9 @@ func revertCaddySwap(
 	switch web.Type {
 	case cobaltfile.TypeContainer:
 		container := docker.ServiceName(project.Name, prev.Number, "web")
+		if cf.UsesStablePublicWeb() {
+			container = docker.StablePublicWebServiceName(project.ID)
+		}
 		if err := cy.ServeService(ctx, project.ID, container, web.Port, prev.Number); err != nil {
 			log.Error("deploy.revertCaddySwap: container revert failed",
 				"project_id", project.ID, "want_upstream", container, "error", err)

--- a/internal/server/deploy/swap_test.go
+++ b/internal/server/deploy/swap_test.go
@@ -176,6 +176,23 @@ func TestCommitCaddySwap_ContainerHappyPath(t *testing.T) {
 	}
 }
 
+func TestCommitCaddySwap_StablePublicWebUsesProjectIDEndpoint(t *testing.T) {
+	t.Parallel()
+	cy := &fakeSwapCaddy{}
+	st := &fakeSwapStore{primaryDomains: []string{"api.example.com"}}
+	project, dep := newSwapFixtures()
+	cf := &cobaltfile.Cobaltfile{StablePublicWeb: true, Services: map[string]cobaltfile.Service{
+		"web": {Type: cobaltfile.TypeContainer, Image: "default", Port: 3000},
+	}}
+
+	if err := commitCaddySwap(context.Background(), cy, st, project, dep, cf); err != nil {
+		t.Fatalf("commitCaddySwap: %v", err)
+	}
+	if len(cy.verifyCalls) != 1 || cy.verifyCalls[0].container != "cobalt-web-7" {
+		t.Errorf("VerifyServeService calls = %+v, want stable cobalt-web-7 endpoint", cy.verifyCalls)
+	}
+}
+
 func TestCommitCaddySwap_StaticAndGeneratorRouteToStaticSite(t *testing.T) {
 	t.Parallel()
 	cases := []struct {

--- a/internal/server/docker/health.go
+++ b/internal/server/docker/health.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"encoding/json"
 	"fmt"
+	"strconv"
 	"strings"
 	"time"
 )
@@ -61,6 +62,43 @@ func (c *Client) WaitForServiceHealthy(ctx context.Context, name string, replica
 		}
 		if time.Now().After(deadline) {
 			return fmt.Errorf("waitHealthy %s: timeout after %s (healthy=%d running=%d)", name, timeout, healthy, running)
+		}
+		select {
+		case <-ctx.Done():
+			return ctx.Err()
+		case <-time.After(pollInterval):
+		}
+	}
+}
+
+// WaitForServiceDeploymentHealthy waits only for the running task containers
+// created by deploymentNumber. Stable services retain the previous revision
+// during a start-first update, so aggregate service health is insufficient.
+func (c *Client) WaitForServiceDeploymentHealthy(ctx context.Context, name string, deploymentNumber, replicas int, timeout time.Duration) error {
+	if replicas < 1 {
+		replicas = 1
+	}
+	deadline := time.Now().Add(timeout)
+	filter := LabelDeploymentNumber + "=" + strconv.Itoa(deploymentNumber)
+	const pollInterval = 3 * time.Second
+	for {
+		healths := c.containerHealthForService(ctx, name, filter)
+		if len(healths) >= replicas {
+			healthy, withHealth := 0, 0
+			for _, health := range healths {
+				if health != "" {
+					withHealth++
+				}
+				if health == "healthy" {
+					healthy++
+				}
+			}
+			if withHealth == 0 || healthy >= replicas {
+				return nil
+			}
+		}
+		if time.Now().After(deadline) {
+			return fmt.Errorf("waitHealthy %s deployment %d: timeout after %s", name, deploymentNumber, timeout)
 		}
 		select {
 		case <-ctx.Done():
@@ -145,13 +183,13 @@ func (c *Client) taskStatuses(ctx context.Context, serviceName string) ([]taskSt
 // container declared no HEALTHCHECK; missing entries (e.g. when the
 // inspect call fails) are simply skipped — the caller treats absence as
 // "no healthcheck declared" and falls back to task-state readiness.
-func (c *Client) containerHealthForService(ctx context.Context, serviceName string) []string {
-	out, err := c.output(
-		ctx,
-		"ps",
-		"--filter", "label=com.docker.swarm.service.name="+serviceName,
-		"--format", "{{.ID}}",
-	)
+func (c *Client) containerHealthForService(ctx context.Context, serviceName string, extraLabelFilters ...string) []string {
+	args := []string{"ps", "--filter", "label=com.docker.swarm.service.name=" + serviceName}
+	for _, filter := range extraLabelFilters {
+		args = append(args, "--filter", "label="+filter)
+	}
+	args = append(args, "--format", "{{.ID}}")
+	out, err := c.output(ctx, args...)
 	if err != nil {
 		return nil
 	}
@@ -159,11 +197,11 @@ func (c *Client) containerHealthForService(ctx context.Context, serviceName stri
 	if len(ids) == 0 {
 		return nil
 	}
-	args := append([]string{
+	inspectArgs := append([]string{
 		"inspect",
 		"--format", `{{if .State.Health}}{{.State.Health.Status}}{{end}}`,
 	}, ids...)
-	out2, err := c.output(ctx, args...)
+	out2, err := c.output(ctx, inspectArgs...)
 	if err != nil {
 		return nil
 	}

--- a/internal/server/docker/health_test.go
+++ b/internal/server/docker/health_test.go
@@ -24,6 +24,17 @@ func TestWaitForServiceHealthy_AllHealthy(t *testing.T) {
 	}
 }
 
+func TestWaitForServiceDeploymentHealthy_IgnoresPriorDeployment(t *testing.T) {
+	t.Parallel()
+	r := newFakeRunner()
+	r.answerStdout("ps --filter label=com.docker.swarm.service.name=cobalt-web-7 --filter label=cobalt.deployment.number=8", "new-task\n")
+	r.answerStdout("inspect --format", "healthy\n")
+	c := NewWithRunner(r)
+	if err := c.WaitForServiceDeploymentHealthy(context.Background(), "cobalt-web-7", 8, 1, 5*time.Second); err != nil {
+		t.Errorf("WaitForServiceDeploymentHealthy: %v", err)
+	}
+}
+
 func TestWaitForServiceHealthy_StartingTimesOut(t *testing.T) {
 	t.Parallel()
 	r := newFakeRunner()

--- a/internal/server/docker/names.go
+++ b/internal/server/docker/names.go
@@ -15,6 +15,14 @@ func ServiceName(projectName string, deploymentNumber int, serviceName string) s
 	return fmt.Sprintf("%s-%d-%s", projectName, deploymentNumber, serviceName)
 }
 
+// StablePublicWebServiceName is the durable Swarm service name for a
+// project's publicly-routed web process. It is deliberately keyed by the
+// immutable project ID rather than its display name or deployment number, so
+// Caddy never holds a DNS name that disappears during generation cleanup.
+func StablePublicWebServiceName(projectID int64) string {
+	return fmt.Sprintf("cobalt-web-%d", projectID)
+}
+
 // WebGeneration parses the deployment number out of a project's `web` service
 // name — the inverse of ServiceName(projectName, n, "web"). It returns
 // ok=false for names that don't belong to this project or aren't the `web`

--- a/internal/server/docker/names_test.go
+++ b/internal/server/docker/names_test.go
@@ -8,6 +8,7 @@ func TestNames(t *testing.T) {
 		got, want string
 	}{
 		{ServiceName("api", 7, "web"), "api-7-web"},
+		{StablePublicWebServiceName(42), "cobalt-web-42"},
 		{NetworkName("api", 7), "cobalt-project-api-7"},
 		{HookContainerName("api", "hook:deploy:start:before", 7), "api-hook-deploy-start-before.7"},
 		{RunContainerName("api", 42), "api-run.42"},

--- a/internal/server/docker/service.go
+++ b/internal/server/docker/service.go
@@ -185,9 +185,8 @@ func (c *Client) ReconcileStableService(ctx context.Context, opts ServiceCreateO
 			args = append(args, "--env-rm", k)
 		}
 	}
-	for _, n := range opts.Networks {
-		args = append(args, "--network-add", networkFlagValue(n))
-	}
+	// Stable public-web services always use their ID-based alias on cobalt-main.
+	// The attachment is created once and must not be added again on every update.
 	if opts.Replicas > 0 {
 		args = append(args, "--replicas", strconv.Itoa(opts.Replicas))
 	}

--- a/internal/server/docker/service.go
+++ b/internal/server/docker/service.go
@@ -2,6 +2,7 @@ package docker
 
 import (
 	"context"
+	"encoding/json"
 	"errors"
 	"fmt"
 	"strconv"
@@ -56,12 +57,15 @@ type ServiceCreateOpts struct {
 	HealthInterval    time.Duration       // defaults to 3 seconds
 	Volumes           []ServiceVolume
 	ExtraParams       []string // pre-split, e.g. via SplitParams(extraSwarmParams)
+	// Name overrides the deployment-numbered default. Stable public web
+	// services use an ID-based name so their Caddy upstream survives deploys.
+	Name string
 }
 
 // CreateService creates a swarm service with the cobalt label set, env
 // vars, networks, ports, optional healthcheck, and optional extra params.
 func (c *Client) CreateService(ctx context.Context, opts ServiceCreateOpts) error {
-	name := ServiceName(opts.ProjectName, opts.DeploymentNumber, opts.ServiceName)
+	name := serviceNameForOpts(opts)
 	args := []string{
 		"service", "create",
 		// --detach=true returns as soon as Swarm accepts the spec.
@@ -142,6 +146,87 @@ func (c *Client) CreateService(ctx context.Context, opts ServiceCreateOpts) erro
 	args = append(args, ShellSplit(opts.Command)...)
 
 	return c.run(ctx, args...)
+}
+
+// ReconcileStableService creates a stable public-web service on its first
+// deploy and updates it in place thereafter. Swarm's start-first update order
+// keeps the service VIP continuously resolvable while tasks roll over.
+func (c *Client) ReconcileStableService(ctx context.Context, opts ServiceCreateOpts) error {
+	if opts.Name == "" {
+		return errors.New("stable service requires an explicit name")
+	}
+	if err := c.run(ctx, "service", "inspect", opts.Name); err != nil {
+		if !isNotFound(err) {
+			return err
+		}
+		return c.CreateService(ctx, opts)
+	}
+	oldEnv, err := c.stableServiceEnvKeys(ctx, opts.Name)
+	if err != nil {
+		return err
+	}
+
+	args := []string{
+		"service", "update", "--detach=true",
+		"--update-order", "start-first",
+		"--update-parallelism", "1",
+		"--update-failure-action", "rollback",
+		"--update-monitor", "90s",
+		"--image", opts.Image,
+	}
+	for _, l := range serviceLabels(opts.ProjectID, opts.ProjectName, opts.ServiceName, opts.DeploymentNumber) {
+		args = append(args, "--label-add", l, "--container-label-add", l)
+	}
+	for _, k := range sortedKeys(opts.EnvVars) {
+		args = append(args, "--env-add", k+"="+opts.EnvVars[k])
+	}
+	for _, k := range oldEnv {
+		if _, wanted := opts.EnvVars[k]; !wanted {
+			args = append(args, "--env-rm", k)
+		}
+	}
+	for _, n := range opts.Networks {
+		args = append(args, "--network-add", networkFlagValue(n))
+	}
+	if opts.Replicas > 0 {
+		args = append(args, "--replicas", strconv.Itoa(opts.Replicas))
+	}
+	if opts.HealthCommand != "" {
+		args = append(args, "--health-cmd", opts.HealthCommand)
+	}
+	if opts.Command != "" {
+		args = append(args, "--args", opts.Command)
+	}
+	return c.run(ctx, append(args, opts.Name)...)
+}
+
+func (c *Client) stableServiceEnvKeys(ctx context.Context, name string) ([]string, error) {
+	out, err := c.output(ctx, "service", "inspect", "--format", "{{json .Spec.TaskTemplate.ContainerSpec.Env}}", name)
+	if err != nil {
+		return nil, err
+	}
+	if len(out) == 0 || string(out) == "null" {
+		return nil, nil
+	}
+	var env []string
+	if err := json.Unmarshal(out, &env); err != nil {
+		return nil, fmt.Errorf("inspect stable service env: %w", err)
+	}
+	keys := make([]string, 0, len(env))
+	for _, entry := range env {
+		if i := strings.IndexByte(entry, '='); i > 0 {
+			keys = append(keys, entry[:i])
+		}
+	}
+	sortStrings(keys)
+	return keys, nil
+}
+
+func serviceNameForOpts(opts ServiceCreateOpts) string {
+	if opts.Name != "" {
+		return opts.Name
+	}
+	return ServiceName(opts.ProjectName, opts.DeploymentNumber, opts.ServiceName)
 }
 
 // RemoveService removes a swarm service by name. Returns nil if the service

--- a/internal/server/docker/service.go
+++ b/internal/server/docker/service.go
@@ -172,6 +172,7 @@ func (c *Client) ReconcileStableService(ctx context.Context, opts ServiceCreateO
 		"--update-parallelism", "1",
 		"--update-failure-action", "rollback",
 		"--update-monitor", "90s",
+		"--rollback-order", "start-first",
 		"--image", opts.Image,
 	}
 	for _, l := range serviceLabels(opts.ProjectID, opts.ProjectName, opts.ServiceName, opts.DeploymentNumber) {

--- a/internal/server/docker/service_test.go
+++ b/internal/server/docker/service_test.go
@@ -150,10 +150,13 @@ func TestReconcileStableService_UpdatesStartFirst(t *testing.T) {
 		t.Fatalf("ReconcileStableService: %v", err)
 	}
 	args := r.lastCall().Args
-	for _, pair := range [][2]string{{"--update-order", "start-first"}, {"--update-failure-action", "rollback"}, {"--image", "api:4"}, {"--env-add", "PORT=3000"}, {"--network-add", "name=cobalt-main,alias=cobalt-web-7"}} {
+	for _, pair := range [][2]string{{"--update-order", "start-first"}, {"--update-failure-action", "rollback"}, {"--image", "api:4"}, {"--env-add", "PORT=3000"}} {
 		if !argSequence(args, pair[0], pair[1]) {
 			t.Errorf("missing %q %q in %v", pair[0], pair[1], args)
 		}
+	}
+	if argHas(args, "--network-add") {
+		t.Errorf("stable update must retain its existing network attachment: %v", args)
 	}
 }
 

--- a/internal/server/docker/service_test.go
+++ b/internal/server/docker/service_test.go
@@ -150,7 +150,7 @@ func TestReconcileStableService_UpdatesStartFirst(t *testing.T) {
 		t.Fatalf("ReconcileStableService: %v", err)
 	}
 	args := r.lastCall().Args
-	for _, pair := range [][2]string{{"--update-order", "start-first"}, {"--update-failure-action", "rollback"}, {"--image", "api:4"}, {"--env-add", "PORT=3000"}} {
+	for _, pair := range [][2]string{{"--update-order", "start-first"}, {"--update-failure-action", "rollback"}, {"--rollback-order", "start-first"}, {"--image", "api:4"}, {"--env-add", "PORT=3000"}} {
 		if !argSequence(args, pair[0], pair[1]) {
 			t.Errorf("missing %q %q in %v", pair[0], pair[1], args)
 		}

--- a/internal/server/docker/service_test.go
+++ b/internal/server/docker/service_test.go
@@ -120,6 +120,64 @@ func TestCreateService_DefaultsForHealth(t *testing.T) {
 	}
 }
 
+func TestReconcileStableService_CreatesMissingService(t *testing.T) {
+	t.Parallel()
+	r := newFakeRunner()
+	r.answerErr("service inspect cobalt-web-7", errors.New("no such service"))
+	c := NewWithRunner(r)
+	err := c.ReconcileStableService(context.Background(), ServiceCreateOpts{
+		ProjectID: 7, ProjectName: "api", ServiceName: "web", DeploymentNumber: 3,
+		Name: "cobalt-web-7", Image: "api:3", Networks: []NetworkAttachment{{Name: "cobalt-main", Alias: "cobalt-web-7"}},
+	})
+	if err != nil {
+		t.Fatalf("ReconcileStableService: %v", err)
+	}
+	if !argSequence(r.lastCall().Args, "--name", "cobalt-web-7") {
+		t.Errorf("create args = %v", r.lastCall().Args)
+	}
+}
+
+func TestReconcileStableService_UpdatesStartFirst(t *testing.T) {
+	t.Parallel()
+	r := newFakeRunner()
+	c := NewWithRunner(r)
+	err := c.ReconcileStableService(context.Background(), ServiceCreateOpts{
+		ProjectID: 7, ProjectName: "api", ServiceName: "web", DeploymentNumber: 4,
+		Name: "cobalt-web-7", Image: "api:4", EnvVars: map[string]string{"PORT": "3000"}, Replicas: 2,
+		Networks: []NetworkAttachment{{Name: "cobalt-main", Alias: "cobalt-web-7"}},
+	})
+	if err != nil {
+		t.Fatalf("ReconcileStableService: %v", err)
+	}
+	args := r.lastCall().Args
+	for _, pair := range [][2]string{{"--update-order", "start-first"}, {"--update-failure-action", "rollback"}, {"--image", "api:4"}, {"--env-add", "PORT=3000"}, {"--network-add", "name=cobalt-main,alias=cobalt-web-7"}} {
+		if !argSequence(args, pair[0], pair[1]) {
+			t.Errorf("missing %q %q in %v", pair[0], pair[1], args)
+		}
+	}
+}
+
+func TestReconcileStableService_RemovesDeletedEnvironment(t *testing.T) {
+	t.Parallel()
+	r := newFakeRunner()
+	r.answerStdout("service inspect --format", `["KEEP=old","REMOVE=old"]`)
+	c := NewWithRunner(r)
+	err := c.ReconcileStableService(context.Background(), ServiceCreateOpts{
+		ProjectID: 7, ProjectName: "api", ServiceName: "web", DeploymentNumber: 4,
+		Name: "cobalt-web-7", Image: "api:4", EnvVars: map[string]string{"KEEP": "new"},
+	})
+	if err != nil {
+		t.Fatalf("ReconcileStableService: %v", err)
+	}
+	args := r.lastCall().Args
+	if !argSequence(args, "--env-rm", "REMOVE") {
+		t.Errorf("deleted env was retained: %v", args)
+	}
+	if argSequence(args, "--env-rm", "KEEP") {
+		t.Errorf("desired env was removed: %v", args)
+	}
+}
+
 func TestCreateService_NoHealthFlag(t *testing.T) {
 	t.Parallel()
 	r := newFakeRunner()

--- a/internal/server/docker/stable_service_integration_test.go
+++ b/internal/server/docker/stable_service_integration_test.go
@@ -1,0 +1,60 @@
+//go:build integration
+
+package docker
+
+import (
+	"context"
+	"fmt"
+	"os/exec"
+	"testing"
+	"time"
+)
+
+// TestReconcileStableService_RealSwarm verifies the operational contract that
+// unit fakes cannot: one durable service name survives a start-first update.
+// It owns a temporary single-node Swarm and is therefore opt-in via the
+// integration build tag.
+func TestReconcileStableService_RealSwarm(t *testing.T) {
+	if testing.Short() {
+		t.Skip("integration test")
+	}
+	ctx, cancel := context.WithTimeout(context.Background(), 3*time.Minute)
+	defer cancel()
+
+	if err := exec.CommandContext(ctx, "docker", "swarm", "init").Run(); err != nil {
+		t.Skipf("docker swarm init failed: %v", err)
+	}
+	t.Cleanup(func() { _ = exec.Command("docker", "swarm", "leave", "--force").Run() })
+
+	id := time.Now().UnixNano()
+	name := StablePublicWebServiceName(id)
+	defer func() { _ = exec.Command("docker", "service", "rm", name).Run() }()
+
+	c := New()
+	opts := ServiceCreateOpts{
+		ProjectID: id, ProjectName: "stable-test", ServiceName: "web", DeploymentNumber: 1,
+		Name: name, Image: "nginx:1.27-alpine",
+	}
+	if err := c.ReconcileStableService(ctx, opts); err != nil {
+		t.Fatalf("create stable service: %v", err)
+	}
+	if err := c.WaitForServiceReady(ctx, name, 1, 2*time.Minute); err != nil {
+		t.Fatalf("wait initial service: %v", err)
+	}
+
+	opts.DeploymentNumber = 2
+	if err := c.ReconcileStableService(ctx, opts); err != nil {
+		t.Fatalf("update stable service: %v", err)
+	}
+	if err := c.WaitForServiceReady(ctx, name, 1, 2*time.Minute); err != nil {
+		t.Fatalf("wait updated service: %v", err)
+	}
+
+	out, err := exec.CommandContext(ctx, "docker", "service", "inspect", "--format", "{{.Spec.Name}}", name).Output()
+	if err != nil {
+		t.Fatalf("inspect stable service: %v", err)
+	}
+	if got := string(out); got != fmt.Sprintf("%s\n", name) {
+		t.Errorf("service name after update = %q, want %q", got, name+"\n")
+	}
+}

--- a/internal/server/worker/caddy_reconcile.go
+++ b/internal/server/worker/caddy_reconcile.go
@@ -200,7 +200,7 @@ func reconcileProject(
 		if err := cy.AddProjectRoute(ctx, p.ID, domains); err != nil {
 			return false, fmt.Errorf("recreate route: %w", err)
 		}
-		return reapplyHandler(ctx, cy, p, *live, web)
+		return reapplyHandler(ctx, cy, p, *live, web, cf.UsesStablePublicWeb())
 	}
 
 	// Domains may have drifted since last deploy — but only PATCH when they
@@ -222,6 +222,9 @@ func reconcileProject(
 	switch web.Type {
 	case cobaltfile.TypeContainer:
 		want := docker.ServiceName(p.Name, live.Number, "web")
+		if cf.UsesStablePublicWeb() {
+			want = docker.StablePublicWebServiceName(p.ID)
+		}
 		got, err := cy.CurrentUpstream(ctx, p.ID)
 		if err != nil {
 			return false, fmt.Errorf("read current upstream: %w", err)
@@ -241,7 +244,7 @@ func reconcileProject(
 		// (the silent post-cutover 502 divergence; the admin GET above can't
 		// see it). Probe the data plane and force-repair if the running router
 		// disagrees.
-		outcome, err := reconcileDataPlane(ctx, log, cy, dp, p, *live, web, domains[0])
+		outcome, err := reconcileDataPlane(ctx, log, cy, dp, p, *live, web, cf.UsesStablePublicWeb(), domains[0])
 		if err != nil {
 			return false, err
 		}
@@ -308,6 +311,7 @@ func reconcileDataPlane(
 	p store.Project,
 	live store.Deployment,
 	web cobaltfile.Service,
+	stableWeb bool,
 	domain string,
 ) (dataPlaneOutcome, error) {
 	if dp == nil {
@@ -333,6 +337,9 @@ func reconcileDataPlane(
 		"project_id", p.ID, "project", p.Name,
 		"want", want, "served", served, "status", status)
 	container := docker.ServiceName(p.Name, live.Number, "web")
+	if stableWeb {
+		container = docker.StablePublicWebServiceName(p.ID)
+	}
 	if err := cy.ServeService(ctx, p.ID, container, web.Port, live.Number); err != nil {
 		return dataPlaneUnknown, fmt.Errorf("repair upstream (data plane): %w", err)
 	}
@@ -403,10 +410,14 @@ func reapplyHandler(
 	p store.Project,
 	live store.Deployment,
 	web cobaltfile.Service,
+	stableWeb bool,
 ) (bool, error) {
 	switch web.Type {
 	case cobaltfile.TypeContainer:
 		container := docker.ServiceName(p.Name, live.Number, "web")
+		if stableWeb {
+			container = docker.StablePublicWebServiceName(p.ID)
+		}
 		if err := cy.ServeService(ctx, p.ID, container, web.Port, live.Number); err != nil {
 			return false, fmt.Errorf("reapply container: %w", err)
 		}


### PR DESCRIPTION
## Summary
- add an opt-in stable Swarm service for compatible public web projects
- keep Caddy on an ID-based upstream across deployments and reconcile it after route drift
- clean up stable services on direct-mode reversion and project deletion

## Validation
- go test ./...
- go test -race ./internal/server/cobaltfile ./internal/server/docker ./internal/server/deploy ./internal/server/worker
- go test -tags=integration ./internal/server/docker -run TestReconcileStableService_RealSwarm -count=1