### PR TITLE
fix(lint): satisfy staticcheck QF1001 in load_test route-order check

### DIFF
--- a/internal/server/caddy/load_test.go
+++ b/internal/server/caddy/load_test.go
@@ -132,7 +132,7 @@ func TestAddProjectRoute_TouchesOnlyOwnedRoutes(t *testing.T) {
 		t.Fatalf("an existing route was altered (redirect=%d project=%d daemon=%d)\nposted: %s",
 			idxRedirect, idxProject, idxDaemon, posted)
 	}
-	if !(idxRedirect < idxProject && idxProject < idxDaemon) {
+	if idxRedirect >= idxProject || idxProject >= idxDaemon {
 		t.Errorf("existing route order changed (redirect=%d project=%d daemon=%d)",
 			idxRedirect, idxProject, idxDaemon)
 	}


### PR DESCRIPTION
## Problem

`lint` fails on every branch with a single pre-existing staticcheck issue in a file none of the open PRs touch:

```
internal/server/caddy/load_test.go:135:5: QF1001: could apply De Morgan's law (staticcheck)
	if !(idxRedirect < idxProject && idxProject < idxDaemon) {
```

It is the only failing check on both open PRs (#42 and #43) — `test` passes on both — so neither can go green until this lands.

## Fix

Inverts the comparison in place: `!(a < b && b < c)` → `a >= b || b >= c`. Same condition, no behaviour change, test-only.

## Validation

- `go test ./internal/server/caddy/` → ok
- `golangci-lint run ./internal/server/caddy/...` → 0 issues