### PR TITLE
feat(stable-web): allow host aliases, and reconcile them on update

### DIFF
--- a/internal/server/cobaltfile/cobaltfile.go
+++ b/internal/server/cobaltfile/cobaltfile.go
@@ -20,6 +20,7 @@ import (
 	"encoding/json"
 	"fmt"
 	"os"
+	"strings"
 )
 
 // SupportedVersion is the only schema version cobaltfile understands today.
@@ -132,11 +133,38 @@ func (cf *Cobaltfile) UsesStablePublicWeb() bool {
 	}
 	web, ok := cf.Services["web"]
 	if !ok || web.Type != TypeContainer || web.ExposedInternally || web.StopFirst ||
-		len(web.PublishedPorts) != 0 || len(web.Volumes) != 0 || web.ExtraSwarmParams != "" {
+		len(web.PublishedPorts) != 0 || len(web.Volumes) != 0 ||
+		!stableSafeSwarmParams(web.ExtraSwarmParams) {
 		return false
 	}
 	for name, service := range cf.Services {
 		if name != "web" && service.Type == TypeContainer {
+			return false
+		}
+	}
+	return true
+}
+
+// stableSafeSwarmParams reports whether every extra swarm param is one the
+// stable service can carry without fighting the properties cobalt manages
+// itself. Only `--host` is allowed: it adds a /etc/hosts entry (the
+// host-gateway alias pattern) and touches nothing cobalt sets. Anything else
+// -- networks, ports, mounts, replicas, constraints -- either duplicates a
+// field the stable path already owns or pins the service to a
+// deployment-scoped resource, which is exactly what this service exists to
+// avoid. Widen this list only with a matching reconcile in
+// ReconcileStableService, or the param silently stops tracking cobalt.json.
+func stableSafeSwarmParams(extra string) bool {
+	params := strings.Fields(extra)
+	for i := 0; i < len(params); i++ {
+		switch {
+		case params[i] == "--host":
+			i++ // skip its value
+			if i >= len(params) {
+				return false
+			}
+		case strings.HasPrefix(params[i], "--host="):
+		default:
 			return false
 		}
 	}

--- a/internal/server/cobaltfile/cobaltfile_test.go
+++ b/internal/server/cobaltfile/cobaltfile_test.go
@@ -37,6 +37,12 @@ func TestUsesStablePublicWeb(t *testing.T) {
 		{"published port", Cobaltfile{StablePublicWeb: true, Services: map[string]Service{"web": {Type: TypeContainer, PublishedPorts: []PublishedPort{{PublishedAs: 80, FromContainerPort: 8000}}}}}, false},
 		{"volume", Cobaltfile{StablePublicWeb: true, Services: map[string]Service{"web": {Type: TypeContainer, Volumes: []Volume{{Name: "data", DestinationPath: "/data"}}}}}, false},
 		{"extra swarm params", Cobaltfile{StablePublicWeb: true, Services: map[string]Service{"web": {Type: TypeContainer, ExtraSwarmParams: "--limit-cpu 1"}}}, false},
+		{"host alias", Cobaltfile{StablePublicWeb: true, Services: map[string]Service{"web": {Type: TypeContainer, ExtraSwarmParams: "--host host.docker.internal:host-gateway"}}}, true},
+		{"host alias equals form", Cobaltfile{StablePublicWeb: true, Services: map[string]Service{"web": {Type: TypeContainer, ExtraSwarmParams: "--host=host.docker.internal:host-gateway"}}}, true},
+		{"two host aliases", Cobaltfile{StablePublicWeb: true, Services: map[string]Service{"web": {Type: TypeContainer, ExtraSwarmParams: "--host a:1.2.3.4 --host b:5.6.7.8"}}}, true},
+		{"host alias missing value", Cobaltfile{StablePublicWeb: true, Services: map[string]Service{"web": {Type: TypeContainer, ExtraSwarmParams: "--host"}}}, false},
+		{"host alias plus disallowed param", Cobaltfile{StablePublicWeb: true, Services: map[string]Service{"web": {Type: TypeContainer, ExtraSwarmParams: "--host a:1.2.3.4 --limit-cpu 1"}}}, false},
+		{"host value not mistaken for a flag", Cobaltfile{StablePublicWeb: true, Services: map[string]Service{"web": {Type: TypeContainer, ExtraSwarmParams: "--host --limit-cpu"}}}, true},
 		{"worker", Cobaltfile{StablePublicWeb: true, Services: map[string]Service{"web": {Type: TypeContainer}, "worker": {Type: TypeContainer}}}, false},
 	}
 	for _, tc := range cases {

--- a/internal/server/docker/service.go
+++ b/internal/server/docker/service.go
@@ -5,6 +5,7 @@ import (
 	"encoding/json"
 	"errors"
 	"fmt"
+	"slices"
 	"strconv"
 	"strings"
 	"time"
@@ -188,6 +189,27 @@ func (c *Client) ReconcileStableService(ctx context.Context, opts ServiceCreateO
 	}
 	// Stable public-web services always use their ID-based alias on cobalt-main.
 	// The attachment is created once and must not be added again on every update.
+	//
+	// Host aliases are the one extra swarm param the stable path accepts (see
+	// cobaltfile.UsesStablePublicWeb). `service update` only changes what it is
+	// handed, so without an explicit add/remove pass the create-time hosts would
+	// outlive any edit to cobalt.json -- silently, and forever. Reconcile them
+	// the same way env vars are reconciled just above.
+	oldHosts, err := c.stableServiceHosts(ctx, opts.Name)
+	if err != nil {
+		return err
+	}
+	wantHosts := hostParams(opts.ExtraParams)
+	for _, h := range wantHosts {
+		if !slices.Contains(oldHosts, h) {
+			args = append(args, "--host-add", h)
+		}
+	}
+	for _, h := range oldHosts {
+		if !slices.Contains(wantHosts, h) {
+			args = append(args, "--host-rm", h)
+		}
+	}
 	if opts.Replicas > 0 {
 		args = append(args, "--replicas", strconv.Itoa(opts.Replicas))
 	}
@@ -220,6 +242,54 @@ func (c *Client) stableServiceEnvKeys(ctx context.Context, name string) ([]strin
 	}
 	sortStrings(keys)
 	return keys, nil
+}
+
+// stableServiceHosts returns the service's custom host entries in the same
+// `hostname:value` shape the --host flag takes. Docker stores them the other
+// way round, space-separated ("host-gateway host.docker.internal"), so they
+// are flipped here rather than at every comparison site.
+func (c *Client) stableServiceHosts(ctx context.Context, name string) ([]string, error) {
+	out, err := c.output(ctx, "service", "inspect", "--format", "{{json .Spec.TaskTemplate.ContainerSpec.Hosts}}", name)
+	if err != nil {
+		return nil, err
+	}
+	if len(out) == 0 || string(out) == "null" {
+		return nil, nil
+	}
+	var stored []string
+	if err := json.Unmarshal(out, &stored); err != nil {
+		return nil, fmt.Errorf("inspect stable service hosts: %w", err)
+	}
+	hosts := make([]string, 0, len(stored))
+	for _, entry := range stored {
+		value, hostname, found := strings.Cut(entry, " ")
+		if !found {
+			continue
+		}
+		hosts = append(hosts, hostname+":"+value)
+	}
+	sortStrings(hosts)
+	return hosts, nil
+}
+
+// hostParams pulls the `--host` values out of pre-split extra swarm params.
+// UsesStablePublicWeb has already rejected any project whose params contain
+// anything else, so unrecognised flags are simply skipped here.
+func hostParams(extra []string) []string {
+	hosts := make([]string, 0, len(extra))
+	for i := 0; i < len(extra); i++ {
+		switch {
+		case extra[i] == "--host":
+			if i+1 < len(extra) {
+				i++
+				hosts = append(hosts, extra[i])
+			}
+		case strings.HasPrefix(extra[i], "--host="):
+			hosts = append(hosts, strings.TrimPrefix(extra[i], "--host="))
+		}
+	}
+	sortStrings(hosts)
+	return hosts
 }
 
 func serviceNameForOpts(opts ServiceCreateOpts) string {

--- a/internal/server/docker/service_test.go
+++ b/internal/server/docker/service_test.go
@@ -181,6 +181,61 @@ func TestReconcileStableService_RemovesDeletedEnvironment(t *testing.T) {
 	}
 }
 
+// A stable service is updated, never recreated, and `service update` only
+// changes what it is handed — so a host alias added or removed in cobalt.json
+// has to be reconciled explicitly or it never reaches the running service.
+func TestReconcileStableService_ReconcilesHostAliases(t *testing.T) {
+	t.Parallel()
+	r := newFakeRunner()
+	r.answerStdout(
+		"service inspect --format {{json .Spec.TaskTemplate.ContainerSpec.Hosts}}",
+		`["host-gateway host.docker.internal","1.2.3.4 stale.example"]`,
+	)
+	c := NewWithRunner(r)
+	err := c.ReconcileStableService(context.Background(), ServiceCreateOpts{
+		ProjectID: 7, ProjectName: "api", ServiceName: "web", DeploymentNumber: 4,
+		Name: "cobalt-web-7", Image: "api:4",
+		ExtraParams: SplitParams("--host host.docker.internal:host-gateway --host fresh.example:5.6.7.8"),
+	})
+	if err != nil {
+		t.Fatalf("ReconcileStableService: %v", err)
+	}
+	args := r.lastCall().Args
+	if !argSequence(args, "--host-add", "fresh.example:5.6.7.8") {
+		t.Errorf("new host alias was not added: %v", args)
+	}
+	if !argSequence(args, "--host-rm", "stale.example:1.2.3.4") {
+		t.Errorf("host alias dropped from cobalt.json was retained: %v", args)
+	}
+	// Already present with the same value — re-adding it churns the spec for
+	// no reason and shows up as a pointless task rollover.
+	if argSequence(args, "--host-add", "host.docker.internal:host-gateway") {
+		t.Errorf("unchanged host alias was re-added: %v", args)
+	}
+	if argSequence(args, "--host-rm", "host.docker.internal:host-gateway") {
+		t.Errorf("unchanged host alias was removed: %v", args)
+	}
+}
+
+func TestReconcileStableService_NoHostFlagsWhenNoneConfigured(t *testing.T) {
+	t.Parallel()
+	r := newFakeRunner()
+	c := NewWithRunner(r)
+	err := c.ReconcileStableService(context.Background(), ServiceCreateOpts{
+		ProjectID: 7, ProjectName: "api", ServiceName: "web", DeploymentNumber: 4,
+		Name: "cobalt-web-7", Image: "api:4",
+	})
+	if err != nil {
+		t.Fatalf("ReconcileStableService: %v", err)
+	}
+	args := r.lastCall().Args
+	for _, w := range []string{"--host-add", "--host-rm"} {
+		if argHas(args, w) {
+			t.Errorf("unexpected %q in %v", w, args)
+		}
+	}
+}
+
 func TestCreateService_NoHealthFlag(t *testing.T) {
 	t.Parallel()
 	r := newFakeRunner()


### PR DESCRIPTION
## Why

`UsesStablePublicWeb()` rejects any project with `extraSwarmParams` set. That excludes blue's `api`, which carries `--host host.docker.internal:host-gateway` — and `api` is the single largest producer of the post-reap 502s the stable service exists to eliminate:

| dead upstream | 502s | window |
|---|---|---|
| `api-472-web` | **1,268** | 8 min |
| `next-663/668/671-web` | 826 | ~43 min |
| everything else | ~200 | — |

`next` and `white-label` are already on the stable path (heyblueteam/blue#1218). `api` cannot follow without this.

## What

**1. Allow-list `--host`, keep banning everything else.**

The blanket ban is a sensible default: most extra params either duplicate a field the stable path already owns (`--network`, `--publish`, `--replicas`) or pin the service to a deployment-scoped resource — precisely what this service exists to avoid. `--host` does neither. It adds an `/etc/hosts` entry and touches nothing cobalt manages, so it is admitted explicitly rather than by loosening the check. Both `--host v` and `--host=v` forms are handled, and a trailing bare `--host` with no value is rejected.

**2. Reconcile host entries on update — the part that isn't obvious.**

`ReconcileStableService` updates in place, and `docker service update` only changes what you hand it. Without an explicit pass, hosts set at create would outlive any later edit to `cobalt.json` — silently, and forever. Now reconciled with `--host-add`/`--host-rm`, mirroring the existing env-var reconcile directly above it.

This also required flipping between the two shapes docker uses: the spec stores `"host-gateway host.docker.internal"` (value first, space-separated) while the flag takes `host.docker.internal:host-gateway`. Verified against a live service:

```
$ docker service inspect api-476-web --format '{{json .Spec.TaskTemplate.ContainerSpec.Hosts}}'
["host-gateway host.docker.internal"]
```

An unchanged alias produces neither flag, so a no-op deploy doesn't churn the spec into a pointless task rollover.

## Validation

- `go test ./...` — full suite passes
- `golangci-lint run` — 0 issues
- New cases: allow-list accept/reject (both flag forms, missing value, mixed with a banned param), and update-path add / remove / leave-alone

## Follow-up

Once released, `api/cobalt.json` in heyblueteam/blue gets `"stablePublicWeb": true`. That is a separate PR and must land only after both daemons run a build containing this — `cobalt.json` is parsed with `DisallowUnknownFields()`.