### PR TITLE
fix(stable-web): count containers, not health lines, when waiting for a rollout

### DIFF
--- a/internal/server/docker/health.go
+++ b/internal/server/docker/health.go
@@ -82,18 +82,20 @@ func (c *Client) WaitForServiceDeploymentHealthy(ctx context.Context, name strin
 	filter := LabelDeploymentNumber + "=" + strconv.Itoa(deploymentNumber)
 	const pollInterval = 3 * time.Second
 	for {
-		healths := c.containerHealthForService(ctx, name, filter)
-		if len(healths) >= replicas {
-			healthy, withHealth := 0, 0
+		containers, healths := c.containerHealthForService(ctx, name, filter)
+		if containers >= replicas {
+			// No healthcheck declared: containers being up is the whole signal,
+			// matching WaitForServiceHealthy's task-state fallback.
+			if len(healths) == 0 {
+				return nil
+			}
+			healthy := 0
 			for _, health := range healths {
-				if health != "" {
-					withHealth++
-				}
 				if health == "healthy" {
 					healthy++
 				}
 			}
-			if withHealth == 0 || healthy >= replicas {
+			if healthy >= replicas {
 				return nil
 			}
 		}
@@ -162,7 +164,7 @@ func (c *Client) taskStatuses(ctx context.Context, serviceName string) ([]taskSt
 	// Layer in per-container health for Running tasks. Failures here are
 	// non-fatal: WaitForServiceHealthy already falls back to task-state
 	// readiness when no Health field is reported.
-	if healths := c.containerHealthForService(ctx, serviceName); len(healths) > 0 {
+	if _, healths := c.containerHealthForService(ctx, serviceName); len(healths) > 0 {
 		var idx int
 		for i := range statuses {
 			if statuses[i].State != "Running" {
@@ -178,12 +180,19 @@ func (c *Client) taskStatuses(ctx context.Context, serviceName string) ([]taskSt
 	return statuses, nil
 }
 
-// containerHealthForService returns the .State.Health.Status of every
-// container backing the named swarm service. Empty string means the
-// container declared no HEALTHCHECK; missing entries (e.g. when the
-// inspect call fails) are simply skipped — the caller treats absence as
-// "no healthcheck declared" and falls back to task-state readiness.
-func (c *Client) containerHealthForService(ctx context.Context, serviceName string, extraLabelFilters ...string) []string {
+// containerHealthForService returns how many containers back the named swarm
+// service, plus the .State.Health.Status of those whose image declares a
+// HEALTHCHECK. An empty verdict slice means no healthcheck is declared, and
+// callers fall back to task-state readiness.
+//
+// The count is deliberately taken from the container ids rather than from the
+// verdict lines. `output` trims the whole blob, so a service whose containers
+// all lack a healthcheck inspects to nothing but blank lines and arrives here
+// as "" — indistinguishable from one container. Counting that string reported
+// a single container however many were running, so no service with more than
+// one replica and no HEALTHCHECK could ever satisfy a caller waiting on its
+// replica count.
+func (c *Client) containerHealthForService(ctx context.Context, serviceName string, extraLabelFilters ...string) (int, []string) {
 	args := []string{"ps", "--filter", "label=com.docker.swarm.service.name=" + serviceName}
 	for _, filter := range extraLabelFilters {
 		args = append(args, "--filter", "label="+filter)
@@ -191,11 +200,11 @@ func (c *Client) containerHealthForService(ctx context.Context, serviceName stri
 	args = append(args, "--format", "{{.ID}}")
 	out, err := c.output(ctx, args...)
 	if err != nil {
-		return nil
+		return 0, nil
 	}
 	ids := strings.Fields(string(out))
 	if len(ids) == 0 {
-		return nil
+		return 0, nil
 	}
 	inspectArgs := append([]string{
 		"inspect",
@@ -203,11 +212,13 @@ func (c *Client) containerHealthForService(ctx context.Context, serviceName stri
 	}, ids...)
 	out2, err := c.output(ctx, inspectArgs...)
 	if err != nil {
-		return nil
+		return len(ids), nil
 	}
 	var healths []string
-	for _, line := range strings.Split(strings.TrimSpace(string(out2)), "\n") {
-		healths = append(healths, strings.TrimSpace(line))
+	for _, line := range strings.Split(string(out2), "\n") {
+		if line = strings.TrimSpace(line); line != "" {
+			healths = append(healths, line)
+		}
 	}
-	return healths
+	return len(ids), healths
 }

--- a/internal/server/docker/health_test.go
+++ b/internal/server/docker/health_test.go
@@ -35,6 +35,40 @@ func TestWaitForServiceDeploymentHealthy_IgnoresPriorDeployment(t *testing.T) {
 	}
 }
 
+// An image with no HEALTHCHECK makes `docker inspect` emit one blank line per
+// container. Counting those lines is how the caller learns the containers are
+// up, so a multi-replica service must not collapse to a single element -- that
+// stalled every 4-replica cutover until the deploy timed out.
+func TestWaitForServiceDeploymentHealthy_MultiReplicaWithoutHealthcheck(t *testing.T) {
+	t.Parallel()
+	r := newFakeRunner()
+	r.answerStdout(
+		"ps --filter label=com.docker.swarm.service.name=cobalt-web-1 --filter label=cobalt.deployment.number=477",
+		"c1\nc2\nc3\nc4\n",
+	)
+	r.answerStdout("inspect --format", "\n\n\n\n")
+	c := NewWithRunner(r)
+	if err := c.WaitForServiceDeploymentHealthy(context.Background(), "cobalt-web-1", 477, 4, 5*time.Second); err != nil {
+		t.Errorf("WaitForServiceDeploymentHealthy: %v", err)
+	}
+}
+
+// The count must come from containers actually present, so a service that has
+// only rolled 2 of its 4 replicas is still considered not ready.
+func TestWaitForServiceDeploymentHealthy_WaitsForEveryReplica(t *testing.T) {
+	t.Parallel()
+	r := newFakeRunner()
+	r.answerStdout(
+		"ps --filter label=com.docker.swarm.service.name=cobalt-web-1 --filter label=cobalt.deployment.number=477",
+		"c1\nc2\n",
+	)
+	r.answerStdout("inspect --format", "\n\n")
+	c := NewWithRunner(r)
+	if err := c.WaitForServiceDeploymentHealthy(context.Background(), "cobalt-web-1", 477, 4, 200*time.Millisecond); err == nil {
+		t.Error("expected timeout while only 2 of 4 replicas were up")
+	}
+}
+
 func TestWaitForServiceHealthy_StartingTimesOut(t *testing.T) {
 	t.Parallel()
 	r := newFakeRunner()


### PR DESCRIPTION
## Impact

Every stable-web cutover on a service with **>1 replica and no `HEALTHCHECK`** fails after burning the full 5-minute timeout — while the service is up and healthy the whole time.

Hit in production on blue's `api` (4 replicas) today:

```
10:19:41  cobalt-web-1 reaches 4/4, all containers Running
10:24:42  deploy failed: "wait healthy stable public web:
          waitHealthy cobalt-web-1 deployment 477: timeout after 5m0s"
```

Cobalt failed safe — the router was never cut over and `api-476-web` kept serving — but the deploy is dead and the orphaned stable service is left running a full extra set of workers.

## Root cause

`WaitForServiceDeploymentHealthy` inferred the container count from the number of lines `docker inspect` returned:

```go
healths := c.containerHealthForService(ctx, name, filter)
if len(healths) >= replicas {   // ← count derived from health lines
```

With no `HEALTHCHECK`, the format string `{{if .State.Health}}…{{end}}` renders **one blank line per container**. `Client.output` ends with `bytes.TrimSpace`, so `"\n\n\n\n"` reaches the caller as `""`, splits to `[""]`, and counts as **1** — no matter how many containers are running.

```
1 replica :  1 >= 1  ✅  next, white-label cut over fine
4 replicas:  1 >= 4  ❌  never satisfiable → 5m timeout
```

Trimming is upstream in `output()`, so the information is destroyed before this function sees it — it cannot be recovered by parsing differently.

## Fix

`containerHealthForService` now returns `(containers int, healths []string)`: the count comes from the container ids (unambiguous), and verdicts are retained only for containers that actually report one. The caller treats an empty verdict slice as "no healthcheck declared" and accepts the containers being up — the same fallback `WaitForServiceHealthy` has always had for the non-stable path.

## Validation

- New `TestWaitForServiceDeploymentHealthy_MultiReplicaWithoutHealthcheck` reproduces the production failure exactly — **verified failing on `main`** with the same `timeout after 5s` error, passing with the fix.
- New `TestWaitForServiceDeploymentHealthy_WaitsForEveryReplica` pins the other direction: 2 of 4 replicas up must still time out, so the count fix can't degrade into accepting a partial rollout.
- `go test ./...` full suite passes; `golangci-lint run` 0 issues.