### PR TITLE
fix(run,cron): put the main network first for one-shot containers

### DIFF
--- a/internal/server/api/run.go
+++ b/internal/server/api/run.go
@@ -334,7 +334,7 @@ func (h *Handler) runV1(ctx context.Context, conn *websocket.Conn, req runReques
 		Image:            req.imageTag,
 		Command:          []string{"sh", "-c", req.command},
 		EnvVars:          req.envVars,
-		Networks:         []string{req.deploymentNetwork, deploy.MainNetworkName},
+		Networks:         docker.OneShotNetworks(deploy.MainNetworkName, req.deploymentNetwork),
 		Volumes:          req.volumes,
 		ExtraParams:      req.extraParams,
 		Stdin:            stdinR,

--- a/internal/server/api/run_v2.go
+++ b/internal/server/api/run_v2.go
@@ -128,7 +128,7 @@ func (h *Handler) runV2(ctx context.Context, conn *websocket.Conn, req runReques
 		Image:            req.imageTag,
 		Command:          []string{"sh", "-c", req.command},
 		EnvVars:          req.envVars,
-		Networks:         []string{req.deploymentNetwork, deploy.MainNetworkName},
+		Networks:         docker.OneShotNetworks(deploy.MainNetworkName, req.deploymentNetwork),
 		Volumes:          req.volumes,
 		ExtraParams:      req.extraParams,
 		Stdin:            carriers.childStdin,

--- a/internal/server/docker/names.go
+++ b/internal/server/docker/names.go
@@ -105,3 +105,33 @@ func InternalImageName(projectName, imageName string, deploymentNumber int) stri
 func InternalImagePrefix(projectName string) string {
 	return fmt.Sprintf("cobalt/project-%s-", projectName)
 }
+
+// OneShotNetworks orders the `--network` list for a one-shot container
+// (`cobalt run`, cron fires) so the shared main network comes FIRST.
+//
+// Order is load-bearing, not cosmetic. `docker run` treats the first
+// `--network` as the container's network *mode* and resolves it without
+// waiting for a swarm-scoped overlay to be realized on the node. A
+// per-deployment overlay is only realized locally while some task is
+// attached to it, so putting it first makes container creation race that
+// realization and fail with a misleading error naming a network that
+// `docker network ls` happily lists:
+//
+//	failed to set up container networking: could not find a network
+//	matching network mode cobalt-project-<project>-<n>: network not found
+//
+// Measured on docker 29.0.3 against a project whose service was attached
+// only to the main network, 12 attempts per ordering:
+//
+//	deployment network first → 3/12 succeeded
+//	main network first       → 12/12 succeeded
+//
+// The main network always hosts long-running containers, so it is always
+// realized and resolves immediately. Additional networks attach after the
+// mode is set and are not affected.
+//
+// Passing both names explicitly keeps this package free of a dependency on
+// the deploy package, which owns the main network's name.
+func OneShotNetworks(mainNetwork, deploymentNetwork string) []string {
+	return []string{mainNetwork, deploymentNetwork}
+}

--- a/internal/server/docker/names_test.go
+++ b/internal/server/docker/names_test.go
@@ -219,3 +219,19 @@ func equalStrings(a, b []string) bool {
 	}
 	return true
 }
+
+// The main network must come first: docker resolves the first --network as
+// the container's network mode without waiting for a swarm-scoped overlay to
+// be realized on the node, so a per-deployment overlay in that slot races its
+// own realization and fails container creation.
+func TestOneShotNetworksPutsMainFirst(t *testing.T) {
+	t.Parallel()
+	got := OneShotNetworks("cobalt-main", "cobalt-project-api-484")
+	want := []string{"cobalt-main", "cobalt-project-api-484"}
+	if !equalStrings(got, want) {
+		t.Errorf("OneShotNetworks: got %v, want %v", got, want)
+	}
+	if got[0] != "cobalt-main" {
+		t.Errorf("main network must be first for the network mode to resolve, got %q", got[0])
+	}
+}

--- a/internal/server/worker/croncron.go
+++ b/internal/server/worker/croncron.go
@@ -284,10 +284,10 @@ func (m *CronManager) cronJob(project store.Project, entry cronEntry) Job {
 			Command:          []string{"sh", "-c", entry.Command},
 			EnvVars:          envVars,
 			Volumes:          entry.Volumes,
-			Networks: []string{
-				docker.NetworkName(project.Name, entry.DeploymentNumber),
+			Networks: docker.OneShotNetworks(
 				"cobalt-main",
-			},
+				docker.NetworkName(project.Name, entry.DeploymentNumber),
+			),
 			Stdout: io.Discard,
 			Stderr: io.Discard,
 		}

--- a/internal/server/worker/croncron_test.go
+++ b/internal/server/worker/croncron_test.go
@@ -245,9 +245,12 @@ func TestCronManager_FireRunsContainerWithExpectedShape(t *testing.T) {
 	if got.DeploymentNumber != 4 {
 		t.Errorf("deployment label: %+v", got)
 	}
+	// cobalt-main first — see docker.OneShotNetworks. The per-deployment
+	// overlay in the network-mode slot races its own realization on the node
+	// and fails container creation, which silently dropped cron fires.
 	if len(got.Networks) != 2 ||
-		got.Networks[0] != "cobalt-project-api-4" ||
-		got.Networks[1] != "cobalt-main" {
+		got.Networks[0] != "cobalt-main" ||
+		got.Networks[1] != "cobalt-project-api-4" {
 		t.Errorf("networks: %+v", got.Networks)
 	}
 	if got.EnvVars["USER_VAR"] != "user-value" {


### PR DESCRIPTION
## Symptom

`cobalt run --project api` fails most of the time:

```
docker: Error response from daemon: failed to set up container networking:
could not find a network matching network mode cobalt-project-api-484:
network cobalt-project-api-484 not found.
```

The error is misleading — `docker network ls` lists that network, and `docker network inspect` reports `driver=overlay scope=swarm attachable=true`.

## Cause

`run` and cron create their one-shot container with two `--network` flags, per-deployment overlay first:

```go
Networks: []string{req.deploymentNetwork, deploy.MainNetworkName}
```

Docker treats the **first** `--network` as the container's network *mode*, and resolves that one without waiting for a swarm-scoped overlay to be realized on the node. A per-deployment overlay is only realized locally while some task is attached to it. Put it in the mode slot and container creation races its own realization.

Reproduced outside cobalt on docker 29.0.3, 12 attempts per ordering, against a project whose service is attached only to `cobalt-main`:

| `--network` order | succeeded |
|---|---:|
| deployment network, then main | **3/12** |
| main, then deployment network | 12/12 |
| deployment network alone | 12/12 |

`cobalt-main` permanently hosts long-running containers, so it is always realized and resolves immediately. Networks after the first attach once the mode is set and are unaffected — which is why the single-network case also passes.

## Fix

Order the list main-network-first. The **set** of attached networks is unchanged; only the mode slot moves. Extracted as `docker.OneShotNetworks` so the reasoning lives in one place instead of being re-derived at three call sites, with a test pinning the order.

Call sites fixed:
- `internal/server/api/run.go` — `cobalt run` (v1)
- `internal/server/api/run_v2.go` — `cobalt run` (v2)
- `internal/server/worker/croncron.go` — cron fires

`hooks.go` and `generator.go` pass only `cobalt-main` (single network, unaffected). Long-running services go through `docker service create`, where swarm handles attachment.

## Cron was the quieter casualty

Cron one-shots set `Stdout/Stderr: io.Discard` and only `log.Warn` on failure, so an affected schedule silently drops most of its fires. Anything relying on cron for a project in this state has been running at roughly a quarter of its intended frequency, with nothing louder than a warning line.

## Which projects are exposed

Any project where the deployment overlay has no locally-attached task, so it is never already-realized. That includes a service attached only to `cobalt-main`, a service scaled to zero, and — on a multi-node swarm — any node that happens to hold no task for that generation, which makes this a latent problem well beyond the single case that surfaced it.

## Checks

- `go build ./...` clean
- `go vet ./...` clean
- `go test ./...` — all packages pass

One existing assertion in `croncron_test.go` pinned the old order and was updated deliberately, since reversing it is the fix.

## Not addressed

`croncron.go` hardcodes the string `"cobalt-main"` rather than using `deploy.MainNetworkName` (the constant lives in a package `worker` doesn't import). Left as-is to keep this change to the ordering bug, but it is a drift risk worth its own cleanup.