### PR TITLE
fix(logs): resolve the stable public web service name

### DIFF
--- a/internal/server/api/logs.go
+++ b/internal/server/api/logs.go
@@ -174,8 +174,10 @@ func (h *Handler) ProjectLogs(w http.ResponseWriter, r *http.Request) {
 	// thinks the stream succeeded — exit 0 hides a typo. Runs before
 	// the Docker-client guard so "service typo" wins over "daemon
 	// misconfigured" when both apply.
+	var cf *cobaltfile.Cobaltfile
 	if live.ResolvedCobaltfile != nil {
-		if cf, err := cobaltfile.Parse([]byte(*live.ResolvedCobaltfile)); err == nil {
+		if parsed, err := cobaltfile.Parse([]byte(*live.ResolvedCobaltfile)); err == nil {
+			cf = parsed
 			if _, ok := cf.Services[serviceName]; !ok {
 				writeError(w, http.StatusNotFound,
 					"service "+serviceName+" not found in deployment #"+
@@ -188,7 +190,7 @@ func (h *Handler) ProjectLogs(w http.ResponseWriter, r *http.Request) {
 		writeError(w, http.StatusInternalServerError, "daemon Docker client not configured")
 		return
 	}
-	fullName := docker.ServiceName(project.Name, live.Number, serviceName)
+	fullName := logsServiceName(project.Name, project.ID, live.Number, serviceName, cf)
 
 	sse, err := newSSE(w)
 	if err != nil {
@@ -275,4 +277,27 @@ func waitForFile(ctx context.Context, path string, budget time.Duration) (*os.Fi
 		case <-time.After(50 * time.Millisecond):
 		}
 	}
+}
+
+// logsServiceName resolves the swarm service `docker service logs` should
+// read for a project's logical service.
+//
+// The web service of a stable-public-web project lives under its durable
+// name, not the per-generation one — the same rule the deploy pipeline's
+// readiness probe applies. Building the generational name unconditionally
+// made `logs` fail with "no such task or service" for the default (web)
+// service of every project that opted in. A nil cobaltfile — deployments
+// recorded before the resolved cobaltfile was stored — keeps the
+// generational name, which is where those deployments' services live.
+func logsServiceName(
+	projectName string,
+	projectID int64,
+	deploymentNumber int,
+	serviceName string,
+	cf *cobaltfile.Cobaltfile,
+) string {
+	if serviceName == "web" && cf != nil && cf.UsesStablePublicWeb() {
+		return docker.StablePublicWebServiceName(projectID)
+	}
+	return docker.ServiceName(projectName, deploymentNumber, serviceName)
 }

--- a/internal/server/api/logs_test.go
+++ b/internal/server/api/logs_test.go
@@ -12,6 +12,7 @@ import (
 	"testing"
 	"time"
 
+	"github.com/heyblueteam/cobalt/internal/server/cobaltfile"
 	"github.com/heyblueteam/cobalt/internal/server/deploy"
 	"github.com/heyblueteam/cobalt/internal/server/store"
 	"github.com/heyblueteam/cobalt/pkg/cobaltapi"
@@ -255,5 +256,41 @@ func TestProjectLogs_UnknownService404(t *testing.T) {
 	body, _ := io.ReadAll(resp.Body)
 	if !strings.Contains(string(body), "bogus") {
 		t.Errorf("body %q does not name the bad service", string(body))
+	}
+}
+
+// TestLogsServiceName pins which swarm service `logs` reads: the durable
+// stable-web name for an opted-in project's web service, the generational
+// name for everything else — other services, projects that didn't opt in,
+// and deployments recorded before the resolved cobaltfile was stored.
+func TestLogsServiceName(t *testing.T) {
+	t.Parallel()
+
+	stable, err := cobaltfile.Parse([]byte(
+		`{"version":"1.0","stablePublicWeb":true,"services":{"web":{"type":"container","image":"default","port":3000}}}`))
+	if err != nil {
+		t.Fatal(err)
+	}
+	plain, err := cobaltfile.Parse([]byte(
+		`{"version":"1.0","services":{"web":{"type":"container","image":"default","port":3000}}}`))
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	cases := []struct {
+		name    string
+		service string
+		cf      *cobaltfile.Cobaltfile
+		want    string
+	}{
+		{"stable web uses durable name", "web", stable, "cobalt-web-7"},
+		{"non-stable web keeps generational name", "web", plain, "proj-42-web"},
+		{"non-web service of a stable project keeps generational name", "worker", stable, "proj-42-worker"},
+		{"nil cobaltfile keeps generational name", "web", nil, "proj-42-web"},
+	}
+	for _, tc := range cases {
+		if got := logsServiceName("proj", 7, 42, tc.service, tc.cf); got != tc.want {
+			t.Errorf("%s: got %q, want %q", tc.name, got, tc.want)
+		}
 	}
 }


### PR DESCRIPTION
## What

`cobalt logs` (and `?service=web` on `GET /api/projects/{name}/logs`) fails with `no such task or service: <project>-<n>-web` for any project that opted into `stablePublicWeb`. The stable-web feature moved the web service to its durable `cobalt-web-<projectID>` name, but `ProjectLogs` still builds the per-generation name unconditionally.

## How

The service-name decision is extracted into `logsServiceName` and mirrors the rule the deploy pipeline's readiness probe already applies: the web service of a stable-public-web deployment resolves to `StablePublicWebServiceName(projectID)`; other services, non-opted-in projects, and deployments recorded before the resolved cobaltfile was stored keep the generational name.

The cobaltfile parse the handler already does for service validation is reused for the decision, so a deployment without a stored cobaltfile degrades to the old behavior rather than erroring.

## Tests

`TestLogsServiceName` pins all four branches (stable web, non-stable web, non-web service of a stable project, nil cobaltfile). Full `./internal/server/...` suite passes.