### PR TITLE
Fix: repo renames leave github_app_repos.full_name stale, breaking deploys

### DIFF
--- a/cmd/cobalt/github.go
+++ b/cmd/cobalt/github.go
@@ -158,8 +158,11 @@ func newGithubAppsPruneCmd() *cobra.Command {
 		Short: "Remove stale GitHub Apps and refresh repo list",
 		Long: `Cross-references cobalt's local DB with GitHub's current state.
 
-Removes apps and installations that no longer exist on GitHub, and adds repos
-from installations that were previously missing.
+Removes apps and installations that no longer exist on GitHub, adds repos
+from installations that were previously missing, and refreshes repos whose
+GitHub-side metadata drifted (renames, visibility, default branch). When a
+rename is detected, projects tracking the old repo name are retargeted to
+the new one.
 
 Examples:
   cobalt github apps prune`,
@@ -181,6 +184,8 @@ Examples:
 				[2]string{"Installations removed", strconv.FormatInt(int64(resp.InstallationsRemoved), 10)},
 				[2]string{"Repos added", strconv.FormatInt(int64(resp.ReposAdded), 10)},
 				[2]string{"Repos removed", strconv.FormatInt(int64(resp.ReposRemoved), 10)},
+				[2]string{"Repos updated", strconv.FormatInt(int64(resp.ReposUpdated), 10)},
+				[2]string{"Projects retargeted", strconv.FormatInt(int64(resp.ProjectsRetargeted), 10)},
 			)
 			return nil
 		}),

--- a/internal/server/api/github_apps.go
+++ b/internal/server/api/github_apps.go
@@ -69,8 +69,10 @@ func (h *Handler) ListGithubAppRepos(w http.ResponseWriter, r *http.Request) {
 
 // PruneGithubApps implements POST /api/github-apps/prune. Synchronously
 // reconciles local DB state with GitHub: removes apps GitHub no longer
-// has, removes installations GitHub no longer has, and adds/removes
-// repos to match GitHub's view of each installation.
+// has, removes installations GitHub no longer has, adds/removes repos to
+// match GitHub's view of each installation, and refreshes repos whose
+// metadata drifted in place (rename, visibility, default branch) —
+// following renames through to the projects that track them.
 func (h *Handler) PruneGithubApps(w http.ResponseWriter, r *http.Request) {
 	apps, err := h.DB.ListGithubApps(r.Context())
 	if err != nil {
@@ -146,14 +148,23 @@ func (h *Handler) pruneInstallation(
 	if err != nil {
 		return
 	}
-	localByRepoID := map[int64]struct{}{}
+	localByRepoID := map[int64]store.GithubAppRepo{}
 	for _, r := range localRepos {
-		localByRepoID[r.RepoID] = struct{}{}
+		localByRepoID[r.RepoID] = r
 	}
 
-	// Add GitHub-side repos not yet local.
+	// Add GitHub-side repos not yet local; refresh local rows whose
+	// metadata drifted (renamed repo, visibility flip, default-branch
+	// change). Repo IDs are stable across renames, so a rename shows up
+	// here as an existing ID with a different full_name — and a stale
+	// full_name breaks installation-token resolution, which resolves
+	// repo → installation by name.
 	for _, r := range githubRepos {
-		if _, ok := localByRepoID[r.ID]; ok {
+		local, exists := localByRepoID[r.ID]
+		if exists &&
+			local.FullName == r.FullName &&
+			local.Private == r.Private &&
+			local.DefaultBranch == r.DefaultBranch {
 			continue
 		}
 		if _, err := h.DB.AddGithubAppRepo(ctx, store.GithubAppRepo{
@@ -161,11 +172,30 @@ func (h *Handler) pruneInstallation(
 			RepoID:         r.ID,
 			FullName:       r.FullName,
 			Private:        r.Private,
+			DefaultBranch:  r.DefaultBranch,
 		}); err != nil {
-			h.Log.Error("prune: add repo", "full_name", r.FullName, "error", err)
+			h.Log.Error("prune: upsert repo", "full_name", r.FullName, "error", err)
 			continue
 		}
-		resp.ReposAdded++
+		if !exists {
+			resp.ReposAdded++
+			continue
+		}
+		resp.ReposUpdated++
+		// A name change also strands projects tracking the old name:
+		// pushes arrive under the new name and match nothing. Follow
+		// the rename through to the projects table.
+		if local.FullName != r.FullName {
+			n, err := h.DB.RetargetProjectsGithubRepo(ctx, local.FullName, r.FullName)
+			if err != nil {
+				h.Log.Error("prune: retarget projects",
+					"from", local.FullName, "to", r.FullName, "error", err)
+				continue
+			}
+			resp.ProjectsRetargeted += int(n)
+			h.Log.Info("prune: repo renamed",
+				"from", local.FullName, "to", r.FullName, "projects_retargeted", n)
+		}
 	}
 	// Remove local repos no longer on GitHub.
 	for _, r := range localRepos {

--- a/internal/server/api/github_apps_test.go
+++ b/internal/server/api/github_apps_test.go
@@ -1,0 +1,213 @@
+package api
+
+import (
+	"context"
+	"crypto/rand"
+	"crypto/rsa"
+	"crypto/x509"
+	"encoding/json"
+	"encoding/pem"
+	"io"
+	"log/slog"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+
+	"github.com/heyblueteam/cobalt/internal/server/deploy"
+	"github.com/heyblueteam/cobalt/internal/server/github"
+	"github.com/heyblueteam/cobalt/internal/server/store"
+	"github.com/heyblueteam/cobalt/pkg/cobaltapi"
+)
+
+func generateRSAPEM(t *testing.T) string {
+	t.Helper()
+	key, err := rsa.GenerateKey(rand.Reader, 2048)
+	if err != nil {
+		t.Fatal(err)
+	}
+	return string(pem.EncodeToMemory(&pem.Block{
+		Type:  "RSA PRIVATE KEY",
+		Bytes: x509.MarshalPKCS1PrivateKey(key),
+	}))
+}
+
+// fakeGithub stands in for api.github.com during prune tests. It
+// answers the three endpoints prune touches: app probe, token mint,
+// and the installation repo list.
+func fakeGithub(t *testing.T, repos []github.Repository) *httptest.Server {
+	t.Helper()
+	mux := http.NewServeMux()
+	mux.HandleFunc("GET /app", func(w http.ResponseWriter, _ *http.Request) {
+		_ = json.NewEncoder(w).Encode(map[string]any{"id": 12345})
+	})
+	mux.HandleFunc("POST /app/installations/{id}/access_tokens", func(w http.ResponseWriter, _ *http.Request) {
+		w.WriteHeader(http.StatusCreated)
+		_ = json.NewEncoder(w).Encode(map[string]any{
+			"token": "ghs_testtoken", "expires_at": "2030-01-01T00:00:00Z",
+		})
+	})
+	mux.HandleFunc("GET /installation/repositories", func(w http.ResponseWriter, _ *http.Request) {
+		_ = json.NewEncoder(w).Encode(map[string]any{
+			"total_count": len(repos), "repositories": repos,
+		})
+	})
+	srv := httptest.NewServer(mux)
+	t.Cleanup(srv.Close)
+	return srv
+}
+
+// pruneEnv builds a handler wired to a fake GitHub and a real store,
+// seeded with one app + one installation.
+type pruneEnv struct {
+	t      *testing.T
+	srv    *httptest.Server
+	db     *store.DB
+	appID  int64 // local PK
+	instID int64 // local PK
+}
+
+func newPruneEnv(t *testing.T, githubRepos []github.Repository) *pruneEnv {
+	t.Helper()
+	db := openTestDB(t)
+	ctx := context.Background()
+
+	gh := fakeGithub(t, githubRepos)
+
+	mux := http.NewServeMux()
+	h := NewHandler(HandlerOpts{
+		DB:     db,
+		Queue:  deploy.NewQueue(db),
+		GitHub: github.NewClientWithBaseURL(gh.URL, nil),
+		Log:    slog.New(slog.NewTextHandler(io.Discard, nil)),
+	})
+	h.Register(mux)
+	srv := httptest.NewServer(mux)
+	t.Cleanup(srv.Close)
+
+	appID, err := db.CreateGithubApp(ctx, store.GithubApp{
+		AppID:         12345,
+		Owner:         "acme",
+		PrivateKey:    generateRSAPEM(t),
+		WebhookSecret: "s",
+	})
+	if err != nil {
+		t.Fatalf("CreateGithubApp: %v", err)
+	}
+	instID, err := db.CreateGithubAppInstallation(ctx, store.GithubAppInstallation{
+		AppID: appID, InstallationID: 777, AccountLogin: "acme",
+	})
+	if err != nil {
+		t.Fatalf("CreateGithubAppInstallation: %v", err)
+	}
+	return &pruneEnv{t: t, srv: srv, db: db, appID: appID, instID: instID}
+}
+
+func (e *pruneEnv) prune() cobaltapi.PruneResponse {
+	e.t.Helper()
+	resp, err := e.srv.Client().Post(e.srv.URL+"/api/github-apps/prune", "application/json", nil)
+	if err != nil {
+		e.t.Fatalf("prune request: %v", err)
+	}
+	defer resp.Body.Close()
+	if resp.StatusCode != http.StatusOK {
+		body, _ := io.ReadAll(resp.Body)
+		e.t.Fatalf("prune status %d: %s", resp.StatusCode, body)
+	}
+	var out cobaltapi.PruneResponse
+	if err := json.NewDecoder(resp.Body).Decode(&out); err != nil {
+		e.t.Fatalf("decode: %v", err)
+	}
+	return out
+}
+
+// TestPrune_RefreshesRenamedRepoAndRetargetsProjects: GitHub reports
+// the same repo ID under a new full_name. Prune must update the local
+// row in place (not skip it as "already known") and retarget projects
+// tracking the old name. This is the remediation path for renames whose
+// webhook was missed — before this behavior existed, prune reported
+// "0 changes" while token resolution stayed broken.
+func TestPrune_RefreshesRenamedRepoAndRetargetsProjects(t *testing.T) {
+	t.Parallel()
+	e := newPruneEnv(t, []github.Repository{
+		{ID: 4242, FullName: "acme/newname", Private: true, DefaultBranch: "main"},
+	})
+	ctx := context.Background()
+
+	_, _ = e.db.AddGithubAppRepo(ctx, store.GithubAppRepo{
+		InstallationID: e.instID, RepoID: 4242, FullName: "acme/oldname", Private: true, DefaultBranch: "main",
+	})
+	_, _ = e.db.CreateProject(ctx, store.Project{
+		Name: "api", GithubRepo: "acme/oldname", Branch: "main",
+	})
+
+	resp := e.prune()
+	if resp.ReposUpdated != 1 {
+		t.Errorf("ReposUpdated: %d, want 1", resp.ReposUpdated)
+	}
+	if resp.ProjectsRetargeted != 1 {
+		t.Errorf("ProjectsRetargeted: %d, want 1", resp.ProjectsRetargeted)
+	}
+	if resp.ReposAdded != 0 || resp.ReposRemoved != 0 {
+		t.Errorf("added/removed: %d/%d, want 0/0", resp.ReposAdded, resp.ReposRemoved)
+	}
+
+	repo, err := e.db.GetGithubRepoByRepoID(ctx, 4242)
+	if err != nil {
+		t.Fatalf("GetGithubRepoByRepoID: %v", err)
+	}
+	if repo.FullName != "acme/newname" {
+		t.Errorf("repo full_name: %q, want acme/newname", repo.FullName)
+	}
+	p, err := e.db.GetProjectByName(ctx, "api")
+	if err != nil {
+		t.Fatalf("GetProjectByName: %v", err)
+	}
+	if p.GithubRepo != "acme/newname" {
+		t.Errorf("project github_repo: %q, want acme/newname", p.GithubRepo)
+	}
+}
+
+// TestPrune_UnchangedRepoIsUntouched: identical metadata on both sides
+// must produce a zero-change response (no gratuitous writes).
+func TestPrune_UnchangedRepoIsUntouched(t *testing.T) {
+	t.Parallel()
+	e := newPruneEnv(t, []github.Repository{
+		{ID: 1, FullName: "acme/api", Private: true, DefaultBranch: "main"},
+	})
+	ctx := context.Background()
+	_, _ = e.db.AddGithubAppRepo(ctx, store.GithubAppRepo{
+		InstallationID: e.instID, RepoID: 1, FullName: "acme/api", Private: true, DefaultBranch: "main",
+	})
+
+	resp := e.prune()
+	if resp.ReposUpdated != 0 || resp.ReposAdded != 0 || resp.ReposRemoved != 0 || resp.ProjectsRetargeted != 0 {
+		t.Errorf("want all-zero response, got %+v", resp)
+	}
+}
+
+// TestPrune_StillAddsAndRemoves: the pre-existing add/remove behavior
+// must survive the in-place-update change.
+func TestPrune_StillAddsAndRemoves(t *testing.T) {
+	t.Parallel()
+	e := newPruneEnv(t, []github.Repository{
+		{ID: 2, FullName: "acme/added", Private: false, DefaultBranch: "main"},
+	})
+	ctx := context.Background()
+	_, _ = e.db.AddGithubAppRepo(ctx, store.GithubAppRepo{
+		InstallationID: e.instID, RepoID: 3, FullName: "acme/removed", Private: false,
+	})
+
+	resp := e.prune()
+	if resp.ReposAdded != 1 {
+		t.Errorf("ReposAdded: %d, want 1", resp.ReposAdded)
+	}
+	if resp.ReposRemoved != 1 {
+		t.Errorf("ReposRemoved: %d, want 1", resp.ReposRemoved)
+	}
+	if _, err := e.db.GetGithubRepoByRepoID(ctx, 2); err != nil {
+		t.Errorf("added repo missing: %v", err)
+	}
+	if _, err := e.db.GetGithubRepoByRepoID(ctx, 3); err == nil {
+		t.Error("removed repo still present")
+	}
+}

--- a/internal/server/api/webhooks.go
+++ b/internal/server/api/webhooks.go
@@ -73,6 +73,8 @@ func (h *Handler) WebhookGithub(w http.ResponseWriter, r *http.Request) {
 		h.handleInstallation(r.Context(), body, app.ID)
 	case github.EventInstallationRepositories:
 		h.handleInstallationRepositories(r.Context(), body)
+	case github.EventRepository:
+		h.handleRepository(r.Context(), body)
 	default:
 		// Silently ignore — we only subscribed to push + installation
 		// events but GitHub may deliver others. Log so we notice if
@@ -189,6 +191,60 @@ func (h *Handler) handleInstallation(ctx context.Context, body []byte, localAppI
 	default:
 		// suspend / unsuspend / new_permissions_accepted etc. — ignore.
 	}
+}
+
+// handleRepository processes repository lifecycle events. Only
+// "renamed" is acted on: GitHub identifies the repo by its stable ID,
+// we look up our cached row under that ID, refresh its full_name, and
+// retarget any projects still tracking the old name.
+//
+// Without this, a rename leaves two stale name references behind:
+// github_app_repos.full_name (breaks installation-token resolution, so
+// deploys of private repos fall back to anonymous clones and fail) and
+// projects.github_repo (pushes arrive under the new name, match no
+// project, and are silently dropped).
+func (h *Handler) handleRepository(ctx context.Context, body []byte) {
+	ev, err := github.ParseRepository(body)
+	if err != nil {
+		h.Log.Warn("webhook: parse repository", "error", err)
+		return
+	}
+	if ev.Action != "renamed" {
+		return // archived / publicized / transferred etc. — ignore.
+	}
+
+	local, err := h.DB.GetGithubRepoByRepoID(ctx, ev.Repository.ID)
+	if errors.Is(err, store.ErrNotFound) {
+		// A repo this daemon never tracked; nothing to update.
+		return
+	}
+	if err != nil {
+		h.Log.Error("webhook: lookup repo for rename", "repo_id", ev.Repository.ID, "error", err)
+		return
+	}
+	if local.FullName == ev.Repository.FullName {
+		return // already current (e.g. replayed delivery)
+	}
+
+	if _, err := h.DB.AddGithubAppRepo(ctx, store.GithubAppRepo{
+		InstallationID: local.InstallationID,
+		RepoID:         ev.Repository.ID,
+		FullName:       ev.Repository.FullName,
+		Private:        ev.Repository.Private,
+		DefaultBranch:  ev.Repository.DefaultBranch,
+	}); err != nil {
+		h.Log.Error("webhook: update renamed repo", "full_name", ev.Repository.FullName, "error", err)
+		return
+	}
+
+	retargeted, err := h.DB.RetargetProjectsGithubRepo(ctx, local.FullName, ev.Repository.FullName)
+	if err != nil {
+		h.Log.Error("webhook: retarget projects after rename",
+			"from", local.FullName, "to", ev.Repository.FullName, "error", err)
+		return
+	}
+	h.Log.Info("webhook: repository renamed",
+		"from", local.FullName, "to", ev.Repository.FullName, "projects_retargeted", retargeted)
 }
 
 // handleInstallationRepositories processes added / removed events when

--- a/internal/server/api/webhooks_test.go
+++ b/internal/server/api/webhooks_test.go
@@ -440,6 +440,123 @@ func TestWebhook_UnhandledEventIsNoOp(t *testing.T) {
 	}
 }
 
+// TestWebhook_RepositoryRenamedUpdatesRepoAndProjects: a repository
+// event with action "renamed" must refresh the cached full_name on the
+// github_app_repos row (matched by the rename-stable repo ID) AND
+// retarget projects tracking the old name. Without both, deploys break
+// in two different ways: token resolution (which joins on full_name)
+// falls back to anonymous clones that fail on private repos, and pushes
+// arriving under the new name match no project at all.
+func TestWebhook_RepositoryRenamedUpdatesRepoAndProjects(t *testing.T) {
+	t.Parallel()
+	e := newWebhookEnv(t)
+	ctx := context.Background()
+
+	instID, _ := e.db.CreateGithubAppInstallation(ctx, store.GithubAppInstallation{
+		AppID: e.app.ID, InstallationID: 777, AccountLogin: "acme",
+	})
+	_, _ = e.db.AddGithubAppRepo(ctx, store.GithubAppRepo{
+		InstallationID: instID, RepoID: 4242, FullName: "acme/oldname", Private: true,
+	})
+	_, _ = e.db.CreateProject(ctx, store.Project{
+		Name: "api", GithubRepo: "acme/oldname", Branch: "main",
+	})
+	// A project on a different repo must NOT be retargeted.
+	_, _ = e.db.CreateProject(ctx, store.Project{
+		Name: "other", GithubRepo: "acme/unrelated", Branch: "main",
+	})
+
+	payload := map[string]any{
+		"action": "renamed",
+		"repository": map[string]any{
+			"id":             4242,
+			"full_name":      "acme/newname",
+			"private":        true,
+			"default_branch": "main",
+		},
+	}
+	resp := e.post(t, "repository", "delivery-rename-1", payload)
+	resp.Body.Close()
+	if resp.StatusCode != http.StatusAccepted {
+		t.Errorf("status: %d, want 202", resp.StatusCode)
+	}
+
+	repo, err := e.db.GetGithubRepoByRepoID(ctx, 4242)
+	if err != nil {
+		t.Fatalf("GetGithubRepoByRepoID: %v", err)
+	}
+	if repo.FullName != "acme/newname" {
+		t.Errorf("repo full_name: %q, want acme/newname", repo.FullName)
+	}
+	if repo.InstallationID != instID {
+		t.Errorf("installation id changed: %d, want %d", repo.InstallationID, instID)
+	}
+
+	p, err := e.db.GetProjectByName(ctx, "api")
+	if err != nil {
+		t.Fatalf("GetProjectByName: %v", err)
+	}
+	if p.GithubRepo != "acme/newname" {
+		t.Errorf("project github_repo: %q, want acme/newname", p.GithubRepo)
+	}
+	other, err := e.db.GetProjectByName(ctx, "other")
+	if err != nil {
+		t.Fatalf("GetProjectByName(other): %v", err)
+	}
+	if other.GithubRepo != "acme/unrelated" {
+		t.Errorf("unrelated project was retargeted: %q", other.GithubRepo)
+	}
+}
+
+// TestWebhook_RepositoryRenameOfUntrackedRepoIsNoOp: renames of repos
+// this daemon never registered must be absorbed silently.
+func TestWebhook_RepositoryRenameOfUntrackedRepoIsNoOp(t *testing.T) {
+	t.Parallel()
+	e := newWebhookEnv(t)
+	payload := map[string]any{
+		"action": "renamed",
+		"repository": map[string]any{
+			"id": 999999, "full_name": "acme/ghost", "private": false,
+		},
+	}
+	resp := e.post(t, "repository", "delivery-rename-2", payload)
+	defer resp.Body.Close()
+	if resp.StatusCode != http.StatusAccepted {
+		t.Errorf("status: %d, want 202", resp.StatusCode)
+	}
+}
+
+// TestWebhook_RepositoryNonRenameActionIsNoOp: other repository-event
+// actions (archived, publicized, ...) must not touch stored state.
+func TestWebhook_RepositoryNonRenameActionIsNoOp(t *testing.T) {
+	t.Parallel()
+	e := newWebhookEnv(t)
+	ctx := context.Background()
+	instID, _ := e.db.CreateGithubAppInstallation(ctx, store.GithubAppInstallation{
+		AppID: e.app.ID, InstallationID: 778, AccountLogin: "acme",
+	})
+	_, _ = e.db.AddGithubAppRepo(ctx, store.GithubAppRepo{
+		InstallationID: instID, RepoID: 5151, FullName: "acme/keepme", Private: true,
+	})
+
+	payload := map[string]any{
+		"action": "archived",
+		"repository": map[string]any{
+			"id": 5151, "full_name": "acme/keepme", "private": true,
+		},
+	}
+	resp := e.post(t, "repository", "delivery-rename-3", payload)
+	resp.Body.Close()
+
+	repo, err := e.db.GetGithubRepoByRepoID(ctx, 5151)
+	if err != nil {
+		t.Fatalf("repo should still exist: %v", err)
+	}
+	if repo.FullName != "acme/keepme" {
+		t.Errorf("full_name changed on non-rename action: %q", repo.FullName)
+	}
+}
+
 // Anchor the cobaltapi import so removing webhook.go's references
 // doesn't accidentally drop coverage.
 var _ = cobaltapi.GithubApp{}

--- a/internal/server/github/client_test.go
+++ b/internal/server/github/client_test.go
@@ -276,7 +276,7 @@ func TestBuildManifest(t *testing.T) {
 	if m.Public {
 		t.Error("Public should be false")
 	}
-	if len(m.Events) != 1 || m.Events[0] != "push" {
+	if len(m.Events) != 2 || !inSlice(m.Events, "push") || !inSlice(m.Events, "repository") {
 		t.Errorf("Events: %v", m.Events)
 	}
 	if m.Permissions["contents"] != "read" {

--- a/internal/server/github/manifest.go
+++ b/internal/server/github/manifest.go
@@ -66,7 +66,7 @@ type Manifest struct {
 	HookAttrs   ManifestHookAttrs `json:"hook_attributes"`
 	RedirectURL string            `json:"redirect_url"`        // where GitHub redirects after creation
 	Public      bool              `json:"public"`              // we always set false
-	Events      []string          `json:"default_events"`      // ["push"]
+	Events      []string          `json:"default_events"`      // ["push", "repository"]
 	Permissions map[string]string `json:"default_permissions"` // {"contents":"read"}
 	SetupURL    string            `json:"setup_url,omitempty"`
 }
@@ -126,7 +126,7 @@ func BuildManifest(daemonHost, name, pendingAppID string) Manifest {
 		HookAttrs:   ManifestHookAttrs{URL: "https://" + daemonHost + "/webhooks/github"},
 		RedirectURL: "https://" + daemonHost + "/github-apps/" + pendingAppID + "/created",
 		Public:      false,
-		Events:      []string{"push"},
+		Events:      []string{"push", "repository"},
 		Permissions: map[string]string{"contents": "read", "metadata": "read"},
 	}
 }

--- a/internal/server/github/webhook.go
+++ b/internal/server/github/webhook.go
@@ -21,6 +21,7 @@ const (
 	EventPush                     = "push"
 	EventInstallation             = "installation"
 	EventInstallationRepositories = "installation_repositories"
+	EventRepository               = "repository"
 )
 
 // VerifySignature returns nil iff signatureHeader is a valid HMAC-SHA256
@@ -168,6 +169,26 @@ type InstallationRepositoriesEvent struct {
 	RepositoriesRemoved []InstallationEventRepo       `json:"repositories_removed"`
 }
 
+// RepositoryEvent fires on repository lifecycle changes (renamed,
+// transferred, archived, ...). We act on "renamed": the repo's ID is
+// stable across renames, so it anchors the update of our cached
+// full_name. Schema:
+// https://docs.github.com/en/webhooks/webhook-events-and-payloads#repository
+type RepositoryEvent struct {
+	Action     string              `json:"action"` // "renamed", "transferred", ...
+	Repository RepositoryEventRepo `json:"repository"`
+}
+
+// RepositoryEventRepo is the subset of the repository event's
+// "repository" object we use. FullName carries the NEW name; the old
+// name is recovered from our own DB row keyed by the stable ID.
+type RepositoryEventRepo struct {
+	ID            int64  `json:"id"`
+	FullName      string `json:"full_name"`
+	Private       bool   `json:"private"`
+	DefaultBranch string `json:"default_branch"`
+}
+
 // ParsePush, ParseInstallation, and ParseInstallationRepositories decode
 // the typed event from the raw webhook body. They exist so the webhook
 // receiver can dispatch to the right struct after looking at HeaderEvent.
@@ -189,6 +210,14 @@ func ParseInstallation(b []byte) (*InstallationEvent, error) {
 
 func ParseInstallationRepositories(b []byte) (*InstallationRepositoriesEvent, error) {
 	var ev InstallationRepositoriesEvent
+	if err := json.Unmarshal(b, &ev); err != nil {
+		return nil, err
+	}
+	return &ev, nil
+}
+
+func ParseRepository(b []byte) (*RepositoryEvent, error) {
+	var ev RepositoryEvent
 	if err := json.Unmarshal(b, &ev); err != nil {
 		return nil, err
 	}

--- a/internal/server/store/github_repos.go
+++ b/internal/server/store/github_repos.go
@@ -50,6 +50,37 @@ func (db *DB) RemoveGithubAppRepo(ctx context.Context, repoID int64) error {
 	return nil
 }
 
+// GetGithubRepoByRepoID looks a repo up by its GitHub-side ID — the one
+// identifier that survives renames and transfers.
+func (db *DB) GetGithubRepoByRepoID(ctx context.Context, repoID int64) (*GithubAppRepo, error) {
+	resp, err := db.QuerySingle(ctx, `
+        SELECT id, installation_id, repo_id, full_name, private, default_branch, created_at
+        FROM github_app_repos WHERE repo_id = ?
+    `, repoID)
+	if err != nil {
+		return nil, err
+	}
+	if hasError, _, errMsg := resp.HasError(); hasError {
+		return nil, errors.New(errMsg)
+	}
+	results := resp.GetQueryResults()
+	if len(results) == 0 || len(results[0].Values) == 0 {
+		return nil, ErrNotFound
+	}
+	row := results[0].Values[0]
+	var r GithubAppRepo
+	r.ID = toInt64(row[0])
+	r.InstallationID = toInt64(row[1])
+	r.RepoID = toInt64(row[2])
+	r.FullName = toString(row[3])
+	r.Private = toInt64(row[4]) != 0
+	if row[5] != nil {
+		r.DefaultBranch = toString(row[5])
+	}
+	r.CreatedAt = toInt64(row[6])
+	return &r, nil
+}
+
 func (db *DB) GetGithubRepoByFullName(ctx context.Context, fullName string) (*GithubAppRepo, error) {
 	resp, err := db.QuerySingle(ctx, `
         SELECT id, installation_id, repo_id, full_name, private, default_branch, created_at

--- a/internal/server/store/projects.go
+++ b/internal/server/store/projects.go
@@ -196,6 +196,29 @@ func (db *DB) UpdateProjectSource(ctx context.Context, id int64, githubRepo, bra
 	return nil
 }
 
+// RetargetProjectsGithubRepo points every project tracking oldFullName
+// at newFullName. Branch, path, domains, env vars, and deployment
+// history are untouched. Returns how many projects were retargeted
+// (zero is not an error — most renames touch repos no project tracks).
+//
+// Used when GitHub reports a repository rename: project rows reference
+// repos by name string, so without this the next push (which arrives
+// under the NEW name) matches no project and is silently dropped.
+func (db *DB) RetargetProjectsGithubRepo(ctx context.Context, oldFullName, newFullName string) (int64, error) {
+	resp, err := db.ExecuteSingle(ctx, `
+        UPDATE projects
+        SET github_repo = ?, updated_at = strftime('%s', 'now')
+        WHERE github_repo = ?
+    `, newFullName, oldFullName)
+	if err != nil {
+		return 0, err
+	}
+	if len(resp.Results) == 0 {
+		return 0, nil
+	}
+	return resp.Results[0].RowsAffected, nil
+}
+
 // OtherProjectsWithSameSource returns the count of projects (other than
 // projectID) that share the same (github_repo, branch, path) tuple as
 // projectID. Returns 0 with no error when projectID doesn't exist —

--- a/pkg/cobaltapi/github_app.go
+++ b/pkg/cobaltapi/github_app.go
@@ -55,4 +55,10 @@ type PruneResponse struct {
 	InstallationsRemoved int `json:"installationsRemoved"`
 	ReposAdded           int `json:"reposAdded"`
 	ReposRemoved         int `json:"reposRemoved"`
+	// ReposUpdated counts local rows refreshed in place because their
+	// GitHub-side metadata drifted (rename, visibility, default branch).
+	ReposUpdated int `json:"reposUpdated"`
+	// ProjectsRetargeted counts projects whose github_repo was followed
+	// through a detected rename.
+	ProjectsRetargeted int `json:"projectsRetargeted"`
 }


### PR DESCRIPTION
## What breaks

Renaming a GitHub repo silently breaks that project's deploys. Two places
key off the repo's `full_name` string instead of its rename-stable ID:

1. `pruneInstallation` only diffs set membership by `RepoID` — when a repo's
   ID already exists locally it `continue`s without ever comparing
   `FullName`, so a rename never gets picked up even though
   `AddGithubAppRepo` already has correct `ON CONFLICT(repo_id) DO UPDATE`
   semantics sitting right there unused for this case. `cobalt github apps
   prune` reports `reposAdded=0 reposRemoved=0` after a rename, which reads
   as confirmation nothing's wrong.
2. `dbTokenProvider.GetInstallationToken` resolves repo → installation via
   `ListGithubReposByFullName(project.GithubRepo)`. Once (1) leaves the
   cached `full_name` stale, this lookup returns zero rows for the
   project's (now current) `github_repo`, `GetInstallationToken` correctly
   treats that as "no installation grants access," and `deploy.Prepare`
   falls back to an anonymous clone — which fails on any private repo with
   a confusing `could not read Username for 'https://github.com'` instead
   of a clear "repository not found."

Reproduced end to end against a real installation: renamed a private repo
on GitHub, watched the webhook go silent (zero log lines, not even a
rejected delivery — GitHub simply wasn't delivering `push` events that
Cobalt's project record could still resolve), ran `prune` and got
`reposAdded=0 reposRemoved=0`, then hit the anonymous-clone failure via
`cobalt deploy`.

## Fix

- `pruneInstallation` now compares `FullName`/`Private`/`DefaultBranch` for
  repo IDs it already knows and upserts via the existing `AddGithubAppRepo`
  when anything drifted, not just on add/remove. New
  `PruneResponse.ReposUpdated` counter, surfaced in the CLI table.
- When prune detects a `full_name` change, it also retargets any project
  rows still pointing at the old name via a new
  `RetargetProjectsGithubRepo` store method, and reports
  `ProjectsRetargeted`. Without this half, prune alone fixes the repo cache
  but pushes under the new name still match no project.
- New `repository` webhook handler (action `"renamed"`) does the same two
  things live, so a rename fixes itself within seconds instead of waiting
  for someone to notice and run `prune` by hand. Looks the local repo row
  up by the rename-stable GitHub repo ID (new `GetGithubRepoByRepoID` store
  method) rather than by name.

## Tests

- `internal/server/api/github_apps_test.go` (new): prune against a fake
  GitHub server — rename detected + repo updated in place + project
  retargeted; unchanged repo is a true no-op; existing add/remove behavior
  still works.
- `internal/server/api/webhooks_test.go`: three new cases for the
  `repository` event — renamed repo updates the row and retargets its
  project (an unrelated project is left alone), a rename of an untracked
  repo is absorbed silently, non-`"renamed"` actions are no-ops.

Locally verified: `go build ./...`, `go vet ./...`, `gofmt`, and the full
existing suite in every package that doesn't need the docker+rqlite store
harness (`internal/server/github`, `internal/server/deploy` token tests,
`pkg/...`) — all green, nothing broken. I didn't have a docker daemon
available in this environment to run the new DB-backed tests locally, so
deferring those to CI rather than skipping verification silently.

🤖 Generated with [Claude Code](https://claude.com/claude-code)