### PR TITLE
fix(deploy): run the cobalt daemon with init:true so it reaps git zombies

### DIFF
--- a/cmd/cobalt/assets/init-docker-compose.yml
+++ b/cmd/cobalt/assets/init-docker-compose.yml
@@ -96,6 +96,11 @@ services:
 
   cobalt:
     image: ${COBALT_IMAGE}
+    # tini as PID 1 reaps the detached `git maintenance run --auto` that
+    # `git fetch` forks on every deploy (deploy/prepare.go). The daemon is
+    # PID 1 in its own container and never wait()s reparented orphans, so
+    # without this each deploy leaves a permanent zombie.
+    init: true
     # depends_on is preserved for the local-dev `docker compose up`
     # workflow — `docker stack deploy` ignores it. The daemon's
     # rqlite client retries on connection refused, so swarm not

--- a/deploy/compose/docker-compose.yml
+++ b/deploy/compose/docker-compose.yml
@@ -36,6 +36,11 @@ version: "3.9"
 
 x-cobalt-base: &cobalt-base
   image: ghcr.io/heyblueteam/cobalt:${COBALT_VERSION:-latest}
+  # tini as PID 1 reaps the detached `git maintenance run --auto` that
+  # `git fetch` forks on every deploy (deploy/prepare.go). The daemon is
+  # PID 1 in its own container and never wait()s reparented orphans, so
+  # without this each deploy leaves a permanent zombie.
+  init: true
   depends_on:
     rqlite:
       condition: service_healthy


### PR DESCRIPTION
Fixes the leak tracked in #51.

## Problem

The cobalt daemon runs as **PID 1 in its own container** with no init, and never `wait()`s on reparented orphans. Every deploy leaks one permanent zombie.

`gitPreparer.Prepare` runs `git fetch --prune origin` once per deploy for each already-cloned project (`internal/server/deploy/prepare.go:126`). git 2.47 ends a fetch by forking a detached `git maintenance run --auto`, which outlives its parent by design. The intermediate `git` exits, the detached child reparents to PID 1 = cobalt, and nothing collects it.

This is **not** a missing `cmd.Wait()` — `ExecGit.Run` and `ExecGit.Output` both wait correctly. The zombies are grandchildren, so only an init process can reap them.

## Evidence from prod (server.blue.cc, 2026-08-18)

Three `blue-doctor` samples, plus the two previous nights' runs, show a monotonic climb that no threshold catches (`blue-doctor`'s zombie warning fires at 1000):

| date | `zombies.count` | parent |
|---|---|---|
| 2026-08-15 23:00Z | 111 | cobalt |
| 2026-08-16 23:00Z | 145 | cobalt |
| 2026-08-17 23:04Z | 175 | cobalt |
| 2026-08-18 23:00Z / 23:04Z | 237 / 237 | cobalt |

Of the 237, **223 are `git`** under the daemon (pid 2881545, `NSpid: 2881545 1`), arriving in bursts of 1–3 at deploy-shaped timestamps — one push to the monorepo deploys `api` + `next` + `white-label`. The count is monotonic for the life of the process (daemon up since 2026-08-14 05:29) and resets only on a cobalt restart, which is why it stayed invisible.

## Fix

`init: true` on the cobalt service in both stack files. Docker puts tini at PID 1 and runs cobalt as its child; tini reaps any reparented orphan, not just git's. `docker stack deploy` honors it (maps to swarm `ContainerSpec.Init`) — confirmed on the prod host, Docker 29.0.3.

Verified against the deployed image (`ghcr.io/heyblueteam/cobalt:v1.5.4`) in throwaway containers, one clone + fetch sequence with a non-reaping PID 1 to match how the daemon runs:

```
without --init:  pid1=sleep        zombies=3
with    --init:  pid1=docker-init  zombies=0
```

## Notes

- **Not urgent.** 237 of a 1000 warning threshold; each zombie costs a PID-table slot. This stops unbounded growth.
- **Applies on the next cobalt stack redeploy**, which recreates the daemon container and clears the accumulated zombies. Do it deliberately — it cycles the control plane.
- The live host runs a drifted copy of the asset at `/opt/cobalt/docker-compose.yml` (Caddy port overrides from the disco cutover), so that file needs the same line before the redeploy.
- Same one-line mechanism as #42, which covers the caddy service. The two PRs touch the same files in different hunks.