### PR TITLE
🔖 feat: Expose build commit metadata

### DIFF
--- a/README.md
+++ b/README.md
@@ -84,6 +84,15 @@ cobalt env set DATABASE_URL=postgres://...
 cobalt deploy
 ```
 
+For Dockerfile builds, Cobalt also provides the exact checked-out revision as
+the public `COBALT_COMMIT` build argument. Declare it only where the build needs
+source identity:
+
+```dockerfile
+ARG COBALT_COMMIT
+RUN echo "Building ${COBALT_COMMIT}"
+```
+
 ### 3. View your deployment
 
 ```bash

--- a/internal/server/deploy/build.go
+++ b/internal/server/deploy/build.go
@@ -156,6 +156,7 @@ func (b *dockerBuilder) Build(ctx context.Context, project store.Project, dep st
 			ProjectName:      project.Name,
 			ImageName:        svc.Image,
 			DeploymentNumber: dep.Number,
+			Commit:           ws.Commit,
 			Dockerfile:       filepath.Join(ws.Path, img.Dockerfile),
 			Context:          filepath.Join(ws.Path, img.Context),
 			EnvSecrets:       envSecrets,

--- a/internal/server/deploy/build_test.go
+++ b/internal/server/deploy/build_test.go
@@ -201,6 +201,31 @@ func TestBuilder_PropagatesEnvSecrets(t *testing.T) {
 	}
 }
 
+func TestBuilder_PropagatesResolvedCommit(t *testing.T) {
+	t.Parallel()
+	cf := &cobaltfile.Cobaltfile{
+		Version:  "1.0",
+		Services: map[string]cobaltfile.Service{"web": {Image: "default", Port: 8000}},
+		Images:   map[string]cobaltfile.Image{"default": {Dockerfile: "Dockerfile", Context: "."}},
+	}
+	d := &fakeImageBuilder{}
+	b := NewBuilder(d, &fakeEnv{}, &fakeProjectQuerier{}, "")
+
+	_, err := b.Build(
+		context.Background(),
+		store.Project{ID: 1, Name: "x"},
+		store.Deployment{Number: 1},
+		&Workspace{Cobaltfile: cf, Commit: "abc123def456"},
+		nil,
+	)
+	if err != nil {
+		t.Fatalf("Build: %v", err)
+	}
+	if got := d.calls[0].Commit; got != "abc123def456" {
+		t.Errorf("Commit: got %q, want resolved workspace SHA", got)
+	}
+}
+
 // TestBuilder_PrebuiltImageSkipsBuild proves that when `svc.Image` is
 // NOT a key in `cf.Images`, the builder treats it as a pre-built docker
 // registry reference: no docker build is invoked, and the resulting

--- a/internal/server/docker/build.go
+++ b/internal/server/docker/build.go
@@ -14,6 +14,7 @@ type BuildOpts struct {
 	ProjectName      string
 	ImageName        string // logical name from cobaltfile.images.<name>
 	DeploymentNumber int
+	Commit           string // resolved source SHA; exposed as the COBALT_COMMIT build arg
 	Dockerfile       string // relative to Context
 	Context          string // build context dir
 	EnvSecrets       map[string]string
@@ -82,6 +83,13 @@ func (c *Client) Build(ctx context.Context, opts BuildOpts) (string, error) {
 	}
 	if opts.NoCache {
 		args = append(args, "--no-cache")
+	}
+	// Source identity is public build metadata, not a secret. A fixed build
+	// argument lets Dockerfiles stamp assets, error reports, and telemetry with
+	// the exact revision Cobalt checked out. Omit it for callers that do not
+	// have a source commit (for example isolated docker primitive tests).
+	if opts.Commit != "" {
+		args = append(args, "--build-arg", "COBALT_COMMIT="+opts.Commit)
 	}
 	for _, label := range serviceLabels(opts.ProjectID, opts.ProjectName, opts.ImageName, opts.DeploymentNumber) {
 		args = append(args, "--label", label)

--- a/internal/server/docker/build_test.go
+++ b/internal/server/docker/build_test.go
@@ -16,6 +16,7 @@ func TestBuild_DeterministicArgs(t *testing.T) {
 		ProjectName:      "api",
 		ImageName:        "default",
 		DeploymentNumber: 3,
+		Commit:           "abc123def456",
 		Dockerfile:       "Dockerfile",
 		Context:          "src",
 		EnvSecrets: map[string]string{
@@ -85,10 +86,27 @@ func TestBuild_DeterministicArgs(t *testing.T) {
 	if !argHas(args, "--no-cache", "-f", "Dockerfile") {
 		t.Errorf("missing flags: %v", args)
 	}
+	if !argSequence(args, "--build-arg", "COBALT_COMMIT=abc123def456") {
+		t.Errorf("resolved commit build arg missing: %v", args)
+	}
 
 	// Build context comes last.
 	if args[len(args)-1] != "src" {
 		t.Errorf("context: got %q", args[len(args)-1])
+	}
+}
+
+func TestBuild_EmptyCommitOmitsBuildArg(t *testing.T) {
+	t.Parallel()
+	r := newFakeRunner()
+	c := NewWithRunner(r)
+	if _, err := c.Build(context.Background(), BuildOpts{
+		ProjectName: "api", ImageName: "default", DeploymentNumber: 1,
+	}); err != nil {
+		t.Fatalf("Build: %v", err)
+	}
+	if argHas(r.lastCall().Args, "COBALT_COMMIT=") {
+		t.Errorf("empty commit build arg should be omitted: %v", r.lastCall().Args)
 	}
 }
 


### PR DESCRIPTION
## Summary

- pass the exact resolved workspace SHA into each Docker image build
- expose it as the public `COBALT_COMMIT` build argument
- omit the argument when no source identity is available
- document Dockerfile consumption

## Validation

- `go test ./internal/server/docker ./internal/server/deploy`
- `go test ./...`
