### PR TITLE
fix(run): remove abandoned one-off containers

### DIFF
--- a/internal/server/api/run.go
+++ b/internal/server/api/run.go
@@ -26,6 +26,13 @@ import (
 // We don't want a slow client to indefinitely back up our docker copy.
 const runWriteTimeout = 10 * time.Second
 
+// runContainerCleanupTimeout bounds the best-effort removal that follows
+// every cobalt run session. The cleanup uses a context detached from the
+// request because the common leak path is precisely a canceled request:
+// exec.CommandContext kills the attached `docker run` client, but Docker
+// keeps the container alive and `--rm` cannot remove it until it exits.
+const runContainerCleanupTimeout = 10 * time.Second
+
 // runMaxLifetime hard-caps any single cobalt run session. Forgotten
 // interactive shells, runaway loops, etc. — none of them get to hold a
 // container open indefinitely. 1 h matches the rough upper bound of
@@ -82,6 +89,29 @@ func newRunLifecycle(parent context.Context, conn *websocket.Conn) (context.Cont
 		}
 	}()
 	return ctx, cancel
+}
+
+// runContainer starts one cobalt run container and always removes that exact
+// container after the attached docker client returns. Normal exits are still
+// handled by `docker run --rm`; RemoveContainer treats that already-missing
+// container as success. On client disconnect or lifetime expiry, this explicit
+// removal stops the still-running container that the killed docker CLI leaves
+// behind.
+//
+// Keep the command result authoritative. A cleanup failure is logged for
+// operators but must not turn a successful command into a failure or
+// hide its real exit code.
+func (h *Handler) runContainer(ctx context.Context, opts docker.RunOpts) error {
+	defer func() {
+		cleanupCtx, cancel := context.WithTimeout(context.WithoutCancel(ctx), runContainerCleanupTimeout)
+		defer cancel()
+		if err := h.Docker.RemoveContainer(cleanupCtx, opts.ContainerName); err != nil {
+			h.Log.Warn("run: container cleanup failed",
+				"container", opts.ContainerName,
+				"error", err)
+		}
+	}()
+	return h.Docker.Run(ctx, opts)
 }
 
 // runRequest carries the resolved-once request fields shared by every
@@ -341,7 +371,7 @@ func (h *Handler) runV1(ctx context.Context, conn *websocket.Conn, req runReques
 		Stdout:           stdoutW,
 		Stderr:           stderrW,
 	}
-	runErr := h.Docker.Run(runCtx, runOpts)
+	runErr := h.runContainer(runCtx, runOpts)
 
 	// Closing the write halves makes the pumps see EOF and drain.
 	// Closing stdinR releases the kernel handle the child held; with

--- a/internal/server/api/run_test.go
+++ b/internal/server/api/run_test.go
@@ -46,6 +46,57 @@ type runFakeDocker struct {
 	lastRunArgs []string
 }
 
+// runCleanupRunner records the docker run and docker rm calls made by
+// runContainer. Its callbacks receive the actual context so tests can prove
+// cleanup survives cancellation of the run session.
+type runCleanupRunner struct {
+	mu       sync.Mutex
+	calls    [][]string
+	onRun    func(context.Context) error
+	onRemove func(context.Context) error
+}
+
+func (f *runCleanupRunner) Run(ctx context.Context, args []string, stdin io.Reader, stdout, stderr io.Writer) error {
+	return f.RunWithEnv(ctx, nil, args, stdin, stdout, stderr)
+}
+
+func (f *runCleanupRunner) RunWithEnv(
+	ctx context.Context,
+	_ map[string]string,
+	args []string,
+	_ io.Reader,
+	_, _ io.Writer,
+) error {
+	f.mu.Lock()
+	f.calls = append(f.calls, append([]string(nil), args...))
+	f.mu.Unlock()
+
+	if len(args) == 0 {
+		return nil
+	}
+	switch args[0] {
+	case "run":
+		if f.onRun != nil {
+			return f.onRun(ctx)
+		}
+	case "rm":
+		if f.onRemove != nil {
+			return f.onRemove(ctx)
+		}
+	}
+	return nil
+}
+
+func (f *runCleanupRunner) snapshotCalls() [][]string {
+	f.mu.Lock()
+	defer f.mu.Unlock()
+	out := make([][]string, len(f.calls))
+	for i := range f.calls {
+		out[i] = append([]string(nil), f.calls[i]...)
+	}
+	return out
+}
+
 func (f *runFakeDocker) Run(ctx context.Context, args []string, stdin io.Reader, stdout, stderr io.Writer) error {
 	return f.RunWithEnv(ctx, nil, args, stdin, stdout, stderr)
 }
@@ -329,6 +380,98 @@ func TestRun_RealExitCodePropagated(t *testing.T) {
 	last := frames[len(frames)-1]
 	if last.Code != 42 {
 		t.Errorf("exit code: %d, want 42", last.Code)
+	}
+}
+
+func TestRunContainer_AlwaysRemovesExactContainerAndPreservesRunResult(t *testing.T) {
+	t.Parallel()
+
+	runFailure := errors.New("run failed")
+	cleanupFailure := errors.New("cleanup failed")
+	for _, tc := range []struct {
+		name       string
+		runErr     error
+		cleanupErr error
+	}{
+		{name: "normal exit"},
+		{name: "run failure", runErr: runFailure},
+		{name: "cleanup failure does not fail successful run", cleanupErr: cleanupFailure},
+		{name: "cleanup failure does not replace run result", runErr: runFailure, cleanupErr: cleanupFailure},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			runner := &runCleanupRunner{
+				onRun:    func(context.Context) error { return tc.runErr },
+				onRemove: func(context.Context) error { return tc.cleanupErr },
+			}
+			h := &Handler{
+				Docker: docker.NewWithRunner(runner),
+				Log:    slog.New(slog.NewTextHandler(io.Discard, nil)),
+			}
+			opts := docker.RunOpts{
+				ContainerName: "api-run.123",
+				Image:         "api:1",
+				Command:       []string{"true"},
+			}
+
+			gotErr := h.runContainer(context.Background(), opts)
+			if !errors.Is(gotErr, tc.runErr) {
+				t.Fatalf("runContainer error: got %v, want %v", gotErr, tc.runErr)
+			}
+			calls := runner.snapshotCalls()
+			if len(calls) != 2 {
+				t.Fatalf("docker calls: got %v, want run then rm", calls)
+			}
+			if got := strings.Join(calls[0], " "); !strings.Contains(got, "run --rm --name api-run.123") {
+				t.Errorf("run call: got %q", got)
+			}
+			if got, want := strings.Join(calls[1], " "), "rm --force api-run.123"; got != want {
+				t.Errorf("cleanup call: got %q, want %q", got, want)
+			}
+		})
+	}
+}
+
+func TestRunContainer_CancellationStillRemovesContainer(t *testing.T) {
+	t.Parallel()
+
+	started := make(chan struct{})
+	cleanupContextErr := make(chan error, 1)
+	runner := &runCleanupRunner{
+		onRun: func(ctx context.Context) error {
+			close(started)
+			<-ctx.Done()
+			return ctx.Err()
+		},
+		onRemove: func(ctx context.Context) error {
+			cleanupContextErr <- ctx.Err()
+			return nil
+		},
+	}
+	h := &Handler{
+		Docker: docker.NewWithRunner(runner),
+		Log:    slog.New(slog.NewTextHandler(io.Discard, nil)),
+	}
+	opts := docker.RunOpts{
+		ContainerName: "api-run.456",
+		Image:         "api:1",
+		Command:       []string{"sleep", "forever"},
+	}
+
+	runCtx, cancel := context.WithCancel(context.Background())
+	done := make(chan error, 1)
+	go func() { done <- h.runContainer(runCtx, opts) }()
+	<-started
+	cancel()
+
+	if err := <-done; !errors.Is(err, context.Canceled) {
+		t.Fatalf("runContainer error: got %v, want context.Canceled", err)
+	}
+	if err := <-cleanupContextErr; err != nil {
+		t.Fatalf("cleanup inherited canceled run context: %v", err)
+	}
+	calls := runner.snapshotCalls()
+	if len(calls) != 2 || strings.Join(calls[1], " ") != "rm --force api-run.456" {
+		t.Fatalf("docker calls: got %v, want canceled run then exact container removal", calls)
 	}
 }
 

--- a/internal/server/api/run_v2.go
+++ b/internal/server/api/run_v2.go
@@ -136,7 +136,7 @@ func (h *Handler) runV2(ctx context.Context, conn *websocket.Conn, req runReques
 		Stderr:           carriers.childStderr,
 		TTY:              tty,
 	}
-	runErr := h.Docker.Run(runCtx, runOpts)
+	runErr := h.runContainer(runCtx, runOpts)
 
 	// Make the pumps see EOF so they exit. In TTY mode that means
 	// closing the master (slave-side close from container exit


### PR DESCRIPTION
## Problem

`cobalt run` starts an attached `docker run --rm` process. When its WebSocket disconnects or the one-hour session cap expires, context cancellation kills the local Docker CLI process. The container itself can keep running because `--rm` only removes it after its process exits.

## Fix

- Route both v1 and v2 run protocols through one cleanup wrapper.
- Force-remove the exact, collision-resistant run container name after the attached Docker process returns.
- Use a fresh context with a 10-second timeout so cleanup still runs after request cancellation.
- Preserve the original command exit result if cleanup fails, while logging the cleanup failure.

Normal exits remain safe: `docker run --rm` removes the container first, and `RemoveContainer` treats an already-missing container as success.

## Safety

- Cleanup targets only the unique container created by the current run session.
- Generic one-shot Docker behavior and deploy hooks are unchanged.
- There is no age-based or name-pattern sweep.
- Cleanup is bounded and cannot inherit a canceled request context.

## Validation

- `go vet ./...`
- `go build ./...`
- `go test -race -count=1 ./...`
- `golangci-lint v2.12.2 run` — 0 issues

Regression tests cover normal exit, command failure, cleanup failure, and cancellation while the container is active.