### PR TITLE
Fix multi-domain data-plane confirmation

### DIFF
--- a/internal/server/deploy/dataplane.go
+++ b/internal/server/deploy/dataplane.go
@@ -266,7 +266,6 @@ func waitDataPlaneServing(
 	if len(domains) == 0 {
 		return nil
 	}
-	domain := domains[0]
 	want := strconv.Itoa(dep.Number)
 
 	fmt.Fprintf(out, "🔎 confirming the live router serves deployment #%d\n", dep.Number)
@@ -278,21 +277,27 @@ func waitDataPlaneServing(
 		if err := ctx.Err(); err != nil {
 			return err
 		}
-		res, err := probeDataPlane(ctx, p, domain)
-		switch {
-		case err != nil:
-			lastDetail = err.Error()
-		case res.Served == want:
-			fmt.Fprintf(out, "✅ live router serves deployment #%d\n", dep.Number)
-			return nil
-		case isGatewayError(res.Status):
-			sawDivergence = true
-			lastDetail = fmt.Sprintf("router returned %d (dialing a dead upstream)", res.Status)
-		case res.Served != "" && res.Served != want:
-			sawDivergence = true
-			lastDetail = fmt.Sprintf("router still serves deployment %s, want %s", res.Served, want)
-		default:
-			lastDetail = fmt.Sprintf("no deployment header yet (status %d)", res.Status)
+		for _, domain := range domains {
+			res, err := probeDataPlane(ctx, p, domain)
+			switch {
+			case err != nil:
+				if !sawDivergence {
+					lastDetail = fmt.Sprintf("%s: %s", domain, err)
+				}
+			case res.Served == want:
+				fmt.Fprintf(out, "✅ live router serves deployment #%d\n", dep.Number)
+				return nil
+			case isGatewayError(res.Status):
+				sawDivergence = true
+				lastDetail = fmt.Sprintf("%s: router returned %d (dialing a dead upstream)", domain, res.Status)
+			case res.Served != "" && res.Served != want:
+				sawDivergence = true
+				lastDetail = fmt.Sprintf("%s: router still serves deployment %s, want %s", domain, res.Served, want)
+			default:
+				if !sawDivergence {
+					lastDetail = fmt.Sprintf("%s: no deployment header yet (status %d)", domain, res.Status)
+				}
+			}
 		}
 		if time.Now().After(deadline) {
 			break

--- a/internal/server/deploy/dataplane_test.go
+++ b/internal/server/deploy/dataplane_test.go
@@ -104,8 +104,10 @@ func TestIsProbableHostname(t *testing.T) {
 // fakeDataPlaneProber stands in for *docker.Client in waitDataPlaneServing
 // tests. It answers the :80 plaintext path with a canned HTTP response.
 type fakeDataPlaneProber struct {
-	plaintextResp string // written to stdout for the nc path; "" + err => :80 closed
-	plaintextErr  error
+	plaintextResp     string // written to stdout for the nc path; "" + err => :80 closed
+	plaintextByDomain map[string]string
+	plaintextErr      error
+	probedDomains     []string
 }
 
 func (f *fakeDataPlaneProber) FindContainerByLabel(context.Context, string) (string, error) {
@@ -114,8 +116,16 @@ func (f *fakeDataPlaneProber) FindContainerByLabel(context.Context, string) (str
 
 func (f *fakeDataPlaneProber) Exec(_ context.Context, _ string, cmd []string, stdout, _ io.Writer) error {
 	if len(cmd) > 0 && cmd[0] == "sh" { // plaintext :80 path
-		if f.plaintextResp != "" {
-			_, _ = io.WriteString(stdout, f.plaintextResp)
+		response := f.plaintextResp
+		for domain, domainResponse := range f.plaintextByDomain {
+			if strings.Contains(cmd[2], "'"+domain+"'") {
+				f.probedDomains = append(f.probedDomains, domain)
+				response = domainResponse
+				break
+			}
+		}
+		if response != "" {
+			_, _ = io.WriteString(stdout, response)
 		}
 		return f.plaintextErr
 	}
@@ -215,6 +225,29 @@ func TestWaitDataPlaneServing(t *testing.T) {
 				t.Fatalf("want nil, got %v", err)
 			}
 		})
+	}
+}
+
+func TestWaitDataPlaneServing_InconclusiveDomain_TriesNextDomain(t *testing.T) {
+	container := &cobaltfile.Cobaltfile{Services: map[string]cobaltfile.Service{
+		"web": {Type: cobaltfile.TypeContainer, Port: 3000},
+	}}
+	prober := &fakeDataPlaneProber{plaintextByDomain: map[string]string{
+		"legacy.example.com": resp("200 OK", ""),
+		"api.example.com":    resp("200 OK", "5"),
+	}}
+	st := fakeDomainLister{domains: []string{"legacy.example.com", "api.example.com"}}
+	project := store.Project{ID: 1, Name: "api"}
+	dep := store.Deployment{Number: 5}
+	log := slog.New(slog.NewTextHandler(io.Discard, nil))
+
+	err := waitDataPlaneServing(context.Background(), prober, st, project, dep, container, log, io.Discard)
+	if err != nil {
+		t.Fatalf("waitDataPlaneServing: %v", err)
+	}
+	if len(prober.probedDomains) != 2 || prober.probedDomains[0] != "legacy.example.com" ||
+		prober.probedDomains[1] != "api.example.com" {
+		t.Fatalf("probed domains = %v, want both domains in order", prober.probedDomains)
 	}
 }
 

--- a/internal/server/worker/caddy_dataplane_test.go
+++ b/internal/server/worker/caddy_dataplane_test.go
@@ -22,6 +22,19 @@ func (f fakeDataPlaneProber) ServedDeployment(context.Context, string) (string, 
 	return f.served, f.status, f.err
 }
 
+type domainProbeResult struct {
+	served string
+	status int
+	err    error
+}
+
+type domainDataPlaneProber map[string]domainProbeResult
+
+func (f domainDataPlaneProber) ServedDeployment(_ context.Context, domain string) (string, int, error) {
+	result := f[domain]
+	return result.served, result.status, result.err
+}
+
 // fakeReaper records RemoveService calls and serves a fixed service list.
 type fakeReaper struct {
 	services []docker.ServiceInfo
@@ -161,6 +174,32 @@ func TestReconcile_DataPlaneHealthy_ReapsSupersededWebOnly(t *testing.T) {
 	}
 	if len(reaper.removed) != 1 || reaper.removed[0] != "api-6-web" {
 		t.Errorf("expected to reap only api-6-web, got %v", reaper.removed)
+	}
+}
+
+func TestReconcile_InconclusiveDomain_TriesNextDomain(t *testing.T) {
+	t.Parallel()
+	st, cy := inSyncFixture(t)
+	st.domains[1] = []string{"legacy.example.com", "api.example.com"}
+	dp := domainDataPlaneProber{
+		"legacy.example.com": {err: context.DeadlineExceeded},
+		"api.example.com":    {served: "7", status: 200},
+	}
+	reaper := &fakeReaper{services: []docker.ServiceInfo{
+		{Name: "api-7-web"},
+		{Name: "api-6-web"},
+	}}
+
+	corrected, err := ReconcileCaddyState(context.Background(), quietLogger(), st, cy, dp, reaper)
+	if err != nil {
+		t.Fatalf("Reconcile: %v", err)
+	}
+	if corrected != 0 || len(cy.serveCalls) != 0 {
+		t.Errorf("healthy fallback domain must not repair: corrected=%d serveCalls=%d",
+			corrected, len(cy.serveCalls))
+	}
+	if len(reaper.removed) != 1 || reaper.removed[0] != "api-6-web" {
+		t.Errorf("expected confirmation from api.example.com to permit reap, got %v", reaper.removed)
 	}
 }
 

--- a/internal/server/worker/caddy_reconcile.go
+++ b/internal/server/worker/caddy_reconcile.go
@@ -244,7 +244,7 @@ func reconcileProject(
 		// (the silent post-cutover 502 divergence; the admin GET above can't
 		// see it). Probe the data plane and force-repair if the running router
 		// disagrees.
-		outcome, err := reconcileDataPlane(ctx, log, cy, dp, p, *live, web, cf.UsesStablePublicWeb(), domains[0])
+		outcome, err := reconcileDataPlane(ctx, log, cy, dp, p, *live, web, cf.UsesStablePublicWeb(), domains)
 		if err != nil {
 			return false, err
 		}
@@ -292,11 +292,14 @@ const (
 	dataPlaneRepaired
 )
 
-// reconcileDataPlane probes Caddy's running router for the project's primary
-// domain and, when it diverges from the desired deployment, force-repairs with
-// a single ServeService PATCH — which makes Caddy recompile the route. That's
-// cheaper and safer than delete+recreate: no window with no route (404), and
-// one reload instead of three.
+// reconcileDataPlane probes Caddy's running router through each primary domain
+// until one returns a conclusive result. A domain with unavailable direct TLS
+// can be valid through an edge redirect, so it must not prevent another domain
+// from confirming the shared project route. When a conclusive probe diverges
+// from the desired deployment, this force-repairs with a single ServeService
+// PATCH — which makes Caddy recompile the route. That's cheaper and safer than
+// delete+recreate: no window with no route (404), and one reload instead of
+// three.
 //
 // A nil prober, an inconclusive probe (Caddy unreachable), or a "no header"
 // response (a pre-header handler) are all treated as dataPlaneUnknown — never
@@ -312,38 +315,41 @@ func reconcileDataPlane(
 	live store.Deployment,
 	web cobaltfile.Service,
 	stableWeb bool,
-	domain string,
+	domains []string,
 ) (dataPlaneOutcome, error) {
 	if dp == nil {
 		return dataPlaneUnknown, nil
 	}
 	want := strconv.Itoa(live.Number)
-	served, status, err := dp.ServedDeployment(ctx, domain)
-	if err != nil {
-		log.Debug("caddy reconcile: data-plane probe inconclusive",
-			"project_id", p.ID, "project", p.Name, "error", err)
-		return dataPlaneUnknown, nil
+	for _, domain := range domains {
+		served, status, err := dp.ServedDeployment(ctx, domain)
+		if err != nil {
+			log.Debug("caddy reconcile: data-plane probe inconclusive",
+				"project_id", p.ID, "project", p.Name, "domain", domain, "error", err)
+			continue
+		}
+		// served=="" (no header) is NOT divergence — treat unknown handlers as
+		// fine and let their next deploy stamp the header — but it's also not a
+		// positive confirmation, so try another domain before giving up.
+		if !isGatewayStatus(status) && served == "" {
+			continue
+		}
+		if !isGatewayStatus(status) && served == want {
+			return dataPlaneConfirmed, nil
+		}
+		log.Warn("caddy reconcile: upstream drifted (data plane)",
+			"project_id", p.ID, "project", p.Name, "domain", domain,
+			"want", want, "served", served, "status", status)
+		container := docker.ServiceName(p.Name, live.Number, "web")
+		if stableWeb {
+			container = docker.StablePublicWebServiceName(p.ID)
+		}
+		if err := cy.ServeService(ctx, p.ID, container, web.Port, live.Number); err != nil {
+			return dataPlaneUnknown, fmt.Errorf("repair upstream (data plane): %w", err)
+		}
+		return dataPlaneRepaired, nil
 	}
-	// served=="" (no header) is NOT divergence — treat unknown handlers as
-	// fine and let their next deploy stamp the header — but it's also not a
-	// positive confirmation, so it must not license a reap either.
-	if !isGatewayStatus(status) && served == "" {
-		return dataPlaneUnknown, nil
-	}
-	if !isGatewayStatus(status) && served == want {
-		return dataPlaneConfirmed, nil
-	}
-	log.Warn("caddy reconcile: upstream drifted (data plane)",
-		"project_id", p.ID, "project", p.Name,
-		"want", want, "served", served, "status", status)
-	container := docker.ServiceName(p.Name, live.Number, "web")
-	if stableWeb {
-		container = docker.StablePublicWebServiceName(p.ID)
-	}
-	if err := cy.ServeService(ctx, p.ID, container, web.Port, live.Number); err != nil {
-		return dataPlaneUnknown, fmt.Errorf("repair upstream (data plane): %w", err)
-	}
-	return dataPlaneRepaired, nil
+	return dataPlaneUnknown, nil
 }
 
 func isGatewayStatus(status int) bool {


### PR DESCRIPTION
## Summary

- probe each primary domain during deploy verification and periodic Caddy reconciliation
- use the first conclusive route result when an earlier domain cannot be probed directly
- preserve the existing divergence repair and grace-reaping safety gates

## Testing

- go test -race -count=1 ./...