### PR TITLE
🔖 feat: Per-project watchPaths for deploy triggering

### DIFF
--- a/cmd/cobalt/projects.go
+++ b/cmd/cobalt/projects.go
@@ -206,6 +206,13 @@ Examples:
 					return err
 				}
 			}
+			if cmd.Flags().Changed("watch-paths") {
+				wp := cmd.Flag("watch-paths").Value.String()
+				if err := validator.ValidateWatchPaths(wp); err != nil {
+					return err
+				}
+				req.WatchPaths = &wp
+			}
 
 			project, err := cl.UpdateProjectSource(cmd.Context(), name, req)
 			if err != nil {
@@ -215,10 +222,14 @@ Examples:
 			if pathDisplay == "" {
 				pathDisplay = "(repo root)"
 			}
-			output.PrintLines(fmt.Sprintf(
+			line := fmt.Sprintf(
 				"Project %s retargeted: %s@%s path=%s",
 				project.Name, project.GithubRepo, project.Branch, pathDisplay,
-			))
+			)
+			if project.WatchPaths != "" {
+				line += " watchPaths=" + project.WatchPaths
+			}
+			output.PrintLines(line)
 			output.PrintLines("Run `cobalt deploy --project " + project.Name + "` to act on the new source.")
 			return nil
 		}),
@@ -226,6 +237,7 @@ Examples:
 	cmd.Flags().String("github", "", "github repo as owner/repo (leave unset to keep current)")
 	cmd.Flags().String("branch", "", "git branch to deploy (leave unset to keep current)")
 	cmd.Flags().String("path", "", "sub-directory inside the repo (leave unset to keep current)")
+	cmd.Flags().String("watch-paths", "", "comma-separated extra sub-paths that also trigger deploys, e.g. \"shared\" (empty string clears; leave unset to keep current)")
 	return cmd
 }
 

--- a/internal/server/api/projects.go
+++ b/internal/server/api/projects.go
@@ -112,7 +112,12 @@ func (h *Handler) UpdateProjectSource(w http.ResponseWriter, r *http.Request) {
 		writeError(w, http.StatusBadRequest, err.Error())
 		return
 	}
-	if err := h.DB.UpdateProjectSource(r.Context(), p.ID, req.GithubRepo, req.Branch, req.Path); err != nil {
+	// nil WatchPaths = keep current (see ProjectUpdateSourceRequest).
+	watchPaths := p.WatchPaths
+	if req.WatchPaths != nil {
+		watchPaths = *req.WatchPaths
+	}
+	if err := h.DB.UpdateProjectSource(r.Context(), p.ID, req.GithubRepo, req.Branch, req.Path, watchPaths); err != nil {
 		if errors.Is(err, store.ErrNotFound) {
 			writeError(w, http.StatusNotFound, "project not found")
 			return
@@ -253,6 +258,7 @@ func projectToAPI(p store.Project) cobaltapi.Project {
 		GithubRepo: p.GithubRepo,
 		Branch:     p.Branch,
 		Path:       p.Path,
+		WatchPaths: p.WatchPaths,
 		CreatedAt:  p.CreatedAt,
 		UpdatedAt:  p.UpdatedAt,
 	}
@@ -314,6 +320,11 @@ func validateProjectUpdateSource(req cobaltapi.ProjectUpdateSourceRequest) error
 	}
 	if err := validator.ValidateProjectPath(req.Path); err != nil {
 		return err
+	}
+	if req.WatchPaths != nil {
+		if err := validator.ValidateWatchPaths(*req.WatchPaths); err != nil {
+			return err
+		}
 	}
 	return nil
 }

--- a/internal/server/api/webhooks.go
+++ b/internal/server/api/webhooks.go
@@ -107,13 +107,14 @@ func (h *Handler) handlePush(ctx context.Context, body []byte, _ int64) {
 	enqueued := 0
 	for _, p := range projects {
 		// Monorepo case: if the project is scoped to a sub-path and no
-		// file under that sub-path was touched by this push, skip.
-		// TouchesPath is conservative — it returns true when the push
-		// is truncated (>=20 commits) or has no commits listed, so we
-		// never skip on incomplete information.
-		if !ev.TouchesPath(p.Path) {
+		// file under that sub-path — or any of its extra watch paths —
+		// was touched by this push, skip. TouchesPath is conservative —
+		// it returns true when the push is truncated (>=2048 commits) or
+		// has no commits listed, so we never skip on incomplete
+		// information.
+		if !touchesProject(ev, p) {
 			h.Log.Info("webhook: skip deploy (path not touched)",
-				"project", p.Name, "path", p.Path, "commit", ev.After)
+				"project", p.Name, "path", p.Path, "watchPaths", p.WatchPaths, "commit", ev.After)
 			continue
 		}
 		req := deploy.EnqueueRequest{ProjectID: p.ID, CommitSHA: ev.After}
@@ -129,6 +130,23 @@ func (h *Handler) handlePush(ctx context.Context, body []byte, _ int64) {
 	if enqueued > 0 && h.Dispatcher != nil {
 		h.Dispatcher.Notify()
 	}
+}
+
+// touchesProject reports whether a push touched the project's Path or
+// any of its extra WatchPaths. A project whose build reads code outside
+// its Path (e.g. a repo-root shared/ folder COPY'd into the image)
+// lists that folder in WatchPaths so pushes touching only it still
+// deploy.
+func touchesProject(ev *github.PushEvent, p store.Project) bool {
+	if ev.TouchesPath(p.Path) {
+		return true
+	}
+	for _, wp := range p.WatchPathsList() {
+		if ev.TouchesPath(wp) {
+			return true
+		}
+	}
+	return false
 }
 
 // handleInstallation processes installation:created / installation:deleted.

--- a/internal/server/api/webhooks_test.go
+++ b/internal/server/api/webhooks_test.go
@@ -560,3 +560,61 @@ func TestWebhook_RepositoryNonRenameActionIsNoOp(t *testing.T) {
 // Anchor the cobaltapi import so removing webhook.go's references
 // doesn't accidentally drop coverage.
 var _ = cobaltapi.GithubApp{}
+
+// TestWebhook_PushEnqueuesProjectWhenWatchPathTouched pins the
+// watch-paths extension of the path filter: a project scoped to `api/`
+// with watchPaths "shared" deploys when a push touches only shared/,
+// while a sibling project on the same repo+branch without that watch
+// path does not — proving the check runs per project and consults
+// watch_paths, not just path.
+func TestWebhook_PushEnqueuesProjectWhenWatchPathTouched(t *testing.T) {
+	t.Parallel()
+	e := newWebhookEnv(t)
+	ctx := context.Background()
+	apiID, err := e.db.CreateProject(ctx, store.Project{
+		Name: "api", GithubRepo: "acme/monorepo", Branch: "main", Path: "api",
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if err := e.db.UpdateProjectSource(ctx, apiID, "acme/monorepo", "main", "api", "shared"); err != nil {
+		t.Fatal(err)
+	}
+	if _, err := e.db.CreateProject(ctx, store.Project{
+		Name: "web", GithubRepo: "acme/monorepo", Branch: "main", Path: "web",
+	}); err != nil {
+		t.Fatal(err)
+	}
+
+	payload := map[string]any{
+		"ref":   "refs/heads/main",
+		"after": "abc123",
+		"repository": map[string]any{
+			"id": 1, "full_name": "acme/monorepo",
+		},
+		"commits": []map[string]any{
+			{"modified": []string{"shared/filter-ir/fold.ts"}},
+		},
+	}
+	resp := e.post(t, "push", "delivery-1", payload)
+	resp.Body.Close()
+	deps, _ := e.db.QueuedDeployments(ctx)
+	if len(deps) != 1 {
+		t.Fatalf("queued: %d, want 1 (push touched shared/, only api watches it)", len(deps))
+	}
+	if deps[0].ProjectID != apiID {
+		t.Errorf("queued project: %d, want %d (api)", deps[0].ProjectID, apiID)
+	}
+
+	// A push touching neither path nor watch paths still skips both.
+	payload["after"] = "def456"
+	payload["commits"] = []map[string]any{
+		{"modified": []string{"docs/readme.md"}},
+	}
+	resp = e.post(t, "push", "delivery-2", payload)
+	resp.Body.Close()
+	deps, _ = e.db.QueuedDeployments(ctx)
+	if len(deps) != 1 {
+		t.Errorf("queued: %d, want still 1 (docs-only push must not deploy)", len(deps))
+	}
+}

--- a/internal/server/store/github_repos.go
+++ b/internal/server/store/github_repos.go
@@ -190,7 +190,7 @@ func (db *DB) ListGithubReposForInstallation(ctx context.Context, installationID
 func (db *DB) FindProjectsForRepoBranch(ctx context.Context, fullName, branch string) ([]Project, error) {
 	resp, err := db.QuerySingle(ctx, `
         SELECT id, name, github_repo, branch, path,
-               github_app_installation_id, created_at, updated_at
+               github_app_installation_id, created_at, updated_at, watch_paths
         FROM projects
         WHERE github_repo = ?
           AND (branch = ? OR (branch = '' AND ? IN ('main', 'master')))

--- a/internal/server/store/migrations/0007_projects_watch_paths.sql
+++ b/internal/server/store/migrations/0007_projects_watch_paths.sql
@@ -1,0 +1,14 @@
+-- 0007_projects_watch_paths.sql
+--
+-- Optional comma-separated list of extra repo-relative sub-paths that
+-- also trigger a deploy when a push touches them, in addition to the
+-- project's path. Empty (the default) means none — every existing
+-- project keeps working unchanged.
+--
+-- Real-world use: a monorepo project whose Docker build COPYs code from
+-- outside its path (e.g. blue's api/ and app/ images both COPY a
+-- repo-root shared/ folder). Without this, a push touching only
+-- shared/ is skipped by the webhook's path filter and the fix never
+-- deploys.
+
+ALTER TABLE projects ADD COLUMN watch_paths TEXT NOT NULL DEFAULT '';

--- a/internal/server/store/projects.go
+++ b/internal/server/store/projects.go
@@ -5,6 +5,7 @@ import (
 	"database/sql"
 	"encoding/json"
 	"errors"
+	"strings"
 
 	"github.com/heyblueteam/cobalt/pkg/cobaltapi/validator"
 	rqlitehttp "github.com/rqlite/rqlite-go-http"
@@ -26,17 +27,37 @@ type Project struct {
 	Name                    string
 	GithubRepo              string
 	Branch                  string
-	Path                    string
+	Path string
+	// WatchPaths is a comma-separated list of extra repo-relative
+	// sub-paths that also trigger a deploy when touched, in addition to
+	// Path. Empty means none. See Project.WatchPathsList.
+	WatchPaths              string
 	GithubAppInstallationID sql.NullInt64
 	CreatedAt               int64
 	UpdatedAt               int64
+}
+
+// WatchPathsList splits the comma-separated WatchPaths column into
+// clean entries, skipping blanks so a stray comma can't produce an
+// empty path (which TouchesPath treats as "repo root — always touched").
+func (p Project) WatchPathsList() []string {
+	if p.WatchPaths == "" {
+		return nil
+	}
+	var out []string
+	for _, entry := range strings.Split(p.WatchPaths, ",") {
+		if entry = strings.TrimSpace(entry); entry != "" {
+			out = append(out, entry)
+		}
+	}
+	return out
 }
 
 // ListProjects returns every project, ordered by name.
 func (db *DB) ListProjects(ctx context.Context) ([]Project, error) {
 	stmt, err := rqlitehttp.NewSQLStatement(`
         SELECT id, name, github_repo, branch, path,
-               github_app_installation_id, created_at, updated_at
+               github_app_installation_id, created_at, updated_at, watch_paths
         FROM projects
         ORDER BY name
     `)
@@ -66,7 +87,7 @@ func (db *DB) ListProjects(ctx context.Context) ([]Project, error) {
 func (db *DB) GetProjectByID(ctx context.Context, id int64) (*Project, error) {
 	resp, err := db.QuerySingle(ctx, `
         SELECT id, name, github_repo, branch, path,
-               github_app_installation_id, created_at, updated_at
+               github_app_installation_id, created_at, updated_at, watch_paths
         FROM projects WHERE id = ?
     `, id)
 	if err != nil {
@@ -88,7 +109,7 @@ func (db *DB) GetProjectByID(ctx context.Context, id int64) (*Project, error) {
 func (db *DB) GetProjectByName(ctx context.Context, name string) (*Project, error) {
 	resp, err := db.QuerySingle(ctx, `
         SELECT id, name, github_repo, branch, path,
-               github_app_installation_id, created_at, updated_at
+               github_app_installation_id, created_at, updated_at, watch_paths
         FROM projects WHERE name = ?
     `, name)
 	if err != nil {
@@ -152,6 +173,7 @@ func scanProjectRow(row []any) Project {
 	}
 	p.CreatedAt = toInt64(row[6])
 	p.UpdatedAt = toInt64(row[7])
+	p.WatchPaths = toString(row[8])
 	return p
 }
 
@@ -178,15 +200,18 @@ func (db *DB) RenameProject(ctx context.Context, id int64, newName string) error
 // the project tracks. Domains, env vars, deployments, and the on-disk
 // project directory are untouched; the next `cobalt deploy` reads from
 // the new source. Running services keep serving until that deploy.
-func (db *DB) UpdateProjectSource(ctx context.Context, id int64, githubRepo, branch, path string) error {
+func (db *DB) UpdateProjectSource(ctx context.Context, id int64, githubRepo, branch, path, watchPaths string) error {
 	if err := validator.ValidateProjectPath(path); err != nil {
+		return err
+	}
+	if err := validator.ValidateWatchPaths(watchPaths); err != nil {
 		return err
 	}
 	resp, err := db.ExecuteSingle(ctx, `
         UPDATE projects
-        SET github_repo = ?, branch = ?, path = ?, updated_at = strftime('%s', 'now')
+        SET github_repo = ?, branch = ?, path = ?, watch_paths = ?, updated_at = strftime('%s', 'now')
         WHERE id = ?
-    `, githubRepo, branch, path, id)
+    `, githubRepo, branch, path, watchPaths, id)
 	if err != nil {
 		return err
 	}

--- a/internal/server/store/projects_test.go
+++ b/internal/server/store/projects_test.go
@@ -336,7 +336,7 @@ func TestOtherProjectsWithSameSource_AfterUpdate(t *testing.T) {
 	}
 
 	// Retarget A to share the path with B.
-	if err := db.UpdateProjectSource(ctx, idA, "heyblueteam/blue", "main", "app"); err != nil {
+	if err := db.UpdateProjectSource(ctx, idA, "heyblueteam/blue", "main", "app", ""); err != nil {
 		t.Fatalf("UpdateProjectSource: %v", err)
 	}
 
@@ -505,7 +505,7 @@ func TestUpdateProjectSource_RoundTrip(t *testing.T) {
 		t.Fatalf("Create: %v", err)
 	}
 
-	if err := db.UpdateProjectSource(ctx, id, "heyblueteam/blue", "develop", "api"); err != nil {
+	if err := db.UpdateProjectSource(ctx, id, "heyblueteam/blue", "develop", "api", ""); err != nil {
 		t.Fatalf("UpdateProjectSource: %v", err)
 	}
 
@@ -537,7 +537,7 @@ func TestUpdateProjectSource_RoundTrip(t *testing.T) {
 func TestUpdateProjectSource_NotFound(t *testing.T) {
 	t.Parallel()
 	db := openTestDB(t)
-	err := db.UpdateProjectSource(context.Background(), 99999, "heyblueteam/blue", "main", "api")
+	err := db.UpdateProjectSource(context.Background(), 99999, "heyblueteam/blue", "main", "api", "")
 	if !errors.Is(err, ErrNotFound) {
 		t.Errorf("got %v, want ErrNotFound", err)
 	}
@@ -552,11 +552,11 @@ func TestUpdateProjectSource_InvalidPath(t *testing.T) {
 	id, _ := db.CreateProject(ctx, Project{Name: "x", GithubRepo: "h/x", Branch: "main"})
 
 	// Leading slash is rejected by ValidateProjectPath.
-	if err := db.UpdateProjectSource(ctx, id, "h/x", "main", "/api"); err == nil {
+	if err := db.UpdateProjectSource(ctx, id, "h/x", "main", "/api", ""); err == nil {
 		t.Error("UpdateProjectSource accepted leading-slash path, want validation error")
 	}
 	// `..` is rejected.
-	if err := db.UpdateProjectSource(ctx, id, "h/x", "main", "../escape"); err == nil {
+	if err := db.UpdateProjectSource(ctx, id, "h/x", "main", "../escape", ""); err == nil {
 		t.Error("UpdateProjectSource accepted parent-traversal path, want validation error")
 	}
 }
@@ -572,7 +572,7 @@ func TestUpdateProjectSource_IsolatesProjects(t *testing.T) {
 	idA, _ := db.CreateProject(ctx, Project{Name: "a", GithubRepo: "h/a", Branch: "main"})
 	idB, _ := db.CreateProject(ctx, Project{Name: "b", GithubRepo: "h/b", Branch: "main"})
 
-	if err := db.UpdateProjectSource(ctx, idA, "h/mono", "develop", "services/a"); err != nil {
+	if err := db.UpdateProjectSource(ctx, idA, "h/mono", "develop", "services/a", ""); err != nil {
 		t.Fatalf("UpdateProjectSource a: %v", err)
 	}
 
@@ -596,7 +596,7 @@ func TestUpdateProjectSource_EmptyPathClearsSubdir(t *testing.T) {
 		Name: "x", GithubRepo: "h/mono", Branch: "main", Path: "services/x",
 	})
 
-	if err := db.UpdateProjectSource(ctx, id, "h/x", "main", ""); err != nil {
+	if err := db.UpdateProjectSource(ctx, id, "h/x", "main", "", ""); err != nil {
 		t.Fatalf("UpdateProjectSource: %v", err)
 	}
 	got, err := db.GetProjectByID(ctx, id)
@@ -629,7 +629,7 @@ func TestUpdateProjectSource_BumpsUpdatedAt(t *testing.T) {
 	// sleep 1.1s so strftime('%s') ticks at least once (second resolution).
 	time.Sleep(1100 * time.Millisecond)
 
-	if err := db.UpdateProjectSource(ctx, id, "h/x", "main", ""); err != nil {
+	if err := db.UpdateProjectSource(ctx, id, "h/x", "main", "", ""); err != nil {
 		t.Fatalf("UpdateProjectSource: %v", err)
 	}
 	after, err := db.GetProjectByID(ctx, id)
@@ -638,5 +638,47 @@ func TestUpdateProjectSource_BumpsUpdatedAt(t *testing.T) {
 	}
 	if after.UpdatedAt <= before.UpdatedAt {
 		t.Errorf("UpdatedAt did not advance: before=%d after=%d", before.UpdatedAt, after.UpdatedAt)
+	}
+}
+
+// TestUpdateProjectSource_WatchPaths proves watch_paths round-trips
+// through update + read, that WatchPathsList tolerates spacing and
+// stray commas, and that invalid entries are rejected at the store
+// boundary like path is.
+func TestUpdateProjectSource_WatchPaths(t *testing.T) {
+	t.Parallel()
+	db := openTestDB(t)
+	ctx := context.Background()
+	id, _ := db.CreateProject(ctx, Project{
+		Name: "api", GithubRepo: "heyblueteam/blue", Branch: "main", Path: "api",
+	})
+
+	if err := db.UpdateProjectSource(ctx, id, "heyblueteam/blue", "main", "api", "shared, packages/ui"); err != nil {
+		t.Fatalf("UpdateProjectSource with watchPaths: %v", err)
+	}
+	p, err := db.GetProjectByID(ctx, id)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if p.WatchPaths != "shared, packages/ui" {
+		t.Errorf("WatchPaths: %q", p.WatchPaths)
+	}
+	got := p.WatchPathsList()
+	if len(got) != 2 || got[0] != "shared" || got[1] != "packages/ui" {
+		t.Errorf("WatchPathsList: %#v, want [shared packages/ui]", got)
+	}
+
+	// Clearing works.
+	if err := db.UpdateProjectSource(ctx, id, "heyblueteam/blue", "main", "api", ""); err != nil {
+		t.Fatalf("clear watchPaths: %v", err)
+	}
+	p, _ = db.GetProjectByID(ctx, id)
+	if p.WatchPaths != "" || p.WatchPathsList() != nil {
+		t.Errorf("after clear: %q / %#v", p.WatchPaths, p.WatchPathsList())
+	}
+
+	// Invalid entries rejected.
+	if err := db.UpdateProjectSource(ctx, id, "heyblueteam/blue", "main", "api", "../escape"); err == nil {
+		t.Error("accepted parent-traversal watch path, want validation error")
 	}
 }

--- a/internal/server/store/store.go
+++ b/internal/server/store/store.go
@@ -180,6 +180,7 @@ func (db *DB) InitSchema(ctx context.Context) error {
 		`ALTER TABLE deployments ADD COLUMN rollback_of INTEGER REFERENCES deployments(id)`,
 		`ALTER TABLE domains ADD COLUMN redirect_to TEXT`,
 		`ALTER TABLE projects ADD COLUMN path TEXT NOT NULL DEFAULT ''`,
+		`ALTER TABLE projects ADD COLUMN watch_paths TEXT NOT NULL DEFAULT ''`,
 	} {
 		_, _ = db.Execute(ctx, rqlitehttp.NewSQLStatementsFromStrings([]string{alter}), nil)
 	}

--- a/pkg/cobaltapi/project.go
+++ b/pkg/cobaltapi/project.go
@@ -12,7 +12,13 @@ type Project struct {
 	// cobalt.json and Dockerfile contexts live. Empty (the default)
 	// means the repo root. Set when one repo hosts multiple deployments
 	// (monorepo layout, e.g. "api", "services/web").
-	Path                    string `json:"path,omitempty"`
+	Path string `json:"path,omitempty"`
+	// WatchPaths is an optional comma-separated list of extra
+	// repo-relative sub-paths that also trigger a deploy when a push
+	// touches them, in addition to Path. Used when a project's build
+	// reads code outside its Path (e.g. a monorepo `shared/` folder
+	// COPY'd into several projects' images).
+	WatchPaths              string `json:"watchPaths,omitempty"`
 	GithubAppInstallationID *int64 `json:"githubAppInstallationId,omitempty"`
 	CreatedAt               int64  `json:"createdAt"`
 	UpdatedAt               int64  `json:"updatedAt"`
@@ -51,4 +57,10 @@ type ProjectUpdateSourceRequest struct {
 	GithubRepo string `json:"githubRepo"`
 	Branch     string `json:"branch"`
 	Path       string `json:"path"`
+	// WatchPaths, when non-nil, replaces the project's comma-separated
+	// extra deploy-trigger paths (empty string clears them). Nil keeps
+	// the current value — pointer semantics so CLIs built before this
+	// field existed cannot silently wipe it, which would silently stop
+	// deploys for pushes that only touch a watched path.
+	WatchPaths *string `json:"watchPaths,omitempty"`
 }

--- a/pkg/cobaltapi/validator/path.go
+++ b/pkg/cobaltapi/validator/path.go
@@ -72,3 +72,25 @@ func ValidateProjectPath(p string) error {
 	}
 	return nil
 }
+
+// ValidateWatchPaths validates a comma-separated list of extra
+// repo-relative sub-paths that trigger a deploy when touched, in
+// addition to the project's Path. Each entry follows the same rules as
+// ValidateProjectPath. An empty string means "no extra paths"; an empty
+// entry inside a non-empty list is a mistake, not repo root — watching
+// the whole repo is what an empty Path already means.
+func ValidateWatchPaths(csv string) error {
+	if csv == "" {
+		return nil
+	}
+	for _, entry := range strings.Split(csv, ",") {
+		entry = strings.TrimSpace(entry)
+		if entry == "" {
+			return fmt.Errorf("%w: empty watch path entry", ErrProjectPathInvalid)
+		}
+		if err := ValidateProjectPath(entry); err != nil {
+			return err
+		}
+	}
+	return nil
+}

--- a/pkg/cobaltapi/validator/path_test.go
+++ b/pkg/cobaltapi/validator/path_test.go
@@ -66,3 +66,32 @@ func TestValidateProjectPath(t *testing.T) {
 		})
 	}
 }
+
+func TestValidateWatchPaths(t *testing.T) {
+	cases := []struct {
+		name    string
+		in      string
+		wantErr bool
+	}{
+		{"empty_list", "", false},
+		{"single", "shared", false},
+		{"multi_with_space", "shared, packages/ui", false},
+		{"nested", "services/shared", false},
+		{"empty_entry", "shared,,api", true},
+		{"trailing_comma_only_entry", ",", true},
+		{"parent_traversal", "shared,../escape", true},
+		{"leading_slash", "/shared", true},
+		{"dot", ".", true},
+	}
+	for _, c := range cases {
+		t.Run(c.name, func(t *testing.T) {
+			err := ValidateWatchPaths(c.in)
+			if (err != nil) != c.wantErr {
+				t.Fatalf("ValidateWatchPaths(%q) = %v, wantErr=%v", c.in, err, c.wantErr)
+			}
+			if c.wantErr && !errors.Is(err, ErrProjectPathInvalid) {
+				t.Errorf("ValidateWatchPaths(%q): want ErrProjectPathInvalid, got %v", c.in, err)
+			}
+		})
+	}
+}


### PR DESCRIPTION
## What

Adds an optional per-project `watchPaths` list (comma-separated, repo-relative) checked by the push-webhook path filter: a deploy is enqueued when the push touches the project's `path` **or** any watch path. Empty (default) changes nothing for existing projects.

Needed by blue's filter predicate IR plan, Stage 02 (D8 as amended): `api` and `app` will build from a repo-root Docker context and COPY a repo-root `shared/` folder, so a push touching only `shared/` must still deploy them — today it is silently skipped.

## How

- `projects.watch_paths TEXT NOT NULL DEFAULT ''` — idempotent ALTER in `InitSchema` + migration doc file (0007), same pattern as `path` (0006).
- `store.Project.WatchPaths` + `WatchPathsList()` (lenient split — blanks skipped so a stray comma can't become "repo root, always deploy").
- Webhook: `touchesProject(ev, p)` = `TouchesPath(path)` OR any watch path; keeps TouchesPath's conservative truncation semantics.
- API: `ProjectUpdateSourceRequest.WatchPaths *string` — **pointer semantics** (nil = keep current) so CLIs built before this field can't silently wipe it; a wiped value would silently stop `shared/`-only deploys, the exact failure this feature removes. Validated per entry with the same rules as `path`.
- CLI: `cobalt projects update <name> --watch-paths "shared"` (empty string clears).

## Tests

- Webhook integration: project with `path=api, watchPaths=shared` deploys on a `shared/`-only push while a sibling `web` project doesn't (proves per-project consultation of watch_paths); docs-only push deploys neither.
- Store round-trip + clear + validation rejection; `WatchPathsList` parsing.
- `ValidateWatchPaths` table test.
- Full `go test ./...` green.

## After merge

Upgrade the cobalt server, then: `cobalt projects update api --watch-paths shared` (same for `next` and `white-label`) — that step belongs to blue Stage 02 verification (shared/-only test push must trigger both CI suites and both deploys).