### PR TITLE
Fix image retention cleanup

### DIFF
--- a/internal/server/store/deployments.go
+++ b/internal/server/store/deployments.go
@@ -35,28 +35,39 @@ type Deployment struct {
 	FinishedAt *int64
 }
 
-var activeKeepImageStatuses = []cobaltapi.State{
+var inFlightKeepStatuses = []cobaltapi.State{
 	cobaltapi.StateQueued,
 	cobaltapi.StateFetching,
 	cobaltapi.StateBuilding,
 	cobaltapi.StateSwapping,
-	cobaltapi.StateSuccess,
 }
 
+// ActiveDeploymentNumbers returns deployments that must remain available:
+// every in-flight deployment and the current (latest successful) deployment.
+// Historical successes are retained separately by the image cleanup policy.
 func (db *DB) ActiveDeploymentNumbers(ctx context.Context, projectID int64) ([]int, error) {
-	statusStrings := make([]string, len(activeKeepImageStatuses))
-	for i, s := range activeKeepImageStatuses {
+	statusStrings := make([]string, len(inFlightKeepStatuses))
+	for i, s := range inFlightKeepStatuses {
 		statusStrings[i] = string(s)
 	}
 
-	inClause := placeholders(len(activeKeepImageStatuses))
-	q := `SELECT number FROM deployments WHERE project_id = ? AND status IN (` + inClause + `)`
+	inClause := placeholders(len(inFlightKeepStatuses))
+	q := `SELECT number FROM deployments
+		WHERE project_id = ? AND (
+			status IN (` + inClause + `)
+			OR number = (
+				SELECT MAX(number) FROM deployments
+				WHERE project_id = ? AND status = ?
+			)
+		)
+		ORDER BY number`
 
-	args := make([]any, 0, len(activeKeepImageStatuses)+1)
+	args := make([]any, 0, len(inFlightKeepStatuses)+3)
 	args = append(args, projectID)
 	for _, s := range statusStrings {
 		args = append(args, s)
 	}
+	args = append(args, projectID, string(cobaltapi.StateSuccess))
 
 	stmt, err := rqlitehttp.NewSQLStatement(q, args...)
 	if err != nil {

--- a/internal/server/store/projects_test.go
+++ b/internal/server/store/projects_test.go
@@ -3,6 +3,7 @@ package store
 import (
 	"context"
 	"errors"
+	"slices"
 	"testing"
 	"time"
 
@@ -412,6 +413,7 @@ func TestActiveDeploymentNumbers(t *testing.T) {
 
 	for i, status := range []cobaltapi.State{
 		cobaltapi.StateSuccess,
+		cobaltapi.StateSuccess,
 		cobaltapi.StateBuilding,
 		cobaltapi.StateFailed,
 		cobaltapi.StateCanceled,
@@ -429,8 +431,9 @@ func TestActiveDeploymentNumbers(t *testing.T) {
 	if err != nil {
 		t.Fatalf("ActiveDeploymentNumbers: %v", err)
 	}
-	if len(got) != 3 {
-		t.Errorf("got %v, want 3 image-keeping deployments", got)
+	want := []int{2, 3, 6}
+	if !slices.Equal(got, want) {
+		t.Errorf("got %v, want %v (in-flight plus latest success)", got, want)
 	}
 }
 


### PR DESCRIPTION
## Summary

- treat only in-flight deployments and the latest successful deployment as active
- let the configured rollback window retain only the newest successful images
- allow the network janitor to remove networks from historical successful deployments
- add a regression test that excludes older successes from the active set

## Root cause

`ActiveDeploymentNumbers` returned every successful deployment. The image janitor combined that unbounded set with the configured latest-10 rollback set, so every successful image and its containerd snapshots remained protected forever. The network janitor used the same query.

## Test plan

- `go test ./...`