### PR TITLE
🐛 fix: deployments cancel/output take the deployment number

### DIFF
--- a/cmd/cobalt/deploy_test.go
+++ b/cmd/cobalt/deploy_test.go
@@ -320,3 +320,72 @@ func TestDeployWithNoCache(t *testing.T) {
 		t.Errorf("noCache not in request body: %s", string(api.lastBody))
 	}
 }
+
+// TestDeploymentsCancelByNumber pins the regression that motivated positional
+// numbers: `cancel 955` used to be silently ignored and cancel the most recent
+// in-flight deployment (#956) instead. The number must resolve to ITS
+// deployment, not the newest.
+func TestDeploymentsCancelByNumber(t *testing.T) {
+	api := newMockAPI()
+	defer api.close()
+
+	var canceled []string
+	api.handler = func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		if r.Method == http.MethodPost {
+			canceled = append(canceled, r.URL.Path)
+			w.WriteHeader(http.StatusOK)
+			return
+		}
+		// GET .../deployments?limit=500 — newest first, like the server
+		json.NewEncoder(w).Encode([]cobaltapi.Deployment{
+			{ID: 3541, Number: 956, Status: cobaltapi.StateQueued},
+			{ID: 3540, Number: 955, Status: cobaltapi.StateBuilding},
+			{ID: 3539, Number: 954, Status: cobaltapi.StateFailed},
+		})
+	}
+
+	if err := api.configPath(t); err != nil {
+		t.Fatal(err)
+	}
+
+	var buf bytes.Buffer
+	oldStdout := output.Stdout
+	output.Stdout = &buf
+	defer func() { output.Stdout = oldStdout }()
+
+	root := newRootCmd()
+	root.SetArgs([]string{"deployments", "cancel", "955", "--project", "api"})
+	if err := root.ExecuteContext(context.Background()); err != nil {
+		t.Fatalf("execute: %v", err)
+	}
+	if len(canceled) != 1 || !strings.HasSuffix(canceled[0], "/deployments/3540/cancel") {
+		t.Errorf("canceled %v, want exactly /deployments/3540/cancel (#955)", canceled)
+	}
+	if !contains(buf.String(), "#955") {
+		t.Errorf("output should name #955: %s", buf.String())
+	}
+}
+
+func TestDeploymentsCancelUnknownNumber(t *testing.T) {
+	api := newMockAPI()
+	defer api.close()
+	api.respond([]cobaltapi.Deployment{{ID: 1, Number: 1, Status: cobaltapi.StateQueued}})
+	if err := api.configPath(t); err != nil {
+		t.Fatal(err)
+	}
+	root := newRootCmd()
+	root.SetArgs([]string{"deployments", "cancel", "999", "--project", "api"})
+	err := root.ExecuteContext(context.Background())
+	if err == nil || !strings.Contains(err.Error(), "#999") {
+		t.Fatalf("want 'no deployment #999' error, got %v", err)
+	}
+}
+
+func TestDeploymentsCancelRejectsExtraArgs(t *testing.T) {
+	root := newRootCmd()
+	root.SetArgs([]string{"deployments", "cancel", "955", "956", "--project", "api"})
+	if err := root.ExecuteContext(context.Background()); err == nil {
+		t.Fatal("two positional args must be rejected, not silently ignored")
+	}
+}

--- a/cmd/cobalt/deployments.go
+++ b/cmd/cobalt/deployments.go
@@ -3,6 +3,7 @@ package main
 import (
 	"fmt"
 	"strconv"
+	"strings"
 	"time"
 
 	"github.com/heyblueteam/cobalt/internal/client"
@@ -77,38 +78,58 @@ Examples:
 	return cmd
 }
 
+// resolveDeployment picks the deployment a command acts on. Precedence:
+// positional number (what `deployments list` shows, e.g. 957), then
+// --deployment <internal id>, then the caller's fallback (most recent /
+// most recent in-flight). Before this, a positional number was silently
+// ignored and the fallback ran — `cancel 955` cancelled #956.
+func resolveDeployment(
+	cmd *cobra.Command,
+	args []string,
+	pc *projectClient,
+	fallback func() (*cobaltapi.Deployment, error),
+) (*cobaltapi.Deployment, error) {
+	if len(args) == 1 {
+		number, err := strconv.Atoi(strings.TrimPrefix(args[0], "#"))
+		if err != nil {
+			return nil, fmt.Errorf("invalid deployment number: %q (use the number from `deployments list`)", args[0])
+		}
+		return pc.DeploymentByNumber(cmd.Context(), pc.WrapProject(), number)
+	}
+	if deployment, _ := cmd.Flags().GetString("deployment"); deployment != "" {
+		id, err := strconv.ParseInt(deployment, 10, 64)
+		if err != nil {
+			return nil, fmt.Errorf("invalid deployment id: %q", deployment)
+		}
+		return pc.GetDeployment(cmd.Context(), id)
+	}
+	return fallback()
+}
+
 func newDeploymentsCancelCmd() *cobra.Command {
 	cmd := &cobra.Command{
-		Use:   "cancel",
+		Use:   "cancel [number]",
 		Short: "Cancel an in-flight deployment",
-		Long: `Cancels the most recent in-flight deployment (queued, fetching, building, or
-swapping). Use --deployment to target a specific deployment by ID.
+		Long: `Cancels a deployment by its number (as shown by 'deployments list'), or the
+most recent in-flight one (queued, fetching, building, or swapping) when no
+number is given. --deployment targets a specific deployment by internal ID.
 
 Examples:
+  cobalt deployments cancel 957 --project api
   cobalt deployments cancel --project api
-  cobalt deployments cancel --project api --deployment 42`,
-		RunE: runE(func(cmd *cobra.Command, _ []string) error {
-			deployment, _ := cmd.Flags().GetString("deployment")
+  cobalt deployments cancel --project api --deployment 3542`,
+		Args: cobra.MaximumNArgs(1),
+		RunE: runE(func(cmd *cobra.Command, args []string) error {
 			pc, err := newProjectClient(cmd)
 			if err != nil {
 				return err
 			}
 
-			var targetDeployment *cobaltapi.Deployment
-			if deployment != "" {
-				id, err := strconv.ParseInt(deployment, 10, 64)
-				if err != nil {
-					return fmt.Errorf("invalid deployment id: %q", deployment)
-				}
-				targetDeployment, err = pc.GetDeployment(cmd.Context(), id)
-				if err != nil {
-					return err
-				}
-			} else {
-				targetDeployment, err = pc.MostRecentInFlightDeployment(cmd.Context(), pc.WrapProject())
-				if err != nil {
-					return err
-				}
+			targetDeployment, err := resolveDeployment(cmd, args, pc, func() (*cobaltapi.Deployment, error) {
+				return pc.MostRecentInFlightDeployment(cmd.Context(), pc.WrapProject())
+			})
+			if err != nil {
+				return err
 			}
 
 			if err := pc.CancelDeployment(cmd.Context(), targetDeployment.ID); err != nil {
@@ -124,37 +145,30 @@ Examples:
 
 func newDeploymentsOutputCmd() *cobra.Command {
 	cmd := &cobra.Command{
-		Use:   "output",
+		Use:   "output [number]",
 		Short: "Stream deployment output",
 		Long: `Streams the stdout/stderr output of a deployment in real time.
 
-Without --deployment, tails the most recent deployment. Use Ctrl+C to stop.
+Give the deployment number (as shown by 'deployments list') to pick one;
+without it, tails the most recent deployment. --deployment targets a specific
+deployment by internal ID. Use Ctrl+C to stop.
 
 Examples:
+  cobalt deployments output 957 --project api
   cobalt deployments output --project api
-  cobalt deployments output --project api --deployment 42`,
-		RunE: runE(func(cmd *cobra.Command, _ []string) error {
-			deployment, _ := cmd.Flags().GetString("deployment")
+  cobalt deployments output --project api --deployment 3542`,
+		Args: cobra.MaximumNArgs(1),
+		RunE: runE(func(cmd *cobra.Command, args []string) error {
 			pc, err := newProjectClient(cmd)
 			if err != nil {
 				return err
 			}
 
-			var targetDeployment *cobaltapi.Deployment
-			if deployment != "" {
-				id, err := strconv.ParseInt(deployment, 10, 64)
-				if err != nil {
-					return fmt.Errorf("invalid deployment id: %q", deployment)
-				}
-				targetDeployment, err = pc.GetDeployment(cmd.Context(), id)
-				if err != nil {
-					return err
-				}
-			} else {
-				targetDeployment, err = pc.MostRecentDeployment(cmd.Context(), pc.WrapProject())
-				if err != nil {
-					return err
-				}
+			targetDeployment, err := resolveDeployment(cmd, args, pc, func() (*cobaltapi.Deployment, error) {
+				return pc.MostRecentDeployment(cmd.Context(), pc.WrapProject())
+			})
+			if err != nil {
+				return err
 			}
 
 			if err := output.FollowDeployOutput(cmd.Context(), pc.Client, targetDeployment.ID, 0, output.Stdout); err != nil {

--- a/internal/client/deployments.go
+++ b/internal/client/deployments.go
@@ -111,6 +111,22 @@ func (c *Client) MostRecentInFlightDeployment(ctx context.Context, project strin
 	return nil, fmt.Errorf("no in-flight deployment found for project %q", project)
 }
 
+// DeploymentByNumber resolves the per-project number shown by `deployments
+// list` (#957) to the deployment. Numbers are what operators read off the
+// list and type back; internal ids are not shown there.
+func (c *Client) DeploymentByNumber(ctx context.Context, project string, number int) (*cobaltapi.Deployment, error) {
+	deps, err := c.ListDeployments(ctx, project, 500)
+	if err != nil {
+		return nil, err
+	}
+	for _, d := range deps {
+		if d.Number == number {
+			return &d, nil
+		}
+	}
+	return nil, fmt.Errorf("no deployment #%d found for project %q (searched the last %d)", number, project, len(deps))
+}
+
 func FormatDeployment(d *cobaltapi.Deployment) string {
 	return fmt.Sprintf("#%d (id=%d)", d.Number, d.ID)
 }


### PR DESCRIPTION
Today `cobalt deployments cancel 955 --project api` cancelled **#956** — the wrong deployment, in the middle of an incident. Neither `cancel` nor `output` declared positional args, so cobra silently dropped the number and the most-recent fallback ran. (`output 952` had the same bug: it showed the newest deployment's log, which misled a diagnosis today.) `--deployment` also expects the internal id, which `deployments list` never shows.

**Fix**
- `cancel [number]` / `output [number]` — the number `deployments list` prints (`#955` or `955`), resolved via new `Client.DeploymentByNumber`.
- `--deployment <id>` kept for the internal id; fallback (most recent / most recent in-flight) only when neither is given.
- `Args: cobra.MaximumNArgs(1)` — extra args now error instead of being swallowed.

**Tests**: regression pins that `cancel 955` POSTs to #955's id (not the newest in-flight #956); unknown number errors mentioning the number; two positional args rejected. `go test ./cmd/... ./internal/client/...` green.