### PR TITLE
🐛 fix(caddy): Pin the cobalt server to h1/h2 when the config predates the default

### DIFF
--- a/internal/server/caddy/load.go
+++ b/internal/server/caddy/load.go
@@ -7,6 +7,10 @@ import (
 	"net/http"
 )
 
+// defaultProtocols is the protocol list WriteInitConfig writes for the
+// cobalt server; applyCobaltRoutes backfills it on configs that predate it.
+const defaultProtocols = `["h1","h2"]`
+
 // applyCobaltRoutes performs a read-modify-write of the `cobalt` HTTP
 // server's routes slice: GET the full live config from /config/, hand the
 // slice to mutate, and POST the merged document back via /load — Caddy's
@@ -47,6 +51,18 @@ func (c *Client) applyCobaltRoutes(ctx context.Context, mutate func(routes []jso
 	cobaltSrv, err := rawObject(servers, "cobalt")
 	if err != nil {
 		return err
+	}
+	// Pin the server to TCP-only HTTP (h1/h2) when no explicit protocol
+	// list exists. WriteInitConfig has set this on fresh installs since
+	// 2026-05, but hosts bootstrapped before then carry a config without
+	// the key, and Caddy 2.7 then defaults to h1+h2+h3 and advertises
+	// `Alt-Svc: h3=":443"` on every response. cobalt only publishes TCP
+	// 443 on the swarm, so the UDP handshake browsers attempt is dropped
+	// silently by the host firewall (2026-09-08 incident). Setting the key
+	// only when absent keeps a deliberate operator choice — including a
+	// future real HTTP/3 rollout — untouched.
+	if _, ok := cobaltSrv["protocols"]; !ok {
+		cobaltSrv["protocols"] = json.RawMessage(defaultProtocols)
 	}
 	var routes []json.RawMessage
 	if raw, ok := cobaltSrv["routes"]; ok {

--- a/internal/server/caddy/load_test.go
+++ b/internal/server/caddy/load_test.go
@@ -209,3 +209,56 @@ func TestApplyCobaltRoutes_UnrecognizedConfigFailsLoud(t *testing.T) {
 		t.Errorf("apply must not POST /load on an unrecognized config, got %d loads", n)
 	}
 }
+
+// rtLegacyConfig is a live document from a host bootstrapped before
+// WriteInitConfig pinned `protocols`: the cobalt server block has no such
+// key, so Caddy defaults to h1+h2+h3 and advertises HTTP/3.
+const rtLegacyConfig = `{"admin":` + rtAdminBlock +
+	`,"apps":{"http":{"servers":{"cobalt":{"listen":[":80"],"logs":{},"routes":[` +
+	rtRedirectRoute + `,` + rtProjectRoute + `,` + rtDaemonRoute +
+	`]}}},"tls":` + rtTLSApp + `},"logging":` + rtLoggingBlock + `}`
+
+func TestApplyCobaltRoutes_BackfillsMissingProtocols(t *testing.T) {
+	t.Parallel()
+	f := newLoadCapturingCaddy(t, rtLegacyConfig)
+	c := NewHTTPClient(f.server.URL, f.server.Client())
+
+	err := c.applyCobaltRoutes(context.Background(), func(routes []json.RawMessage) ([]json.RawMessage, error) {
+		return routes, nil
+	})
+	if err != nil {
+		t.Fatalf("applyCobaltRoutes: %v", err)
+	}
+	posted := f.lastLoad(t)
+
+	// The only change is the added protocols key, in its alphabetical
+	// slot between logs and routes; everything else is byte-identical to
+	// the pinned document.
+	if posted != rtLiveConfig {
+		t.Errorf("legacy config not backfilled to the pinned document\n got: %s\nwant: %s", posted, rtLiveConfig)
+	}
+	if !strings.Contains(posted, `"protocols":["h1","h2"]`) {
+		t.Errorf("protocols not pinned to h1/h2: %s", posted)
+	}
+}
+
+func TestApplyCobaltRoutes_KeepsExplicitProtocols(t *testing.T) {
+	t.Parallel()
+	// An operator who deliberately enabled HTTP/3 must not be reverted.
+	h3 := strings.Replace(rtLiveConfig, `"protocols":["h1","h2"]`, `"protocols":["h1","h2","h3"]`, 1)
+	if h3 == rtLiveConfig {
+		t.Fatal("test fixture did not contain the protocols key")
+	}
+	f := newLoadCapturingCaddy(t, h3)
+	c := NewHTTPClient(f.server.URL, f.server.Client())
+
+	err := c.applyCobaltRoutes(context.Background(), func(routes []json.RawMessage) ([]json.RawMessage, error) {
+		return routes, nil
+	})
+	if err != nil {
+		t.Fatalf("applyCobaltRoutes: %v", err)
+	}
+	if posted := f.lastLoad(t); posted != h3 {
+		t.Errorf("explicit protocols altered\n got: %s\nwant: %s", posted, h3)
+	}
+}


### PR DESCRIPTION
## Why

Hosts bootstrapped before `WriteInitConfig` started writing `protocols: ["h1","h2"]` (May 2026) run Caddy with its default h1+h2+h3. Caddy then advertises `Alt-Svc: h3=":443"` on every response, but cobalt only publishes TCP 443 on the swarm, so browsers' QUIC handshake packets are dropped silently by the host firewall (`[UFW BLOCK] ... PROTO=UDP DPT=443` in the kernel log). On 2026-09-08 this was corrected by hand on the production host through the admin API while investigating a wave of Chromium-only "Failed to fetch" reports.

## What

- `applyCobaltRoutes` backfills `protocols: ["h1","h2"]` on the `cobalt` server block when the key is absent. It already re-encodes that block, so no new plumbing and the first deploy or reconcile after upgrading converges every host.
- An explicit protocol list is never touched, so a deliberate HTTP/3 rollout (which also needs UDP 443 published) is not reverted.
- Tests: a legacy config without the key round-trips to the pinned document byte-for-byte; a config with `["h1","h2","h3"]` is preserved; existing no-op and route tests unchanged.

## Verification

```
go vet ./internal/server/caddy/ && go test ./internal/server/caddy/   # ok
go build ./...                                                          # ok
```

Rollout: release + daemon upgrade per host, same path as v1.6.1. Until then the manual admin-API change on the production host stays in place.