### PR TITLE
🐛 fix(caddy): Bound the reload grace period so old connections cannot outlive a reaped upstream

### DIFF
--- a/internal/server/caddy/init.go
+++ b/internal/server/caddy/init.go
@@ -35,6 +35,14 @@ func WriteInitConfig(path, daemonHost string, behindTunnel bool) error {
 		},
 		"apps": map[string]any{
 			"http": map[string]any{
+				// Bound how long a superseded server keeps its existing
+				// connections after a config reload. Caddy's default is
+				// eternal, so a long-lived edge connection (Cloudflare
+				// keep-alive) stayed pinned to the old server and its old
+				// upstream name until the reaper removed that service, then
+				// failed with "no such host" for as long as the edge kept the
+				// connection open. 30s is far inside reapMinAge (5m).
+				"grace_period": "30s",
 				"servers": map[string]any{
 					"cobalt": map[string]any{
 						"listen":    []any{listen},

--- a/internal/server/caddy/load.go
+++ b/internal/server/caddy/load.go
@@ -11,6 +11,10 @@ import (
 // cobalt server; applyCobaltRoutes backfills it on configs that predate it.
 const defaultProtocols = `["h1","h2"]`
 
+// defaultGracePeriod bounds how long a superseded Caddy server keeps its
+// existing connections after a reload; see WriteInitConfig.
+const defaultGracePeriod = `"30s"`
+
 // applyCobaltRoutes performs a read-modify-write of the `cobalt` HTTP
 // server's routes slice: GET the full live config from /config/, hand the
 // slice to mutate, and POST the merged document back via /load — Caddy's
@@ -43,6 +47,15 @@ func (c *Client) applyCobaltRoutes(ctx context.Context, mutate func(routes []jso
 	httpApp, err := rawObject(apps, "http")
 	if err != nil {
 		return err
+	}
+	// Backfill the http app's grace_period the same way protocols is
+	// backfilled below: hosts bootstrapped before WriteInitConfig wrote it
+	// run with Caddy's eternal default, which is what let a Cloudflare
+	// keep-alive connection outlive the reaped upstream it was pinned to
+	// (2026-07-14, 2026-09-06). Only when absent, so an operator's explicit
+	// value survives.
+	if _, ok := httpApp["grace_period"]; !ok {
+		httpApp["grace_period"] = json.RawMessage(defaultGracePeriod)
 	}
 	servers, err := rawObject(httpApp, "servers")
 	if err != nil {

--- a/internal/server/caddy/load_test.go
+++ b/internal/server/caddy/load_test.go
@@ -29,7 +29,7 @@ const (
 // (alphabetical) key order, so an untouched round trip must reproduce the
 // document byte-for-byte.
 const rtLiveConfig = `{"admin":` + rtAdminBlock +
-	`,"apps":{"http":{"servers":{"cobalt":{"listen":[":80"],"logs":{},"protocols":["h1","h2"],"routes":[` +
+	`,"apps":{"http":{"grace_period":"30s","servers":{"cobalt":{"listen":[":80"],"logs":{},"protocols":["h1","h2"],"routes":[` +
 	rtRedirectRoute + `,` + rtProjectRoute + `,` + rtDaemonRoute +
 	`]}}},"tls":` + rtTLSApp + `},"logging":` + rtLoggingBlock + `}`
 
@@ -211,8 +211,9 @@ func TestApplyCobaltRoutes_UnrecognizedConfigFailsLoud(t *testing.T) {
 }
 
 // rtLegacyConfig is a live document from a host bootstrapped before
-// WriteInitConfig pinned `protocols`: the cobalt server block has no such
-// key, so Caddy defaults to h1+h2+h3 and advertises HTTP/3.
+// WriteInitConfig pinned `protocols` and `grace_period`: neither key is
+// present, so Caddy defaults to h1+h2+h3 (advertising HTTP/3) and to an
+// eternal grace period on reload.
 const rtLegacyConfig = `{"admin":` + rtAdminBlock +
 	`,"apps":{"http":{"servers":{"cobalt":{"listen":[":80"],"logs":{},"routes":[` +
 	rtRedirectRoute + `,` + rtProjectRoute + `,` + rtDaemonRoute +
@@ -231,14 +232,38 @@ func TestApplyCobaltRoutes_BackfillsMissingProtocols(t *testing.T) {
 	}
 	posted := f.lastLoad(t)
 
-	// The only change is the added protocols key, in its alphabetical
-	// slot between logs and routes; everything else is byte-identical to
-	// the pinned document.
+	// The only changes are the added grace_period and protocols keys, each
+	// in its alphabetical slot; everything else is byte-identical to the
+	// pinned document.
 	if posted != rtLiveConfig {
 		t.Errorf("legacy config not backfilled to the pinned document\n got: %s\nwant: %s", posted, rtLiveConfig)
 	}
 	if !strings.Contains(posted, `"protocols":["h1","h2"]`) {
 		t.Errorf("protocols not pinned to h1/h2: %s", posted)
+	}
+	if !strings.Contains(posted, `"grace_period":"30s"`) {
+		t.Errorf("grace_period not backfilled: %s", posted)
+	}
+}
+
+func TestApplyCobaltRoutes_KeepsExplicitGracePeriod(t *testing.T) {
+	t.Parallel()
+	// An operator who chose a different drain window must not be reverted.
+	custom := strings.Replace(rtLiveConfig, `"grace_period":"30s"`, `"grace_period":"2m"`, 1)
+	if custom == rtLiveConfig {
+		t.Fatal("test fixture did not contain the grace_period key")
+	}
+	f := newLoadCapturingCaddy(t, custom)
+	c := NewHTTPClient(f.server.URL, f.server.Client())
+
+	err := c.applyCobaltRoutes(context.Background(), func(routes []json.RawMessage) ([]json.RawMessage, error) {
+		return routes, nil
+	})
+	if err != nil {
+		t.Fatalf("applyCobaltRoutes: %v", err)
+	}
+	if posted := f.lastLoad(t); posted != custom {
+		t.Errorf("explicit grace_period altered\n got: %s\nwant: %s", posted, custom)
 	}
 }
 

--- a/internal/server/store/projects.go
+++ b/internal/server/store/projects.go
@@ -23,11 +23,11 @@ var _ *sql.DB = nil // enforce that we don't accidentally use database/sql
 // single GitHub repo. See `pkg/cobaltapi/validator.ValidateProjectPath`
 // for the shape rules.
 type Project struct {
-	ID                      int64
-	Name                    string
-	GithubRepo              string
-	Branch                  string
-	Path string
+	ID         int64
+	Name       string
+	GithubRepo string
+	Branch     string
+	Path       string
 	// WatchPaths is a comma-separated list of extra repo-relative
 	// sub-paths that also trigger a deploy when touched, in addition to
 	// Path. Empty means none. See Project.WatchPathsList.


### PR DESCRIPTION
## Why

Caddy's default `grace_period` is eternal. After every cobalt config reload the superseded server keeps serving the connections it already had, using its old upstream name (`api-N-web`). A Cloudflare keep-alive connection stayed pinned that way until `reapMinAge` (5 min) elapsed and the reaper removed the old service; from then on every request on that connection failed with `dial tcp: lookup api-N-web ... no such host` until the edge happened to cycle the connection, which took 20+ minutes on 2026-07-14 and 2026-09-06. With `api.blue.app` now Cloudflare-proxied this would recur on most API deploys.

## What

- `WriteInitConfig`: `apps.http.grace_period = "30s"` on fresh installs.
- `applyCobaltRoutes`: backfill `grace_period` when absent, exactly like the `protocols` backfill from #62. Explicit values are never touched.
- Tests: legacy config gains both keys and matches the pinned document byte-for-byte; an explicit `2m` grace period is preserved; existing tests updated for the new pinned fixture.

Effect on reload: idle old connections close immediately, active requests get 30 s, then the old server is torn down. 30 s is far inside the 5 min reap window, so no connection can outlive the service it is pinned to. Cloudflare and browsers reconnect transparently (HTTP/2 GOAWAY).

Cost: a request still running 30 s after a deploy is cut. Production sees about 12 such requests per 48 h across all deploys.

## Verification

```
go vet ./internal/server/caddy/ && go test ./internal/... && go build ./...   # ok
```

Applied by hand via the admin API on both production hosts on 2026-09-08 10:30 UTC ahead of this release; this PR makes it durable.